### PR TITLE
Tag provisioning instances to make them easier to identify

### DIFF
--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -33,7 +33,14 @@ launch_spec = {
     'SecurityGroups': ['indexer'],
     'UserData': user_data,
     'InstanceType': 'c3.2xlarge',
-    'BlockDeviceMappings': []
+    'BlockDeviceMappings': [],
+    'TagSpecifications': [{
+        'ResourceType': 'instance',
+        'Tags': [{
+            'Key': 'provisioner',
+            'Value': sys.argv[1],
+         }],
+    }],
 }
 
 client.run_instances(MinCount=1, MaxCount=1, **launch_spec)


### PR DESCRIPTION
Same idea as #125, but tagging for provisioning instances used to generate new AMIs.