### PR TITLE
Remove spurious load-vars.sh goop and FILTER variable

### DIFF
--- a/infrastructure/indexer-run.sh
+++ b/infrastructure/indexer-run.sh
@@ -9,16 +9,15 @@ fi
 set -e
 set -x
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-
-CONFIG_REPO=$(readlink -f $1)
-WORKING=$(readlink -f $2)
+export MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+export CONFIG_REPO=$(readlink -f $1)
+export WORKING=$(readlink -f $2)
 
 CONFIG_FILE=$WORKING/config.json
 
 for TREE_NAME in $($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees)
 do
-    .  $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
+    . $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
     $MOZSEARCH_PATH/scripts/mkindex.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME
 done
 

--- a/infrastructure/indexer-setup.sh
+++ b/infrastructure/indexer-setup.sh
@@ -9,10 +9,9 @@ fi
 set -e
 set -x
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-
+export MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
 export CONFIG_REPO=$(readlink -f $1)
-WORKING=$(readlink -f $2)
+export WORKING=$(readlink -f $2)
 
 if [ -z "$KEEP_WORKING" ]; then
     echo "Removing old contents of $WORKING/"
@@ -22,13 +21,12 @@ else
 fi
 
 $MOZSEARCH_PATH/scripts/generate-config.sh $CONFIG_REPO $WORKING
-
 CONFIG_FILE=$WORKING/config.json
 
 for TREE_NAME in $($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees)
 do
-   .  $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-   mkdir -p $INDEX_ROOT
+    . $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
+    mkdir -p $INDEX_ROOT
 
     $CONFIG_REPO/$TREE_NAME/setup
 done

--- a/infrastructure/indexer-upload.sh
+++ b/infrastructure/indexer-upload.sh
@@ -20,10 +20,10 @@ export AWS_ROOT=$MOZSEARCH_PATH/infrastructure/aws
 
 for TREE_NAME in $($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees)
 do
-   .  $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
+    . $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
 
-   if [ -f $CONFIG_REPO/$TREE_NAME/upload ]
-   then
-       $CONFIG_REPO/$TREE_NAME/upload
-   fi
+    if [ -f $CONFIG_REPO/$TREE_NAME/upload ]
+    then
+        $CONFIG_REPO/$TREE_NAME/upload
+    fi
 done

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $# -ne 3 -a $# -ne 4 ]
+if [ $# -ne 3 ]
 then
-    echo "Usage: build.sh config-repo config-file.json tree_name [file_filter]"
+    echo "Usage: build.sh config-repo config-file.json tree_name"
     exit 1
 fi
 
@@ -13,9 +13,4 @@ CONFIG_REPO=$(realpath $1)
 CONFIG_FILE=$(realpath $2)
 TREE_NAME=$3
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
-FILTER=$3
-
-$CONFIG_REPO/$TREE_NAME/build $FILTER
+$CONFIG_REPO/$TREE_NAME/build

--- a/scripts/crossref.sh
+++ b/scripts/crossref.sh
@@ -6,9 +6,6 @@ set -x # Show commands
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
 echo Root is $INDEX_ROOT
 
 # Find the files to cross-reference.

--- a/scripts/idl-analyze.sh
+++ b/scripts/idl-analyze.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $# -ne 2 -a $# -ne 3 ]
+if [ $# -ne 2 ]
 then
-    echo "Usage: idl-analyze.sh config-file.json tree_name [file_filter]"
+    echo "Usage: idl-analyze.sh config-file.json tree_name"
     exit 1
 fi
 
@@ -11,15 +11,6 @@ set -x # Show commands
 
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
-
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
-FILTER=$3
-if [ "x${FILTER}" = "x" ]
-then
-    FILTER=".*"
-fi
 
 if [ ! -d /tmp/pymodules ]
 then
@@ -37,7 +28,7 @@ fi
 
 export PYTHONPATH=/tmp/pymodules
 
-cat $INDEX_ROOT/idl-files | grep "$FILTER" | \
+cat $INDEX_ROOT/idl-files | \
     parallel python $MOZSEARCH_PATH/idl-analyze.py \
     $INDEX_ROOT $FILES_ROOT/{} ">" $INDEX_ROOT/analysis/{}
 echo $?

--- a/scripts/ipdl-analyze.sh
+++ b/scripts/ipdl-analyze.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $# -ne 2 -a $# -ne 3 ]
+if [ $# -ne 2 ]
 then
-    echo "Usage: ipdl-analyze.sh config-file.json tree_name [file_filter]"
+    echo "Usage: ipdl-analyze.sh config-file.json tree_name"
     exit 1
 fi
 
@@ -12,17 +12,8 @@ set -x # Show commands
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
-FILTER=$3
-if [ "x${FILTER}" = "x" ]
-then
-    FILTER=".*"
-fi
-
 pushd $FILES_ROOT
-cat $INDEX_ROOT/ipdl-files | grep "$FILTER" | \
+cat $INDEX_ROOT/ipdl-files | \
     xargs $MOZSEARCH_PATH/tools/target/release/ipdl-analyze $(cat $INDEX_ROOT/ipdl-includes) \
           -d $INDEX_ROOT/analysis/__GENERATED__/ipc/ipdl/_ipdlheaders \
           -b $FILES_ROOT \

--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $# -ne 2 -a $# -ne 3 ]
+if [ $# -ne 2 ]
 then
-    echo "Usage: js-analyze.sh config-file.json tree_name [file_filter]"
+    echo "Usage: js-analyze.sh config-file.json tree_name"
     exit 1
 fi
 
@@ -12,16 +12,7 @@ set -x # Show commands
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
-FILTER=$3
-if [ "x${FILTER}" = "x" ]
-then
-    FILTER=".*"
-fi
-
-cat $INDEX_ROOT/js-files | grep "$FILTER" | \
+cat $INDEX_ROOT/js-files | \
     parallel --halt 2 js -f $MOZSEARCH_PATH/js-analyze.js -- {#} \
     $MOZSEARCH_PATH $FILES_ROOT/{} ">" $INDEX_ROOT/analysis/{}
 echo $?

--- a/scripts/load-vars.sh
+++ b/scripts/load-vars.sh
@@ -1,6 +1,13 @@
-#!/bin/bash
+# This file is intentionally not executable, because it should always be sourced
+# into a pre-existing shell. MOZSEARCH_PATH should be defined prior to sourcing.
+# Arguments are the config.json in the index and the tree for which variables
+# are desired
 
-export MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+if [ -z $MOZSEARCH_PATH ]
+then
+    echo "Error: load-vars.sh is being sourced without MOZSEARCH_PATH defined"
+    return # leave load-vars.sh without aborting the calling script
+fi
 
 export CONFIG_FILE=$1
 export TREE_NAME=$2

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -13,9 +13,6 @@ CONFIG_REPO=$1
 CONFIG_FILE=$2
 TREE_NAME=$3
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
 export PYTHONPATH=$MOZSEARCH_PATH/scripts
 
 date

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-if [ $# -ne 3 -a $# -ne 4 ]
+if [ $# -ne 3 ]
 then
-    echo "Usage: output.sh config_repo config-file.json tree_name [file_filter]"
+    echo "Usage: output.sh config_repo config-file.json tree_name"
     exit 1
 fi
 
@@ -13,25 +13,13 @@ CONFIG_REPO=$(realpath $1)
 CONFIG_FILE=$(realpath $2)
 TREE_NAME=$3
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
-FILTER=$4
-if [ "x${FILTER}" = "x" ]
-then
-    FILTER=".*"
-fi
-
-cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files | grep "$FILTER" | \
+cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files | \
     parallel --files --halt 2 -X --eta \
 	     $MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME
 
-if [ "${FILTER}" = ".*" ]
-then
-    HG_ROOT=$(python $MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees/$TREE_NAME/hg_root)
-    cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files > /tmp/dirs
-    js $MOZSEARCH_PATH/output-dir.js $FILES_ROOT $INDEX_ROOT "$HG_ROOT" $MOZSEARCH_PATH $OBJDIR $TREE_NAME /tmp/dirs
+HG_ROOT=$(python $MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees/$TREE_NAME/hg_root)
+cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files > /tmp/dirs
+js $MOZSEARCH_PATH/output-dir.js $FILES_ROOT $INDEX_ROOT "$HG_ROOT" $MOZSEARCH_PATH $OBJDIR $TREE_NAME /tmp/dirs
 
-    js $MOZSEARCH_PATH/output-template.js $FILES_ROOT $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME
-    js $MOZSEARCH_PATH/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH
-fi
+js $MOZSEARCH_PATH/output-template.js $FILES_ROOT $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME
+js $MOZSEARCH_PATH/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -12,9 +12,6 @@ set -x # Show commands
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
-. $MOZSEARCH_PATH/scripts/load-vars.sh $CONFIG_FILE $TREE_NAME
-
 find $OBJDIR -type d -name save-analysis |
 while read ANALYSIS_DIR; do
   $MOZSEARCH_PATH/tools/target/release/rust-indexer \


### PR DESCRIPTION
Each sub-script that does a particular step of the index building
runs the load-vars script as though it can be run in a standalone
manner. But it can't. There are hidden dependencies on other
variables (most notably the $WORKING variable which is only set
in the indexer-* scripts but used as part of various config
variables like $OBJDIR). So this standalone mode is not a real
thing and we should stop pretending that it is.

This patch does a bunch of cleanup on the load-vars.sh script
and places that use it.

As a bonus it also removes the FILTER variable from some scripts
which seems to be similarly unused and broken.