### PR TITLE
Add sticky highlight support

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -29,8 +29,12 @@ function setContextMenu(menu, event)
   });
 }
 
+// When this is set to true, moving the mouse doesn't change what is highlighted.
+var stickyHover = false;
+
 // Remove the menu when a user clicks outside it.
 window.addEventListener('mousedown', function() {
+  stickyHover = false;
   $('#context-menu').remove();
 }, false);
 
@@ -41,7 +45,7 @@ window.addEventListener("pageshow", function() {
 var hovered = $();
 
 $("#file").on("mousemove", function(event) {
-  if ($('#context-menu').length) {
+  if ($('#context-menu').length || stickyHover) {
     return;
   }
 
@@ -72,44 +76,61 @@ $("#file").on("mousemove", function(event) {
   hovered.addClass("hovered");
 });
 
-$("#file").on("click", "span[data-i]", function(event) {
-  var tree = $("#data").data("tree");
+function stickyHighlight(id)
+{
+  $('#context-menu').remove();
 
-  var elt = $(event.target);
-  while (!elt.attr("data-i")) {
-    elt = elt.parent();
-  }
-  var index = elt.attr("data-i");
+  hovered.removeClass("hovered");
+  hovered = $(`span[data-id="${id}"]`);
+  hovered.addClass("hovered");
+
+  stickyHover = true;
+}
+
+$("#file").on("click", "span[data-id]", function(event) {
+  stickyHover = false;
+
+  var tree = $("#data").data("tree");
 
   function fmt(s, data) {
     data = data
-       .replace(/&/g, "&amp;")
-       .replace(/</g, "&lt;")
-       .replace(/>/g, "&gt;")
-       .replace(/"/g, "&quot;")
-       .replace(/'/g, "&#039;");
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
     return s.replace("_", data);
   }
 
-  // Comes from the generated page.
-  var [jumps, searches] = ANALYSIS_DATA[index];
-
   var menuItems = [];
 
-  for (var i = 0; i < jumps.length; i++) {
-    var sym = jumps[i].sym;
-    var pretty = jumps[i].pretty;
-    menuItems.push({html: fmt("Go to definition of _", pretty),
-                    href: `/${tree}/define?q=${encodeURIComponent(sym)}&redirect=false`,
-                    icon: "search"});
+  var elt = $(event.target);
+  var index = elt.closest("[data-i]").attr("data-i");
+  if (index) {
+    // Comes from the generated page.
+    var [jumps, searches] = ANALYSIS_DATA[index];
+
+    for (var i = 0; i < jumps.length; i++) {
+      var sym = jumps[i].sym;
+      var pretty = jumps[i].pretty;
+      menuItems.push({html: fmt("Go to definition of _", pretty),
+                      href: `/${tree}/define?q=${encodeURIComponent(sym)}&redirect=false`,
+                      icon: "search"});
+    }
+
+    for (var i = 0; i < searches.length; i++) {
+      var sym = searches[i].sym;
+      var pretty = searches[i].pretty;
+      menuItems.push({html: fmt("Search for _", pretty),
+                      href: `/${tree}/search?q=symbol:${encodeURIComponent(sym)}&redirect=false`,
+                      icon: "search"});
+    }
   }
 
-  for (var i = 0; i < searches.length; i++) {
-    var sym = searches[i].sym;
-    var pretty = searches[i].pretty;
-    menuItems.push({html: fmt("Search for _", pretty),
-                    href: `/${tree}/search?q=symbol:${encodeURIComponent(sym)}&redirect=false`,
-                    icon: "search"});
+  var id = elt.closest("[data-id]").attr("data-id");
+  if (id) {
+    menuItems.push({html: "Sticky highlight",
+                    href: `javascript:stickyHighlight('${id}')`});
   }
 
   setContextMenu({menuItems: menuItems}, event);


### PR DESCRIPTION
This patch allows you to click on an identifier and then select "Sticky highlight" from the context menu. The context menu disappears and the identifier stays highlighted until you click somewhere. This is nice to find all the uses of a local variable in a large function.