### PR TITLE
Bug 1451373 - Ensure we index the mozilla subrepo inside c-c as well.

### DIFF
--- a/router/codesearch.py
+++ b/router/codesearch.py
@@ -23,7 +23,14 @@ class CodeSearch:
     def collateMatches(self, matches):
         paths = {}
         for m in matches:
-            paths.setdefault(m['path'], []).append({
+            # For results in the "mozilla-subrepo" repo, which is the mozilla/
+            # subfolder of comm-central, we need to adjust the path to reflect
+            # the fact that it's in the subfolder.
+            path = m['path']
+            if m['tree'] == 'mozilla-subrepo':
+                path = 'mozilla/' + path
+
+            paths.setdefault(path, []).append({
                 'lno': m['lno'],
                 'bounds': m['bounds'],
                 'line': m['line']
@@ -118,6 +125,11 @@ def startup_codesearch(data):
 
 def search(pattern, fold_case, path, tree_name):
     repo = '%s|%s-__GENERATED__' % (tree_name, tree_name)
+    # For comm-central we also want to search the mozilla/ subfolder which is a
+    # separate repo that we indexed into livegrep under the name "mozilla-subrepo"
+    if tree_name == "comm-central":
+        repo = repo + "|mozilla-subrepo"
+
     data = tree_data[tree_name]
 
     try:

--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -47,6 +47,15 @@ if 'git_path' in tree:
         'path': tree['git_path'],
         'revisions': ['HEAD']
     })
+
+    # comm-central has a mozilla subfolder which is another git repo, so
+    # add that to the livegrep config as well
+    if tree_name == 'comm-central':
+        livegrep_config['repositories'].append({
+            'name': 'mozilla-subrepo',
+            'path': tree['files_path'] + '/mozilla/',
+            'revisions': ['HEAD']
+        })
 else:
     run(['ln', '-s', tree['files_path'], '/tmp/dummy/%s' % tree_name])
 


### PR DESCRIPTION
The livegrep indexing is git-aware, and works on a per-repo basis for git repos.
When we switched c-c from using a hg repo to a git repo, we also started going
down the "git repo" codepath in build-codesearch.py, which ignored the mozilla/
subfolder since it wasn't part of the repo. This patch adds the mozilla/
subfolder as another repo to the livegrep config, and ensures it gets searched
along with comm-central. Some fiddling is needed to make sure we adjust the paths
properly to account for the mozilla/ subfolder.

Perhaps in the future we can find a way to reuse the top-level gecko-dev repo
here to save building the livegrep index twice, but that seems more involved and
this gets the job done for now.