### PR TITLE
Use HSTS in release

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -11,11 +11,22 @@ mozsearch_path = os.path.realpath(os.path.join(os.path.dirname(os.path.realpath(
 
 config = json.load(open(config_fname))
 
-fmt = {'doc_root': doc_root, 'mozsearch_path': mozsearch_path}
+fmt = {
+  'doc_root': doc_root,
+  'mozsearch_path': mozsearch_path,
+
+  # Use HSTS in release - ELB sets http_x_forwarded_proto, so this won't match in dev builds.
+  # This needs to be included in all locations, instead of in the server block, since
+  # add_header won't be inherited if a location sets any headers of its own.
+  'add_hsts': '''if ($http_x_forwarded_proto = "https") {
+      add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
+    }'''
+}
 
 print '''server {
   listen 80 default_server;
 
+  # Redirect HTTP to HTTPS in release
   if ($http_x_forwarded_proto = "http") {
     return 301 https://$host$request_uri;
   }
@@ -23,6 +34,7 @@ print '''server {
   sendfile off;
 
   location /static {
+    %(add_hsts)s
     root %(mozsearch_path)s;
   }
 ''' % fmt
@@ -32,6 +44,7 @@ for repo in config['trees']:
 
     print '''
   location /%(repo)s/source {
+    %(add_hsts)s
     root %(doc_root)s;
     try_files /file/$uri /dir/$uri/index.html =404;
     types {
@@ -44,36 +57,44 @@ for repo in config['trees']:
   }
 
   location /%(repo)s/search {
+    %(add_hsts)s
     proxy_pass http://localhost:8000;
   }
 
   location /%(repo)s/define {
+    %(add_hsts)s
     proxy_pass http://localhost:8000;
   }
 
   location /%(repo)s/diff {
+    %(add_hsts)s
     proxy_pass http://localhost:8001;
   }
 
   location /%(repo)s/commit {
+    %(add_hsts)s
     proxy_pass http://localhost:8001;
   }
 
   location /%(repo)s/rev {
+    %(add_hsts)s
     proxy_pass http://localhost:8001;
   }
 
   location /%(repo)s/complete {
+    %(add_hsts)s
     proxy_pass http://localhost:8001;
   }
 
   location /%(repo)s/commit-info {
+    %(add_hsts)s
     proxy_pass http://localhost:8001;
   }''' % fmt
 
 del fmt['repo']
 print '''
   location = / {
+    %(add_hsts)s
     root %(doc_root)s;
     try_files $uri/help.html =404;
     expires 1d;


### PR DESCRIPTION
Unfortunately it seems we need to add this header manually for all locations, at least based on https://www.nginx.com/blog/http-strict-transport-security-hsts-and-nginx/.

We should test this on dev.