### PR TITLE
Allow using an envvar to make the output files diff easily

### DIFF
--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -1,3 +1,4 @@
+use std::env;
 use std::io::Write;
 use std::collections::HashMap;
 use std::path::Path;
@@ -299,7 +300,7 @@ pub fn format_file_data(cfg: &config::Config,
     let opt = Options {
         title: &title,
         tree_name: tree_name,
-        include_date: true,
+        include_date: env::var("MOZSEARCH_DIFFABLE").is_err(),
         revision: revision,
     };
 


### PR DESCRIPTION
If you generate two index dirs with different versions of the mozsearch code,
doing a recursive diff on the two file/ directories turns up a lot of spew
because of the changed timestamp. With this patch you can set the
MOZSEARCH_DIFFABLE=1 envvar while running indexer-run.sh to omit the timestamp
and get a cleaner diff. This makes it easier to test changes.