### PR TITLE
Some small tweaks to make mozsearch a bit less Gecko-specific.

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -439,7 +439,7 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
                 j = j.replace("</", "<\\/").replace("<script", "<\\script").replace("<!", "<\\!")
                 template = os.path.join(index_path(tree_name), 'templates/search.html')
                 self.generateWithTemplate({'{{BODY}}': j, '{{TITLE}}': 'Search'}, template)
-        elif path_elts[1] == 'define':
+        elif len(path_elts) >= 2 and path_elts[1] == 'define':
             tree_name = path_elts[0]
             query = urlparse.parse_qs(url.query)
             symbol = query['q'][0]

--- a/router/router.py
+++ b/router/router.py
@@ -23,6 +23,11 @@ from logger import log
 def index_path(tree_name):
     return config['trees'][tree_name]['index_path']
 
+def get_main_tree():
+    if 'mozilla-central' in config['trees']:
+        return 'mozilla-central'
+    return config['trees'].keys()[0]
+
 # Simple globbing implementation, except ^ and $ are also allowed.
 def parse_path_filter(filter):
     filter = filter.replace('(', '\\(')
@@ -408,7 +413,7 @@ class Handler(SimpleHTTPServer.SimpleHTTPRequestHandler):
         # start mucking around in here.
 
         if not path_elts:
-            filename = os.path.join(index_path('mozilla-central'), 'help.html')
+            filename = os.path.join(index_path(get_main_tree()), 'help.html')
             data = open(filename).read()
             self.generate(data, 'text/html')
         elif len(path_elts) >= 2 and path_elts[1] == 'source':

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -53,7 +53,8 @@ function locstr2(loc, str)
 
 function nameValid(name)
 {
-  return name.indexOf(" ") == -1 &&
+  return name &&
+         name.indexOf(" ") == -1 &&
          name.indexOf("\n") == -1 &&
          name.indexOf("\r") == -1 &&
          name.indexOf("\0") == -1 &&

--- a/scripts/output-help.js
+++ b/scripts/output-help.js
@@ -1,11 +1,12 @@
 let helpFile = scriptArgs[0];
 let indexRoot = scriptArgs[1];
 let mozSearchRoot = scriptArgs[2];
+let treeName = scriptArgs[3];
 
 run(mozSearchRoot + "/scripts/output-lib.js");
 run(mozSearchRoot + "/scripts/output.js");
 
-let opt = {tree: "mozilla-central",
+let opt = {tree: treeName,
            title: "Searchfox",
            autofocusSearch: true};
 

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -23,4 +23,4 @@ cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files > /tmp/dirs
 js $MOZSEARCH_PATH/scripts/output-dir.js $FILES_ROOT $INDEX_ROOT "$HG_ROOT" $MOZSEARCH_PATH $OBJDIR $TREE_NAME /tmp/dirs
 
 js $MOZSEARCH_PATH/scripts/output-template.js $FILES_ROOT $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME
-js $MOZSEARCH_PATH/scripts/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH
+js $MOZSEARCH_PATH/scripts/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -15,9 +15,11 @@ TREE_NAME=$2
 
 if [ -d "$OBJDIR" ]; then
   ANALYSIS_DIRS="$(find $OBJDIR -type d -name save-analysis)"
-  $MOZSEARCH_PATH/tools/target/release/rust-indexer \
-    "$FILES_ROOT" \
-    "$INDEX_ROOT/analysis" \
-    "$OBJDIR" \
-    $ANALYSIS_DIRS
+  if [ "x$ANALYSIS_DIRS" != "x" ]; then
+    $MOZSEARCH_PATH/tools/target/release/rust-indexer \
+      "$FILES_ROOT" \
+      "$INDEX_ROOT/analysis" \
+      "$OBJDIR" \
+      $ANALYSIS_DIRS
+  fi
 fi


### PR DESCRIPTION
I convinced some Igalia folks to try maintaining their own searchfox instance with an up-to-date WebKit index (which would be very useful for us as well, since grepping WebKit is a bit of a pain).

This were some fixes that I needed to set something very simple up.