### PR TITLE
Remove obsolete guardedHandlers code.

### DIFF
--- a/js-analyze.js
+++ b/js-analyze.js
@@ -318,9 +318,6 @@ let Analyzer = {
 
     case "TryStatement":
       this.statement(stmt.block);
-      for (let guarded of stmt.guardedHandlers) {
-        this.catchClause(guarded);
-      }
       if (stmt.handler) {
         this.catchClause(stmt.handler);
       }


### PR DESCRIPTION
guardedHandlers was removed in bug 1228841.