### PR TITLE
 Make rust and C agree on symbols for extern functions

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -310,6 +310,10 @@ private:
 
   std::string getMangledName(clang::MangleContext *Ctx,
                              const clang::NamedDecl *Decl) {
+    if (isa<FunctionDecl>(Decl) && cast<FunctionDecl>(Decl)->isExternC()) {
+      return cast<FunctionDecl>(Decl)->getNameAsString();
+    }
+
     if (isa<FunctionDecl>(Decl) || isa<VarDecl>(Decl)) {
       const DeclContext *DC = Decl->getDeclContext();
       if (isa<TranslationUnitDecl>(DC) || isa<NamespaceDecl>(DC) ||

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1421,8 +1421,8 @@ void PreprocessorHook::MacroExpands(const Token &Tok, const MacroDefinition &Md,
 }
 
 #if CLANG_VERSION_MAJOR >= 5
-void PreprocessorHook::MacroUndefined(const Token &tok,
-                                      const MacroDefinition &md,
+void PreprocessorHook::MacroUndefined(const Token &Tok,
+                                      const MacroDefinition &Md,
                                       const MacroDirective *Undef)
 #else
 void PreprocessorHook::MacroUndefined(const Token &Tok,

--- a/tests/tests/files/simple.cpp
+++ b/tests/tests/files/simple.cpp
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+extern "C" void WithNoMangle();
+
 namespace NS {
 
 struct R;
@@ -148,6 +150,8 @@ int main()
     NS::Dummy::Hello();
 
     NS::StackObj<int> stackobj(10);
+
+    WithNoMangle();
 
     return 0;
 }

--- a/tests/tests/files/simple.rs
+++ b/tests/tests/files/simple.rs
@@ -18,6 +18,11 @@ impl MyTrait for Loader {
     }
 }
 
+extern "C" fn WithoutNoMangle() {}
+
+#[no_mangle]
+extern "C" fn WithNoMangle() {}
+
 impl Loader {
     pub fn new(deps_dir: PathBuf) -> Self {
         Self { deps_dir, my_type: MyType::new() }

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -26,6 +26,15 @@ pub struct Defs {
     map: HashMap<DefId, data::Def>,
 }
 
+// Given a definition, and the global crate id where that definition is found,
+// return a qualified name that identifies the definition unambiguously.
+fn crate_independent_qualname(
+    def: &data::Def,
+    crate_id: &data::GlobalCrateId,
+) -> String {
+    format!("{}{}", crate_id.name, def.qualname)
+}
+
 impl Defs {
     fn new() -> Self {
         Self { map: HashMap::new() }
@@ -34,9 +43,7 @@ impl Defs {
     fn insert(&mut self, analysis: &data::Analysis, def: &data::Def) {
         let crate_id = analysis.prelude.as_ref().unwrap().crate_id.clone();
         let mut definition = def.clone();
-        let crate_independent_qualname =
-            format!("{}{}", crate_id.name, def.qualname);
-        definition.qualname = crate_independent_qualname;
+        definition.qualname = crate_independent_qualname(&def, &crate_id);
 
         let index = definition.id.index;
         let previous = self.map.insert(DefId(crate_id, index), definition);
@@ -239,8 +246,8 @@ fn analyze_file(
             }
         }
 
-        let crate_name = &file_analysis.prelude.as_ref().unwrap().crate_id.name;
-        let qualname = format!("{}{}", crate_name, def.qualname);
+        let crate_id = &file_analysis.prelude.as_ref().unwrap().crate_id;
+        let qualname = crate_independent_qualname(&def, crate_id);
         visit(&mut file, "def", &def.span, &qualname, parent.as_ref().map(|p| &*p.qualname))
     }
 

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -32,6 +32,13 @@ fn crate_independent_qualname(
     def: &data::Def,
     crate_id: &data::GlobalCrateId,
 ) -> String {
+    // For functions with "no_mangle", we just use the name.
+    if def.kind == DefKind::Function &&
+        def.attributes.iter().any(|attr| attr.value == "no_mangle")
+    {
+        return def.name.clone();
+    }
+
     format!("{}{}", crate_id.name, def.qualname)
 }
 


### PR DESCRIPTION
(By returning the unmangled name in both cases)

This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1428841.