### PR TITLE
highlighter: Add support for multiple symbols per identifier.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4,18 +4,8 @@ body {
     margin: 0;
 }
 
-span[data-id]:hover {
+span[data-symbols]:hover {
   cursor: pointer;
-}
-
-span[data-id][data-kind="def"].hovered {
-  background-color: cyan;
-}
-span[data-id][data-kind="use"].hovered {
-  background-color: yellow;
-}
-span[data-id][data-kind="assign"].hovered {
-  background-color: greenyellow;
 }
 
 .context-menu a:hover {

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -402,10 +402,10 @@ body.old-rev .content {
 }
 
 /* Hovering over symbol names */
-span[data-id]:hover {
+span[data-symbols]:hover {
   cursor: pointer;
 }
-span[data-id].hovered {
+span[data-symbols].hovered {
   background-color: yellow;
 }
 

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -117,21 +117,21 @@ pub fn format_code(jumps: &HashMap<String, Jump>, format: FormatAs,
                 let d = d.iter().filter(|item| !item.no_crossref).collect::<Vec<_>>();
 
                 let mut menu_jumps : HashMap<String, Json> = HashMap::new();
-                for item in d.iter() {
-                    for sym in &item.sym {
-                        match jumps.get(sym) {
-                            Some(jump) => {
-                                if !(&jump.path == path && jump.lineno == cur_line) {
-                                    let key = format!("{}:{}", jump.path, jump.lineno);
-                                    let mut obj = json::Object::new();
-                                    obj.insert("sym".to_string(), Json::String(sym.to_string()));
-                                    obj.insert("pretty".to_string(), Json::String(jump.pretty.clone()));
-                                    menu_jumps.insert(key, Json::Object(obj));
-                                }
-                            },
-                            None => {}
-                        }
+                for sym in d.iter().flat_map(|item| item.sym.iter()) {
+                    let jump = match jumps.get(sym) {
+                        Some(jump) => jump,
+                        None => continue,
+                    };
+
+                    if jump.path == *path && jump.lineno == cur_line {
+                        continue;
                     }
+
+                    let key = format!("{}:{}", jump.path, jump.lineno);
+                    let mut obj = json::Object::new();
+                    obj.insert("sym".to_string(), Json::String(sym.to_string()));
+                    obj.insert("pretty".to_string(), Json::String(jump.pretty.clone()));
+                    menu_jumps.insert(key, Json::Object(obj));
                 }
 
                 let items = d.iter().map(|item| {


### PR DESCRIPTION
This fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1510318 and
https://bugzilla.mozilla.org/show_bug.cgi?id=1430112.

There's a chance that this highlights too much for C++, but from my testing it
looks ok, and we can always filter symbols / add more heuristics if needed.

I removed some unused [data-kind] rules while I was at it.