### PR TITLE
Immediately clear sticky hover when clicking away from things

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -34,7 +34,11 @@ var stickyHover = false;
 
 // Remove the menu when a user clicks outside it.
 window.addEventListener('mousedown', function() {
-  stickyHover = false;
+  if (stickyHover) {
+    stickyHover = false;
+    hovered.removeClass("hovered");
+    hovered = $();
+  }
   $('#context-menu').remove();
 }, false);
 


### PR DESCRIPTION
Without this, once sticky hover is enabled, the user has to click on empty
space, AND move the mouse for the sticky hover to be cleared. Instead the
click alone should do it.

Follow-up to #58.