### PR TITLE
Allow picking up the private key from ~/.aws

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -102,14 +102,9 @@ All later AWS commands should be run within the virtual environment.
 
 To SSH into an EC2 instance, you will need to obtain the private key
 file for Searchfox. Once you have the key, ensure that the permissions
-are set so that it is not world-readable. Then add it to your SSH
-configuration (substituting the path below):
-
-```
-cat >> .ssh/config <<"THEEND"
-IdentityFile /path/to/private/key.pem
-THEEND
-```
+are set so that it is not world-readable. Put it (or a symlink to it) at
+`~/.aws/private_key.pem`. The ssh script below will check this location
+and use this as the identity file if it exists.
 
 Now you can connect to an instance as follows:
 

--- a/infrastructure/aws/ssh.py
+++ b/infrastructure/aws/ssh.py
@@ -6,6 +6,7 @@
 #   With an instance ID as argument, connects to that instance.
 
 import boto3
+import os
 import sys
 import subprocess
 import time
@@ -49,8 +50,15 @@ def change_security(instance, make_secure):
 def log_into(instance):
     change_security(instance, False)
 
+    # If there is a private key at ~/.aws/private_key.pem, use it
+    identity_args = []
+    privkey_file = os.path.expanduser('~/.aws/private_key.pem')
+    if os.path.isfile(privkey_file):
+        print 'Using %s as identity keyfile' % privkey_file
+        identity_args = ['-i', privkey_file]
+
     print 'Connecting to', instance.public_ip_address
-    p = subprocess.Popen(['ssh', 'ubuntu@' + instance.public_ip_address])
+    p = subprocess.Popen(['ssh'] + identity_args + ['ubuntu@' + instance.public_ip_address])
     p.wait()
 
     change_security(instance, True)


### PR DESCRIPTION
I don't know if anybody else is having this problem, but putting the IdentityFile command in my .ssh/config file was causing my other ssh connections to always fail. So I kept having to comment it out for those connections and uncomment it for searchfox ssh connections.

This PR makes it so that the ssh.py script picks up the key from ~/.aws/private_key.pem (if it exists) so you don't need to put it in your .ssh/config file. (This is optional, so if you want to leave it in your .ssh/config file that's fine too).