### PR TITLE
Install cbindgen for m-c

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -45,6 +45,9 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0
 # Install Rust. We need rust nightly to use the save-analysis
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 
+# Install cbindgen for mozilla-central.
+cargo install --force cbindgen
+
 # Install codesearch.
 rm -rf livegrep
 git clone -b mozsearch-version2 https://github.com/mozsearch/livegrep


### PR DESCRIPTION
I added this build dependency in https://bugzilla.mozilla.org/show_bug.cgi?id=1478813.

Perhaps we should run `./mach bootstrap` somehow...