### PR TITLE
Bug 1466402 - Bump livegrep version to fork from latest master

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -47,7 +47,7 @@ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 
 # Install codesearch.
 rm -rf livegrep
-git clone -b mozsearch-version https://github.com/mozsearch/livegrep
+git clone -b mozsearch-version2 https://github.com/mozsearch/livegrep
 pushd livegrep
 # The last two options turn off the bazel sandbox, which doesn't work
 # inside an LDX container.

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -36,7 +36,7 @@ curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 
 # Install codesearch.
 rm -rf livegrep
-git clone -b mozsearch-version https://github.com/mozsearch/livegrep
+git clone -b mozsearch-version2 https://github.com/mozsearch/livegrep
 pushd livegrep
 bazel build //src/tools:codesearch --incompatible_disallow_set_constructor=false
 sudo install bazel-bin/src/tools/codesearch /usr/local/bin

--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -77,7 +77,7 @@ livegrep_config['fs_paths'].append({
 
 json.dump(livegrep_config, open('/tmp/livegrep.json', 'w'))
 
-run(['codesearch', '/tmp/livegrep.json', '-dump_index', tree['codesearch_path'],
+run(['codesearch', '/tmp/livegrep.json', '-dump_index', tree['codesearch_path'], '-index_only',
      '-max_matches', '1000', '-line_limit', '4096'], stdin=open('/dev/null'), cwd='/tmp/dummy')
 
 run(['rm', '-rf', '/tmp/dummy'])


### PR DESCRIPTION
This will require rebuilding the indexer and web-server AMIs.

Current dev instance is running with this.