### PR TITLE
Remove symlinks as they don't work well on a Windows host

### DIFF
--- a/tests/searchfox/find-repo-files
+++ b/tests/searchfox/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*

--- a/tests/tests/find-repo-files
+++ b/tests/tests/find-repo-files
@@ -1,1 +1,3 @@
-../find-repo-files.py
+#!/usr/bin/env bash
+
+exec $(dirname $0)/../find-repo-files.py $*


### PR DESCRIPTION
Developing mozsearch locally on a Windows host doesn't work well because
the repository contains symlinks and the Windows checkout of the symlinks
may not work properly (at least by default). Since all the symlinks
point to the same script, we can just put that script in the scripts/ folder
and use it from there. The script is also updated to incorporate changes
from the mozsearch-mozilla repo, as this script will now be used to process
all trees.