### PR TITLE
Bug 1490160 - Don't install cbindgen directly; let bootstrap do it

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -45,9 +45,6 @@ sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0
 # Install Rust. We need rust nightly to use the save-analysis
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
 
-# Install cbindgen for mozilla-central.
-cargo install --force cbindgen
-
 # Install codesearch.
 rm -rf livegrep
 git clone -b mozsearch-version3 https://github.com/mozsearch/livegrep
@@ -113,9 +110,6 @@ echo Config repository is $CONFIG_REPO
 # We need rust nightly to use the save-analysis, and firefox requires recent
 # versions of Rust.
 curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
-
-# Ensure cbindgen is updated.
-cargo install --force cbindgen
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js


### PR DESCRIPTION
Depends on https://github.com/mozsearch/mozsearch-mozilla/pull/17