### PR TITLE
Don't allow VM to use more than half of system memory.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,20 @@ Vagrant.configure("2") do |config|
   config.vm.network :forwarded_port, guest: 80, host: 8000
 
   config.vm.provider "virtualbox" do |v|
-    v.memory = 10000
+    host = RbConfig::CONFIG['host_os']
+    if host =~ /darwin/
+      # sysctl returns Bytes and we need to convert to MB
+      mem = `sysctl -n hw.memsize`.to_i / 1024
+    elsif host =~ /linux/
+      # meminfo shows KB and we need to convert to MB
+      mem = `grep 'MemTotal' /proc/meminfo | sed -e 's/MemTotal://' -e 's/ kB//'`.to_i
+    elsif host =~ /mswin|mingw|cygwin/
+      # Windows code via https://github.com/rdsubhas/vagrant-faster
+      mem = `wmic computersystem Get TotalPhysicalMemory`.split[1].to_i / 1024
+    end
+
+    # Give VM 1/2 system memory or 10G, whichever is less
+    v.memory = [mem / 1024 / 2, 10000].min
     v.cpus = 4
   end
 end


### PR DESCRIPTION
For those of us trying to run on 8GB macbook air devices giving the VM
10G locks up the machine and forces a reboot :(

This patch keeps the 10G desired memory amount, but clamps it to no more than half of system memory.