### PR TITLE
Add support for "Go to definition of IDL ..."

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -421,8 +421,9 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
             tree_name = path_elts[0]
             query = urlparse.parse_qs(url.query)
             symbol = query['q'][0]
+            kind = query['kind'][0]
             results = crossrefs.lookup(tree_name, symbol)
-            definition = results['Definitions'][0]
+            definition = results[kind][0]
             filename = definition['path']
             lineno = definition['lines'][0]['lno']
             url = '/' + tree_name + '/source/' + filename + '#' + str(lineno)

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -117,8 +117,9 @@ $("#file").on("click", "span[data-id]", function(event) {
     for (var i = 0; i < jumps.length; i++) {
       var sym = jumps[i].sym;
       var pretty = jumps[i].pretty;
+      var kind = jumps[i].kind;
       menuItems.push({html: fmt("Go to definition of _", pretty),
-                      href: `/${tree}/define?q=${encodeURIComponent(sym)}&redirect=false`,
+                      href: `/${tree}/define?q=${encodeURIComponent(sym)}&kind=${kind}&redirect=false`,
                       icon: "search"});
     }
 

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -29,8 +29,12 @@ function setContextMenu(menu, event)
   });
 }
 
+// When this is set to true, moving the mouse doesn't change what is highlighted.
+var stickyHover = false;
+
 // Remove the menu when a user clicks outside it.
 window.addEventListener('mousedown', function() {
+  stickyHover = false;
   $('#context-menu').remove();
 }, false);
 
@@ -41,7 +45,7 @@ window.addEventListener("pageshow", function() {
 var hovered = $();
 
 $("#file").on("mousemove", function(event) {
-  if ($('#context-menu').length) {
+  if ($('#context-menu').length || stickyHover) {
     return;
   }
 
@@ -72,45 +76,64 @@ $("#file").on("mousemove", function(event) {
   hovered.addClass("hovered");
 });
 
-$("#file").on("click", "span[data-i]", function(event) {
-  var tree = $("#data").data("tree");
+function stickyHighlight(id)
+{
+  $('#context-menu').remove();
 
-  var elt = $(event.target);
-  while (!elt.attr("data-i")) {
-    elt = elt.parent();
-  }
-  var index = elt.attr("data-i");
+  hovered.removeClass("hovered");
+  hovered = $(`span[data-id="${id}"]`);
+  hovered.addClass("hovered");
+
+  stickyHover = true;
+}
+
+$("#file").on("click", "span[data-id]", function(event) {
+  stickyHover = false;
+
+  var tree = $("#data").data("tree");
 
   function fmt(s, data) {
     data = data
-       .replace(/&/g, "&amp;")
-       .replace(/</g, "&lt;")
-       .replace(/>/g, "&gt;")
-       .replace(/"/g, "&quot;")
-       .replace(/'/g, "&#039;");
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
     return s.replace("_", data);
   }
 
-  // Comes from the generated page.
-  var [jumps, searches] = ANALYSIS_DATA[index];
-
   var menuItems = [];
 
-  for (var i = 0; i < jumps.length; i++) {
-    var sym = jumps[i].sym;
-    var pretty = jumps[i].pretty;
-    menuItems.push({html: fmt("Go to definition of _", pretty),
-                    href: `/${tree}/define?q=${encodeURIComponent(sym)}&redirect=false`,
-                    icon: "search"});
+  var elt = $(event.target);
+  if (elt.attr("data-i")) {
+    while (!elt.attr("data-i")) {
+      elt = elt.parent();
+    }
+    var index = elt.attr("data-i");
+
+    // Comes from the generated page.
+    var [jumps, searches] = ANALYSIS_DATA[index];
+
+    for (var i = 0; i < jumps.length; i++) {
+      var sym = jumps[i].sym;
+      var pretty = jumps[i].pretty;
+      menuItems.push({html: fmt("Go to definition of _", pretty),
+                      href: `/${tree}/define?q=${encodeURIComponent(sym)}&redirect=false`,
+                      icon: "search"});
+    }
+
+    for (var i = 0; i < searches.length; i++) {
+      var sym = searches[i].sym;
+      var pretty = searches[i].pretty;
+      menuItems.push({html: fmt("Search for _", pretty),
+                      href: `/${tree}/search?q=symbol:${encodeURIComponent(sym)}&redirect=false`,
+                      icon: "search"});
+    }
   }
 
-  for (var i = 0; i < searches.length; i++) {
-    var sym = searches[i].sym;
-    var pretty = searches[i].pretty;
-    menuItems.push({html: fmt("Search for _", pretty),
-                    href: `/${tree}/search?q=symbol:${encodeURIComponent(sym)}&redirect=false`,
-                    icon: "search"});
-  }
+  var id = elt.attr("data-id");
+  menuItems.push({html: "Sticky highlight",
+                  href: `javascript:stickyHighlight('${id}')`});
 
   setContextMenu({menuItems: menuItems}, event);
 });

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -197,9 +197,10 @@ pub struct Jump {
     pub path: String,
     pub lineno: u64,
     pub pretty: String,
+    pub kind: String,
 }
 
-pub fn read_jumps(filename: &str) -> HashMap<String, Jump> {
+pub fn read_jumps(filename: &str) -> HashMap<String, Vec<Jump>> {
     let file = File::open(filename).unwrap();
     let reader = BufReader::new(&file);
     let mut result = HashMap::new();
@@ -220,9 +221,10 @@ pub fn read_jumps(filename: &str) -> HashMap<String, Jump> {
             path: array[1].as_string().unwrap().to_string(),
             lineno: array[2].as_u64().unwrap(),
             pretty: array[3].as_string().unwrap().to_string(),
+            kind: array[4].as_string().unwrap().to_string(),
         };
 
-        result.insert(id, data);
+        result.entry(id).or_insert_with(|| vec![]).push(data);
     }
     result
 }


### PR DESCRIPTION
One annoying weakness of Searchfox is as follows. Suppose a method foo() is defined in an IDL file nsIBar. If some C++ code calls bar->Foo() and you click on Foo, the context menu will have "Go to definition" and "Search" options. The "go to definition" item will take you to a C++ implementation of Foo, if there is one. The "search" option will show you the XPIDL line that defines foo(), as well as any C++ implementations and uses. To find JS implementations and uses, you have to click on the IDL search result and then search again.

This patch improves things somewhat. It adds an option to jump directly to the IDL file from the C++ method call. From there, you can find JS implementations and uses. To do this, I had to expand the notion of a definition so that there can be one regular definition and one IDL definition.

Eventually it would be nice to have some sort of "See also" functionality to expose the JS code directly.

Note that this same code will work equally well for IPDL and WebIDL (once we support WebIDL in bug 1416899).