### PR TITLE
Allow preserving the old working dir when setting up the indexer

### DIFF
--- a/infrastructure/indexer-setup.sh
+++ b/infrastructure/indexer-setup.sh
@@ -14,7 +14,12 @@ MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
 export CONFIG_REPO=$(readlink -f $1)
 WORKING=$(readlink -f $2)
 
-rm -rf $WORKING/*
+if [ -z "$KEEP_WORKING" ]; then
+    echo "Removing old contents of $WORKING/"
+    rm -rf $WORKING/*
+else
+    echo "Keeping old contents of $WORKING/"
+fi
 
 $MOZSEARCH_PATH/scripts/generate-config.sh $CONFIG_REPO $WORKING
 


### PR DESCRIPTION
When indexing mozilla-central, blowing away the working dir is
painful because it has to redownload the world which takes forever.
This allows devs (who know what they are doing) to run indexer-setup
with KEEP_WORKING=1 to keep the working directory instead of
blowing it away. The default behaviour is unchanged.