### PR TITLE
rust-analyze: only stick with the deps/save-analysis file, instead of all of them.

### DIFF
--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -26,12 +26,12 @@ $MOZSEARCH_PATH/scripts/build.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME
 
 date
 
-$MOZSEARCH_PATH/scripts/find-objdir-files.py
-$MOZSEARCH_PATH/scripts/objdir-mkdirs.sh
+$MOZSEARCH_PATH/scripts/rust-analyze.sh $CONFIG_FILE $TREE_NAME
 
 date
 
-$MOZSEARCH_PATH/scripts/rust-analyze.sh $CONFIG_FILE $TREE_NAME
+$MOZSEARCH_PATH/scripts/find-objdir-files.py
+$MOZSEARCH_PATH/scripts/objdir-mkdirs.sh
 
 date
 

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -12,10 +12,11 @@ set -x # Show commands
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-find $OBJDIR -type d -name save-analysis |
-while read ANALYSIS_DIR; do
+if [ -e "$OBJDIR" ]; then
+  ANALYSIS_DIRS="$(find $OBJDIR -type d -name save-analysis)"
   $MOZSEARCH_PATH/tools/target/release/rust-indexer \
     "$FILES_ROOT" \
-    "$ANALYSIS_DIR" \
-    "$INDEX_ROOT/analysis"
-done
+    "$INDEX_ROOT/analysis" \
+    "$OBJDIR" \
+    $ANALYSIS_DIRS
+fi

--- a/tests/tests/files/Cargo.toml
+++ b/tests/tests/files/Cargo.toml
@@ -2,6 +2,7 @@
 name = "files"
 version = "0.1.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
+build = "build.rs"
 
 [lib]
 name = "simple"

--- a/tests/tests/files/simple.rs
+++ b/tests/tests/files/simple.rs
@@ -4,8 +4,14 @@ use std::path::{Path, PathBuf};
 use test_rust_dependency::{MyType, MyTrait};
 use test_rust_dependency::my_mod::MyOtherType;
 
+mod build_time_generated {
+    include!(concat!(env!("OUT_DIR"), "/generated.rs"));
+}
+
 #[derive(Clone)]
 pub struct Loader {
+    #[allow(unused)]
+    whatever: build_time_generated::GeneratedType,
     deps_dir: PathBuf,
     my_type: MyType,
 }
@@ -25,7 +31,11 @@ extern "C" fn WithNoMangle() {}
 
 impl Loader {
     pub fn new(deps_dir: PathBuf) -> Self {
-        Self { deps_dir, my_type: MyType::new() }
+        Self {
+            whatever: build_time_generated::GeneratedType,
+            deps_dir,
+            my_type: MyType::new(),
+        }
     }
 
     fn needs_hard_reload(&self, _: &Path) -> bool { true }

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -1,5 +1,6 @@
 #[macro_use]
 extern crate clap;
+extern crate env_logger;
 extern crate rls_analysis;
 extern crate rls_data as data;
 extern crate serde;
@@ -350,6 +351,7 @@ fn analyze_crate(
 }
 
 fn main() {
+    env_logger::init().unwrap();
     let matches = app_from_crate!()
         .args_from_usage(
             "<src>    'Points to the source root'


### PR DESCRIPTION
When building with crates.io, all the crate dependencies also get save-analysis
dirs.

We probably want to use them, but not quite yet.