### PR TITLE
Bug 1494348 - Add a toggle to disable keyboard shortcuts.

### DIFF
--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -68,6 +68,10 @@ a.type {
 }
 /* End of Context-menu only icons */
 
+.panel label.panel-accel {
+    padding: 0.5rem
+}
+
 .panel .accel {
     /* simulate a keyboard key effect */
     font-family: monospace;

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -49,7 +49,7 @@ $(function() {
         });
     }
 
-    document.documentElement.addEventListener('keypress', (event) => {
+    function handleAccelerator(event) {
         if (event.altKey || event.ctrlKey || event.metaKey) {
             return;
         }
@@ -81,5 +81,50 @@ $(function() {
                 }
                 break;
         }
+    }
+
+    function acceleratorsEnabledInLocalStorage() {
+        return !('accel-enable' in localStorage) || localStorage.getItem('accel-enable') == '1';
+    }
+
+    var acceleratorsEnabled = acceleratorsEnabledInLocalStorage();
+
+    if (acceleratorsEnabled) {
+        // Keyboard accelerators are enabled, so register them.
+        document.documentElement.addEventListener('keypress', handleAccelerator);
+    } else {
+        // Keyboard accelerators disabled, so reflect that state in the checkbox and
+        // hide the accelerators. Also don't register the keyboard listeners.
+        $('#panel-accel-enable')[0].checked = false;
+        $('.panel span.accel').hide();
+    }
+
+    function updateAccelerators(newState) {
+        if (acceleratorsEnabled == newState) {
+            return;
+        }
+        acceleratorsEnabled = newState;
+        if (newState) {
+            document.documentElement.addEventListener('keypress', handleAccelerator);
+            $('.panel span.accel').show();
+            localStorage.setItem('accel-enable', '1');
+            $('#panel-accel-enable')[0].checked = true;
+        } else {
+            document.documentElement.removeEventListener('keypress', handleAccelerator);
+            $('.panel span.accel').hide();
+            localStorage.setItem('accel-enable', '0');
+            $('#panel-accel-enable')[0].checked = false;
+        }
+    }
+
+    // If the user toggles the checkbox let's update the state accordingly.
+    $('#panel-accel-enable')[0].addEventListener('change', () => {
+        var newState = ($('#panel-accel-enable')[0].checked);
+        updateAccelerators(newState);
+    });
+    // If the user toggles it in a different tab, update the checkbox/state here
+    window.addEventListener("storage", function() {
+        var newState = acceleratorsEnabledInLocalStorage();
+        updateAccelerators(newState);
     });
 });

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -301,6 +301,7 @@ pub fn generate_panel(writer: &mut Write, sections: &[PanelSection]) -> Result<(
             ]),
             F::S("</button>"),
             F::S(r#"<section id="panel-content" aria-expanded="true" aria-hidden="false">"#),
+            F::S(r#"<label class="panel-accel"><input type="checkbox" id="panel-accel-enable" checked="checked">Enable keyboard shortcuts</label>"#),
             F::Seq(sections),
             F::S("</section>"),
         ]),


### PR DESCRIPTION
It doesn't play well with some features like typeahead find, so
people may want to disable it. This also adds a small cookie
library to save the user's choice.