### PR TITLE
Bug 1469956 - Make is_test googlier

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -126,7 +126,8 @@ class SearchResults(object):
                 return False
             return ('/test/' in p or '/tests/' in p or '/mochitest/' in p or '/unit/' in p or 'testing/' in p or
                     '/jsapi-tests/' in p or '/reftests/' in p or '/reftest/' in p or
-                    '/crashtests/' in p or '/crashtest/' in p)
+                    '/crashtests/' in p or '/crashtest/' in p or
+                    '/googletest/' in p or '/gtest/' in p or '/gtests/' in p)
 
         if '__GENERATED__' in path:
             return 'generated'


### PR DESCRIPTION
There are a bunch of imported gtests that have paths that aren't matched by the existing is_test(). 'gtest' is the generic name given to gtest directories by Mozilla code. 'gtests' is needed in addition to 'gtest' because NSS has a lot of gtests with 'gtests' in the path, but not 'gtest'. 'googletest' is needed because libcubeb and libvpx have that in some of the test paths without 'gtest' or anything else. 'google_test' is used by NSS, but those files are all nested under a 'gtests' directory, so that is not needed.