### PR TITLE
rust-indexer: Index rust standard library source.

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -44,6 +44,7 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0
 
 # Install Rust. We need rust nightly to use the save-analysis
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+rustup component add rust-src rust-analysis
 
 # Install codesearch.
 rm -rf livegrep
@@ -108,6 +109,7 @@ echo Config repository is $CONFIG_REPO
 # We need rust nightly to use the save-analysis, and firefox requires recent
 # versions of Rust.
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+rustup component add rust-src rust-analysis
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js

--- a/scripts/export-rust-source.sh
+++ b/scripts/export-rust-source.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+OBJDIR="$1"
+
+mkdir -p "$OBJDIR/__RUST__"
+
+cp -r "$(rustc --print sysroot)/lib/rustlib/src/rust/src" "$OBJDIR/__RUST__"

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -15,9 +15,15 @@ TREE_NAME=$2
 
 if [ -d "$OBJDIR" ]; then
   ANALYSIS_DIRS="$(find $OBJDIR -type d -name save-analysis)"
+  if [ "x$ANALYSIS_DIRS" = "x" ]; then
+    exit 0 # Nothing to analyze really.
+  fi
+  ANALYSIS_DIRS="$ANALYSIS_DIRS $(find `rustc --print sysroot` -type d -name analysis)"
+  RUST_SRC="$(rustc --print sysroot)/lib/rustlib/src/rust/src"
   $MOZSEARCH_PATH/tools/target/release/rust-indexer \
     "$FILES_ROOT" \
     "$INDEX_ROOT/analysis" \
     "$OBJDIR" \
+    "$RUST_SRC" \
     $ANALYSIS_DIRS
 fi

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -33,3 +33,5 @@ rm BuildTimeFile.cpp
 GENERATED_FILE=$OBJDIR/GeneratedFile.cpp
 echo "int main() { return 0; }" > $GENERATED_FILE
 $CXX -DTEST_MACRO1 -DTEST_MACRO2 $GENERATED_FILE -std=c++14 -c -o $OBJDIR/GeneratedFile.o -Wall
+
+$MOZSEARCH_PATH/scripts/export-rust-source.sh $OBJDIR

--- a/tests/tests/files/simple.cpp
+++ b/tests/tests/files/simple.cpp
@@ -1,6 +1,13 @@
 #include <stdio.h>
 
 extern "C" void WithNoMangle();
+extern "C" {
+    void InExternBlock();
+}
+
+void InExternBlock()
+{
+}
 
 namespace NS {
 
@@ -156,6 +163,8 @@ int main()
     NS::StackObj<int> stackobj(10);
 
     WithNoMangle();
+
+    InExternBlock();
 
     return 0;
 }

--- a/tests/tests/files/simple.rs
+++ b/tests/tests/files/simple.rs
@@ -26,6 +26,10 @@ impl MyTrait for Loader {
 
 extern "C" fn WithoutNoMangle() {}
 
+extern "C" {
+    fn InExternBlock();
+}
+
 #[no_mangle]
 extern "C" fn WithNoMangle() {}
 
@@ -41,6 +45,7 @@ impl Loader {
     fn needs_hard_reload(&self, _: &Path) -> bool { true }
 
     fn set_path_prefix(&mut self, _: &Path) {
+        unsafe { InExternBlock() };
         MyType::new().do_foo();
     }
 


### PR DESCRIPTION
This reuses the generated files infrastructure just for convenience.

We pull the source and the analysis data from the `rustup` component, so no need to build anything, which means it's quite fast.