### PR TITLE
Bug 1432300 - Improve the heuristic to pick the symbol that will be a…

### DIFF
--- a/tests/tests/files/bug1432300.cpp
+++ b/tests/tests/files/bug1432300.cpp
@@ -1,0 +1,22 @@
+namespace mozilla {
+
+template<class T> class Maybe {
+public:
+  Maybe(T x) : mX(x) {
+  }
+
+  Maybe(const Maybe<T>& x) : mX(x.mX) {
+  }
+
+  T mX;
+};
+
+}
+
+mozilla::Maybe<int> getAThing() {
+  return mozilla::Maybe<int>(42);
+}
+
+void useAThing() {
+  mozilla::Maybe<int> thing = getAThing();
+}

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -102,7 +102,17 @@ pub fn format_code(jumps: &HashMap<String, Jump>, format: FormatAs,
 
         let data = match (&token.kind, datum) {
             (&tokenize::TokenKind::Identifier(None), Some(d)) => {
-                let ref id = d[0].sym;
+                // In case the token has multiple symbols associated with it,
+                // try to pick the "best" one for determining which other tokens
+                // this gets highlighted with. For now we just take the first
+                // symbol that contains the token, or the first one in the list
+                // if none contain the token.
+                let id = if d.len() == 1 {
+                    &d[0].sym
+                } else {
+                    let displayed = &input[token.start .. token.end];
+                    &d.iter().find(|item| item.sym.contains(displayed)).unwrap_or(&d[0]).sym
+                };
 
                 let d = d.iter().filter(|item| { !item.no_crossref }).collect::<Vec<_>>();
 


### PR DESCRIPTION
…ssociated with a token's highlight.

Instead of just picking the first symbol in the list, check to see
if any of the symbols for that token contain the token's user-visible
string representation. If so, use that token. Otherwise fall back to
the first one in the list.