### PR TITLE
Don't throw an exception when encountering a CallImport statement

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -691,8 +691,8 @@ let Analyzer = {
       });
       break;
 
-    case "MetaProperty":
-      // Not sure what this is!
+    case "MetaProperty": // Not sure what this is!
+    case "CallImport": // dynamic import statement, see e.g. https://hg.mozilla.org/mozilla-central/file/4df1ba9c741f/testing/web-platform/tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-external.js#l3
       break;
 
     default:


### PR DESCRIPTION
This fixes the current indexing failure, so I'm going to go ahead and merge it.