### PR TITLE
Log AWS provisioning script output to a file

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -217,8 +217,8 @@ The `trigger-provision.py` script starts a new EC2 instance and uses
 cloud-init to run the given provisioner shell scripts in it. These
 scripts install all the required dependencies. When the scripts finish
 (which you need to check for manually by looking up the machine in the
-AWS console, sshing into it, and using `ps` to verify that nothing is
-running), you can use the AWS console to generate an AMI from the
+AWS console, sshing into it, and `tail`ing the provision.log file to
+check for completion), you can use the AWS console to generate an AMI from the
 instance. Select the instance in the console, then choose "Actions,
 Image, Create Image". The Image Name must be changed to
 `indexer-16.04` or `web-server-16.04`. The other values can remain as

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -21,7 +21,8 @@ cat > ~ubuntu/provision.sh <<"FINAL"
 FINAL
 
 chmod +x ~ubuntu/provision.sh
-sudo -i -u ubuntu ~ubuntu/provision.sh
+sudo -i -u ubuntu ~ubuntu/provision.sh > ~ubuntu/provision.log 2>&1
+echo "Provisioning complete." >> ~ubuntu/provision.log
 '''.format(script=script)
 
 # ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20160815 (ami-f701cb97)


### PR DESCRIPTION
This makes it easier to tell when the provisioning is complete. Running `ps` is not as good because there appears to be a bazel daemon that keeps running and sometimes it's not obvious when the provisioning itself is done.