### PR TITLE
context-menu: Escape html special characters.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -82,6 +82,12 @@ $("#file").on("click", "span[data-i]", function(event) {
   var index = elt.attr("data-i");
 
   function fmt(s, data) {
+    data = data
+       .replace(/&/g, "&amp;")
+       .replace(/</g, "&lt;")
+       .replace(/>/g, "&gt;")
+       .replace(/"/g, "&quot;")
+       .replace(/'/g, "&#039;");
     return s.replace("_", data);
   }
 


### PR DESCRIPTION
Some rust pretty symbols have angle brackets and such. Make sure to escape them so that they show up properly.