### PR TITLE
Bug 1416806 - Followup to ensure the crontab entry also provides the …

### DIFF
--- a/infrastructure/aws/make-crontab.py
+++ b/infrastructure/aws/make-crontab.py
@@ -10,7 +10,7 @@ delta = datetime.timedelta(hours=6)
 when = datetime.datetime.now() + delta
 s = when.strftime('%M %H %d %m *')
 
-s += ' ' + os.path.join(dir_path, 'send-failure-email.py') + '\n'
+s += ' ' + os.path.join(dir_path, 'send-failure-email.py') + ' release-timeout searchfox-aws@mozilla.com\n'
 
 print s
 


### PR DESCRIPTION
…required args to failure-email.py

Turns out that in commit 25f3f1c8a27cea698414c3385ba8e58fd688c58a I forgot to update the crontab generator, and so if the indexer hung (which happened on the May 28 run) it wouldn't self-terminate in 6 hours but just keep going.