### PR TITLE
config: Don't hardcode gecko-dev commit links.

### DIFF
--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -17,6 +17,7 @@ pub struct TreeConfigPaths {
     pub git_blame_path: Option<String>,
     pub objdir_path: String,
     pub hg_root: Option<String>,
+    pub github_repo: Option<String>,
 }
 
 pub struct GitData {
@@ -56,10 +57,22 @@ pub fn get_hg_root(tree_config: &TreeConfig) -> String {
     // there isn't one specified. We can remove this once all relevant
     // deployed config.json files have an explicit hg root, and make
     // this return an Option<&str> instead.
-    match &tree_config.paths.hg_root {
-        &Some(ref hg_root) => hg_root.clone(),
-        &None => String::from("https://hg.mozilla.org/mozilla-central"),
+    match tree_config.paths.hg_root {
+        Some(ref hg_root) => hg_root.clone(),
+        None => String::from("https://hg.mozilla.org/mozilla-central"),
     }
+}
+
+pub fn get_git_commit_link(tree_config: &TreeConfig, commit_id: &str) -> String {
+    // For backwards compatibility, produce the gecko-dev link if there isn't
+    // one specified. We can remove this if we want as described above for
+    // get_hg_root and such.
+    let repo = match tree_config.paths.github_repo {
+        Some(ref repo) => &**repo,
+        None => "https://github.com/mozilla/gecko-dev",
+    };
+
+    format!("{}/commit/{}", repo, commit_id)
 }
 
 fn index_blame(_repo: &Repository, blame_repo: &Repository) -> (HashMap<Oid, Oid>, HashMap<Oid, String>) {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -794,8 +794,12 @@ fn generate_commit_info(tree_name: &str,
         None => vec![]
     };
 
-    let git = format!("<a href=\"https://github.com/mozilla/gecko-dev/commit/{}\">{}</a>",
-                      commit.id(), commit.id());
+    let id_string = format!("{}", commit.id());
+    let git = format!(
+        "<a href=\"{}\">{}</a>",
+        config::get_git_commit_link(tree_config, &id_string),
+        id_string,
+    );
 
     let naive_t = NaiveDateTime::from_timestamp(commit.time().seconds(), 0);
     let tz = FixedOffset::east(commit.time().offset_minutes() * 60);
@@ -827,7 +831,7 @@ fn generate_commit_info(tree_name: &str,
                       .arg("--cc")
                       .arg("--pretty=format:")
                       .arg("--raw")
-                      .arg(format!("{}", commit.id()))
+                      .arg(id_string)
                       .current_dir(&git_path)
                       .output()
                       .map_err(|_| "Diff failed 1"));


### PR DESCRIPTION
Need this for Servo and WebKit.