### PR TITLE
Windows

### DIFF
--- a/scripts/idl-analyze.py
+++ b/scripts/idl-analyze.py
@@ -59,7 +59,11 @@ def read_cpp_analysis(fname):
         return None
     decls = {}
     for line in lines:
-        j = json.loads(line.strip())
+        try:
+            j = json.loads(line.strip())
+        except ValueError, e:
+            print >>sys.stderr, 'Syntax error in JSON file', p, line.strip()
+            raise e
         if 'target' in j and j['kind'] == 'decl' and j['sym'].startswith('_Z'):
             idents = parse_mangled(j['sym'])
             if idents and len(idents) == 2:

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -106,12 +106,16 @@ pub struct AnalysisSource {
 }
 
 impl AnalysisSource {
-    /// Merges the `syntax` and `sym` fields from `other` into `self`.
-    /// Also asserts that the `pretty` and `no_crossref` fields are
-    /// the same because otherwise the merge doesn't really make sense.
+    /// Merges the `syntax`, `sym`, and `no_crossref` fields from `other`
+    /// into `self`. The `no_crossref` field can be different sometimes
+    /// with different versions of clang being used across different
+    /// platforms; in this case we only set `no_crossref` if all the versions
+    /// being merged have the `no_crossref` field set.
+    /// Also asserts that the `pretty` field is the same because otherwise
+    /// the merge doesn't really make sense.
     pub fn merge(&mut self, mut other: AnalysisSource) {
         assert_eq!(self.pretty, other.pretty);
-        assert_eq!(self.no_crossref, other.no_crossref);
+        self.no_crossref &= other.no_crossref;
         self.syntax.append(&mut other.syntax);
         self.syntax.sort();
         self.syntax.dedup();


### PR DESCRIPTION
Stuff I needed to fix for windows compat. Note that the patch to rust-indexer.rs doesn't properly deal with some cases that happen in practice (the mixed-separators case at https://github.com/nrc/rls-data/issues/20) but there's relatively few cases where that actually happens. I'm hoping it can be fixed in rls-data rather than having to make this hack even uglier.