### PR TITLE
Resync MozsearchIndexer.cpp after changes in bug 1501821

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -34,6 +34,12 @@
 #include "JSONFormatter.h"
 #include "StringOperations.h"
 
+#if CLANG_VERSION_FULL < 800
+// Starting with Clang 8.0 some basic functions have been renamed
+#define getBeginLoc getLocStart
+#define getEndLoc getLocEnd
+#endif
+
 using namespace clang;
 
 const std::string GENERATED("__GENERATED__" PATHSEP_STRING);
@@ -1021,7 +1027,7 @@ public:
       // the parameters in that case.
       if (ParamLoc.first == FuncLoc.first) {
         // Assume parameters are in order, so we always take the last one.
-        End = Param->getLocEnd();
+        End = Param->getEndLoc();
       }
     }
 
@@ -1039,13 +1045,13 @@ public:
     if (CXXRecordDecl* D2 = dyn_cast<CXXRecordDecl>(D)) {
       // But if there are parameters, we want to include those as well.
       for (CXXBaseSpecifier& Base : D2->bases()) {
-        std::pair<FileID, unsigned> Loc = SM.getDecomposedLoc(Base.getLocEnd());
+        std::pair<FileID, unsigned> Loc = SM.getDecomposedLoc(Base.getEndLoc());
 
         // It's possible there are macros involved or something. We don't include
         // the parameters in that case.
         if (Loc.first == FuncLoc.first) {
           // Assume parameters are in order, so we always take the last one.
-          End = Base.getLocEnd();
+          End = Base.getEndLoc();
         }
       }
     }
@@ -1128,7 +1134,7 @@ public:
     int Flags = 0;
     const char *Kind = "def";
     const char *PrettyKind = "?";
-    SourceRange PeekRange(D->getLocStart(), D->getLocEnd());
+    SourceRange PeekRange(D->getBeginLoc(), D->getEndLoc());
     if (FunctionDecl *D2 = dyn_cast<FunctionDecl>(D)) {
       if (D2->isTemplateInstantiation()) {
         D = D2->getTemplateInstantiationPattern();


### PR DESCRIPTION
Will merge after https://treeherder.mozilla.org/#/jobs?repo=try&revision=09b89c1684c660cf9496e5765ca6ef0ebdd97429&searchStr=searchfox is green. I verified these changes build in the vagrant machine. (But we should really update to a newer clang in the provisioning code)