### PR TITLE
Downgrade a panic to a warning so we handle it more gracefully

### DIFF
--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -180,15 +180,18 @@ pub fn read_analyses<T>(filenames: &[&str], filter: &mut FnMut(&Object) -> Optio
             Err(_) => continue,
         };
         let reader = BufReader::new(&file);
-        let mut lineno = 1;
+        let mut lineno = 0;
         for line in reader.lines() {
             let line = line.unwrap();
+            lineno += 1;
             let data = Json::from_str(&line);
             let data = match data {
                 Ok(data) => data,
-                Err(e) => panic!("error {} on file {} line {}: {}", e, filename, lineno, &line),
+                Err(e) => {
+                    warn!("Error [{}] trying to read analysis from file [{}] line [{}]: [{}]", e, filename, lineno, &line);
+                    continue;
+                }
             };
-            lineno += 1;
             let obj = data.as_object().unwrap();
             match filter(obj) {
                 Some(v) => {

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,5 +1,7 @@
 #[macro_use]
 extern crate lazy_static;
+#[macro_use]
+extern crate log;
 extern crate rustc_serialize;
 extern crate git2;
 extern crate regex;


### PR DESCRIPTION
We'll still get notified via a warning email but at least we'll finish indexing, minus the analysis data that couldn't be parsed.