### PR TITLE
Bug 1478639 - Use consistent caching, have 301's expire after 10min rather than 1 day.

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -35,7 +35,13 @@ def location(route, directives):
     print '  }'
     print
 
-print '''server {
+print '''# we are in the "http" context here.
+map $status $expires {
+  default 1d;
+  "301" 10m;
+}
+
+server {
   listen 80 default_server;
 
   # Redirect HTTP to HTTPS in release
@@ -44,6 +50,8 @@ print '''server {
   }
 
   sendfile off;
+
+  expires $expires;
 ''' % fmt
 
 location('/static', ['root %(mozsearch_path)s;'])
@@ -56,7 +64,6 @@ for repo in config['trees']:
         'try_files /file/$uri /dir/$uri/index.html =404;',
         'types { image/png png; image/jpeg jpeg jpg; image/gif gif; }',
         'default_type text/html;',
-        'expires 1d;',
         'add_header Cache-Control "public";',
     ])
 
@@ -77,7 +84,6 @@ for repo in config['trees']:
 location('= /', [
     'root %(doc_root)s;',
     'try_files $uri/help.html =404;',
-    'expires 1d;',
     'add_header Cache-Control "public";',
 ])
 


### PR DESCRIPTION
Firefox(/browsers) cache 301 results which makes them hard for users to
deal with since the normal "refresh" mechanism is no good once you've been
redirected to the target location.  The 301 redirect mechanism is used by
the REPO/define?q=TERM mechanism served by router.py.

In order to reduce users experiencing stale redirects and needing to
disable/purge their cache, we set the expiration time to 10 minutes.

Although the redirects are generated in router.py, the actual cache
lifetime comes from the nginx config, so we alter it there using nginx's
map module, documented at
https://nginx.org/en/docs/http/ngx_http_map_module.html

In the process of implementing and testing this, I realized that we
were actually only providing expiration directives for REPO/source and
"/".  All the proxy_pass'ed connections did not get expiration
directives, so the browser would use its own heuristics.  I've changed
this to specify the expiration directive at a server level.  We may not
actually want this.  Or maybe we do, but maybe we want the default to
be less than 1 day.