### PR TITLE
Explicitly use bazel 0.7.0 for building

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -10,11 +10,16 @@ sudo apt-get install -y curl
 sudo apt-get install -y software-properties-common
 
 # Livegrep (Bazel is needed for Livegrep builds, OpenJDK 8 required for bazel)
-sudo apt-get install -y openjdk-8-jdk
-echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-curl https://storage.googleapis.com/bazel-apt/doc/apt-key.pub.gpg | sudo apt-key add -
-sudo apt-get update
-sudo apt-get install -y bazel libssl-dev
+sudo apt-get install -y openjdk-8-jdk libssl-dev
+# Install Bazel 0.7.0
+rm -rf bazel
+mkdir bazel
+pushd bazel
+# Note that bazel unzips itself so we can't just pipe it to sudo bash.
+curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/0.7.0/bazel-0.7.0-without-jdk-installer-linux-x86_64.sh
+chmod +x bazel-0.7.0-without-jdk-installer-linux-x86_64.sh
+sudo ./bazel-0.7.0-without-jdk-installer-linux-x86_64.sh
+popd
 
 # Clang
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -


### PR DESCRIPTION
The current vagrant build (provision? whatever you'd call it) was broken for me due to a bazel update, this fixed it. Specifically, I get something like 

```
==> default: ERROR: /home/vagrant/livegrep/src/proto/BUILD:6:1: Traceback (most recent call last):
==> default: 	File "/home/vagrant/livegrep/src/proto/BUILD", line 6
==> default: 		go_proto_library(name = "go_proto", protos = ["live..."], ...)
==> default: 	File "/root/.cache/bazel/_bazel_root/afac32cc4b4378a2a7ed263118fd7a0e/external/org_pubref_rules_protobuf/go/rules.bzl", line 69, in go_proto_library
==> default: 		go_proto_deps += GRPC_COMPILE_DEPS
==> default: trying to mutate a frozen object
```

When building codesearch. https://github.com/bazelbuild/bazel/releases/tag/0.8.0 says they took out the `--incompatible_disallow_set_constructor` flag that we use as well, although maybe that doesn't matter anymore?

I'm not sure if we have the ability to update enough things to make version 0.8.0 work at the moment (as of filing this bug, I don't think so, but I also have absolutely no idea how any of this works 😅).

In the short term this forces us to use the previous version, which works. There may be a way to make that work with apt, i'm not familiar enough with apt to know how to make that happen.