### PR TITLE
Provisioning fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,9 +3,9 @@ Vagrant.configure("2") do |config|
   config.vm.box = "cbednarski/ubuntu-1604-large"
   config.vm.box_version = "0.1.0"
 
-  config.vm.provision :shell, path: "infrastructure/indexer-provision.sh"
-  config.vm.provision :shell, path: "infrastructure/vagrant/indexer-provision.sh"
-  config.vm.provision :shell, path: "infrastructure/web-server-provision.sh"
+  config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"
+  config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
+  config.vm.provision :shell, privileged: false, path: "infrastructure/web-server-provision.sh"
 
   config.vm.network :forwarded_port, guest: 80, host: 8000
 

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -59,11 +59,11 @@ popd
 sudo pip install boto3
 
 # Install pygit2.
-rm -rf libgit2-0.26.0
-wget -q https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
-tar xf v0.26.0.tar.gz
-rm -rf v0.26.0.tar.gz
-pushd libgit2-0.26.0
+rm -rf libgit2-0.27.1
+wget -q https://github.com/libgit2/libgit2/archive/v0.27.1.tar.gz
+tar xf v0.27.1.tar.gz
+rm -rf v0.27.1.tar.gz
+pushd libgit2-0.27.1
 cmake .
 make
 sudo make install

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -46,11 +46,11 @@ popd
 sudo pip install boto3
 
 # Install pygit2.
-rm -rf libgit2-0.26.0
-wget -q https://github.com/libgit2/libgit2/archive/v0.26.0.tar.gz
-tar xf v0.26.0.tar.gz
-rm -rf v0.26.0.tar.gz
-pushd libgit2-0.26.0
+rm -rf libgit2-0.27.1
+wget -q https://github.com/libgit2/libgit2/archive/v0.27.1.tar.gz
+tar xf v0.27.1.tar.gz
+rm -rf v0.27.1.tar.gz
+pushd libgit2-0.27.1
 cmake .
 make
 sudo make install


### PR DESCRIPTION
Right now provisioning a new vagrant machine is broken because pip installs a newer version of pygit2 than the libgit that gets installed. This fixes that and also (unrelatedly) also fixes the provisioning to better match what happens in production.