### PR TITLE
Ensure we provision rustup.

### DIFF
--- a/infrastructure/aws/trigger-web-server.py
+++ b/infrastructure/aws/trigger-web-server.py
@@ -40,7 +40,7 @@ userData = '''#!/usr/bin/env bash
 
 cd ~ubuntu
 touch web_server_started
-HOME=/home/ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
+sudo -i -u ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
 sudo -i -u ubuntu mozsearch/infrastructure/aws/web-serve.sh config
 '''.format(branch=branch, channel=channel, mozsearch_repo=mozsearch_repo, config_repo=config_repo)
 

--- a/infrastructure/aws/trigger_indexer.py
+++ b/infrastructure/aws/trigger_indexer.py
@@ -12,7 +12,7 @@ def trigger(mozsearch_repo, config_repo, branch, channel, spot=False):
     user_data = '''#!/usr/bin/env bash
 
 cd ~ubuntu
-HOME=/home/ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
+sudo -i -u ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
 sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh "{branch}" "{channel}" "{mozsearch_repo}" "{config_repo}" config
 '''.format(branch=branch, channel=channel, mozsearch_repo=mozsearch_repo, config_repo=config_repo)
 

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -43,7 +43,11 @@ sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 400
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0 400
 
 # Install Rust. We need rust nightly to use the save-analysis
-curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+rustup install nightly
+rustup default nightly
+rustup uninstall stable
 
 # Install codesearch.
 rm -rf livegrep
@@ -106,10 +110,10 @@ echo Branch is $BRANCH
 echo Mozsearch repository is $MOZSEARCH_REPO
 echo Config repository is $CONFIG_REPO
 
-# Re-install Rust (make sure we have the latest version).
+# Update Rust (make sure we have the latest version).
 # We need rust nightly to use the save-analysis, and firefox requires recent
 # versions of Rust.
-curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+rustup update
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -31,8 +31,12 @@ sudo apt-get install -y nginx
 # Install pkg-config (needed for Rust's OpenSSL wrappers)
 sudo apt-get install pkg-config
 
-# Install Rust.
-curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+# Install Rust. We need rust nightly to build rls-data.
+curl https://sh.rustup.rs -sSf | sh -s -- -y
+source $HOME/.cargo/env
+rustup install nightly
+rustup default nightly
+rustup uninstall stable
 
 # Install codesearch.
 rm -rf livegrep
@@ -96,8 +100,8 @@ echo Branch is $BRANCH
 echo Mozsearch repository is $MOZSEARCH_REPO
 echo Config repository is $CONFIG_REPO
 
-# Re-install Rust (make sure we have the latest version).
-curl -sSf https://static.rust-lang.org/rustup.sh | sh -s -- --channel=nightly
+# Update Rust (make sure we have the latest version).
+rustup update
 
 # Install mozsearch.
 rm -rf mozsearch


### PR DESCRIPTION
Previously we were installing rust using static.rust-lang.org which
installs rustc into /usr/local/bin and doesn't install rustup. However,
in order to get the rust stdlib source, it's better to use the more
traditional rustup installation mechanism, which installs it into the
user home folder and also installs rustup. This patch does that and
then uses `rustup update` to update rust as needed, instead of rerunning
the installer in update.sh

This also means we need to run the update.sh script as the ubuntu user,
instead of root, so that rustup is on the $PATH. This is desirable anyway
because running things as root sucks, and the update.sh scripts already
use sudo for individual commands that need root, so in this case running
the script as root is completely avoidable.