### PR TITLE
Work around bug in crossref unicode handling

### DIFF
--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -158,6 +158,15 @@ fn main() {
 
                 let (line, offset) = lines[lineno].clone();
 
+                // It's not specified whether column numbers are byte
+                // offsets or character offsets. For ASCII code this
+                // doesn't matter, but in the case of unicode
+                // characters, we don't want to have an integer
+                // underflow when subtracting these values below.
+                if datum.loc.col_start < offset {
+                    continue;
+                }
+
                 let peek_start = piece.peek_range.start_lineno;
                 let peek_end = piece.peek_range.end_lineno;
                 let mut peek_lines = String::new();


### PR DESCRIPTION
This is a bug caused by the fact that most of the mozsearch code treats column numbers as UTF8 byte offsets, while the js-analyze.js indexer generates column numbers as character offsets. Ideally we would fix js-analyze to use byte offsets, but that's hard to do since JS doesn't natively use UTF8.

The bug manifested in this way: there was a line that started with a funny unicode whitespace character that requires two bytes to represent. For an identifier at the beginning of the line, JS wrote out the column offset as 1 (although the byte offset was 2), while our Rust code stripped off 2 bytes of whitespace. Then when the Rust code subtracts the identifier's column number from the number of bytes stripped, we get an integer underflow:
https://github.com/bill-mccloskey/mozsearch/blob/master/tools/src/bin/crossref.rs#L184

In release builds, this is not an error. In debug builds, it asserts. I happened to run into this when doing some testing.

I thought about changing the Rust code to only strip regular whitespace (spaces and tabs). But it's actually nice that it strips other forms of whitespace. It's really the JS analyzer's fault that this happens. So I just worked around this by skipping places where we'd get an underflow. Eventually I'll find a way to fix the JS analysis.