### PR TITLE
Bug 1507923 - Add "hyperblame" functionality

### DIFF
--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -28,7 +28,7 @@ fn main() {
     let args: Vec<_> = env::args().collect();
     let (base_args, fname_args) = args.split_at(3);
 
-    let cfg = config::load(&base_args[1], false);
+    let cfg = config::load(&base_args[1], true);
     println!("Config file read");
 
     let tree_name = &base_args[2];

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -16,6 +16,7 @@ extern crate tools;
 use tools::find_source_file;
 use tools::file_format::analysis::{read_analysis, read_source, read_jumps};
 use tools::format::format_file_data;
+use tools::git_ops;
 use tools::config;
 use tools::languages;
 use languages::FormatAs;
@@ -53,6 +54,7 @@ fn main() {
         &None => (None, None),
     };
 
+    let mut diff_cache = git_ops::TreeDiffCache::new();
     for path in fname_args {
         println!("File {}", path);
 
@@ -199,6 +201,7 @@ fn main() {
                          input,
                          &jumps,
                          &analysis,
-                         &mut writer).unwrap();
+                         &mut writer,
+                         Some(&mut diff_cache)).unwrap();
     }
 }

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -79,7 +79,7 @@ pub fn get_git_commit_link(tree_config: &TreeConfig, commit_id: &str) -> String 
     format!("{}/commit/{}", repo, commit_id)
 }
 
-fn index_blame(_repo: &Repository, blame_repo: &Repository) -> (HashMap<Oid, Oid>, HashMap<Oid, String>) {
+pub fn index_blame(_repo: &Repository, blame_repo: &Repository) -> (HashMap<Oid, Oid>, HashMap<Oid, String>) {
     let mut walk = blame_repo.revwalk().unwrap();
     walk.push_head().unwrap();
 

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -229,7 +229,8 @@ pub fn format_file_data(cfg: &config::Config,
                         data: String,
                         jumps: &HashMap<String, Jump>,
                         analysis: &[WithLocation<Vec<AnalysisSource>>],
-                        writer: &mut Write) -> Result<(), &'static str>  {
+                        writer: &mut Write,
+                        mut diff_cache: Option<&mut git_ops::TreeDiffCache>) -> Result<(), &'static str>  {
     let tree_config = try!(cfg.trees.get(tree_name).ok_or("Invalid tree"));
 
     let format = languages::select_formatting(path);
@@ -352,6 +353,7 @@ pub fn format_file_data(cfg: &config::Config,
                         &cur_path,
                         cur_lineno,
                         &mut prev_blame_cache,
+                        diff_cache.as_mut().map(|c| &mut **c),
                     ) {
                         Ok(prev) => prev,
                         Err(e) => {
@@ -522,7 +524,8 @@ pub fn format_path(cfg: &config::Config,
                           data,
                           &jumps,
                           &analysis,
-                          writer));
+                          writer,
+                          None));
 
     Ok(())
 }

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -338,7 +338,7 @@ pub fn format_file_data(cfg: &config::Config,
 
     output::generate_formatted(writer, &f, 0).unwrap();
 
-    let mut last_rev = None;
+    let mut last_revs = None;
     let mut last_color = false;
     for i in 0 .. output_lines.len() {
         let lineno = i + 1;
@@ -346,16 +346,19 @@ pub fn format_file_data(cfg: &config::Config,
         let blame_data = if let Some(ref lines) = blame_lines {
             let blame_line = lines[i as usize];
             let pieces = blame_line.splitn(4, ':').collect::<Vec<_>>();
-            let rev = pieces[0];
-            let filespec = pieces[1];
-            let blame_lineno = pieces[2];
+            let revs = pieces[0];
+            let filespecs = pieces[1];
+            let blame_linenos = pieces[2];
 
-            let color = if last_rev == Some(rev) { last_color } else { !last_color };
-            last_rev = Some(rev);
+            // TODO: append with comma-separation to revs, filespecs, and blame_linenos
+            // if we want to have multiple blame entries
+
+            let color = if last_revs == Some(revs) { last_color } else { !last_color };
+            last_revs = Some(revs);
             last_color = color;
             let class = if color { 1 } else { 2 };
             let data = format!(" class=\"blame-strip c{}\" data-blame=\"{}#{}#{}\"",
-                               class, rev, filespec, blame_lineno);
+                               class, revs, filespecs, blame_linenos);
             data
         } else {
             "".to_owned()

--- a/tools/src/git_ops.rs
+++ b/tools/src/git_ops.rs
@@ -1,6 +1,6 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use git2::{Commit, Repository, TreeEntry};
+use git2::{Commit, DiffFindOptions, DiffOptions, Error, Oid, Patch, Repository, TreeEntry};
 
 use config::GitData;
 
@@ -41,5 +41,168 @@ pub fn get_blame_lines(git_data: Option<&GitData>, blame_commit: &Option<Commit>
             }
         },
         _ => None,
+    }
+}
+
+#[derive(Debug)]
+pub struct LineMap {
+    // Stores pairs (a, b) sorted so that `a` is always increasing.
+    // `a` is a line number, and `b` is the amount of adjustment needed
+    // for line numbers from `a` onwards. Subsequent entries effectively
+    // override previous ones, rather than being cumulative.
+    adjustments: Vec<(u32, i32)>,
+}
+
+impl LineMap {
+    pub fn map_line(&self, lineno: u32) -> u32 {
+        // Find the entry (a, b) in `adjustments` with the largest
+        // a <= lineno. This will give us the adjustment needed for
+        // lineno
+        let mut line_shift = 0;
+        for (ref start, ref shift) in &self.adjustments {
+            if *start <= lineno {
+                line_shift = *shift;
+            } else {
+                break;
+            }
+        }
+        assert!(lineno as i32 + line_shift >= 0);
+        (lineno as i32 + line_shift) as u32
+    }
+}
+
+/// Given two blob ids, corresponding to the "old" and "new" version of
+/// a file, this function produces a LineMap that can be used to map line
+/// numbers in the "new" file to approximately equivalent line numbers in
+/// "old" file. It does this by walking through the diff hunks between the
+/// two files and tracking a cumulative "shift" that needs to be applied
+/// to find the equivalent line in the old file.
+/// This is largely a reimplementation of the core bit of the implementation at
+/// https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/master/git_hyper_blame.py
+fn compute_line_map(repo: &Repository, new_oid: Oid, old_oid: Oid) -> Result<LineMap, Error> {
+    let new_blob = repo.find_blob(new_oid)?;
+    let old_blob = repo.find_blob(old_oid)?;
+    if old_blob.content().len() == 0 {
+        // If the old file had no lines, we can't really generate a line map to it, so abort
+        return Err(Error::from_str("Can't generate a linemap to an empty file"));
+    }
+
+    let patch = Patch::from_blobs(&old_blob,
+                                  None,
+                                  &new_blob,
+                                  None,
+                                  Some(DiffOptions::new().context_lines(0)))?;
+
+    let mut adjustments = Vec::new();
+    let mut shift : i32 = 0;
+    for hunk_index in 0..patch.num_hunks() {
+        let (hunk, _) = patch.hunk(hunk_index)?;
+        if hunk.new_lines() == hunk.old_lines() {
+            // The hunk didn't add or remove lines, so the amount to
+            // shift remains the same as before
+            continue;
+        }
+        if hunk.new_lines() > hunk.old_lines() {
+            // Lines were added in the hunk, let's map all the new
+            // lines to the last line of the hunk in the old file.
+            let extra_lines = hunk.new_lines() - hunk.old_lines();
+            for i in 0..extra_lines {
+                shift -= 1;
+                adjustments.push((hunk.new_start() + hunk.old_lines() + i, shift))
+            }
+        }
+        if hunk.new_lines() < hunk.old_lines() {
+            // Lines were removed in the hunk, so we have a discontinuity
+            // where lines after the hunk in the new file have a bigger
+            // shift than lines before/inside the hunk.
+            shift = shift + hunk.old_lines() as i32 - hunk.new_lines() as i32;
+            adjustments.push((hunk.new_start() + hunk.new_lines(), shift));
+        }
+    }
+    Ok(LineMap { adjustments })
+}
+
+/// Given a GitData, commit revision, and target file, this function returns information
+/// to track lines in that file backwards by one commit. Specifically, it returns
+/// the parent commit, the corresponding path of the equivalent source file in that commit
+/// (in case it was moved or copied), and a LineMap that allows mapping individual lines
+/// backwards from the target file to the source file. Note that this only works with
+/// non-merge revisions (i.e. there has to be a unique parent).
+/// If the target_file was not modified in the indicated commit, this function will return
+/// an error.
+fn map_to_previous_version(
+    git_data: &GitData,
+    rev: &str,
+    target_file: &Path
+) -> Result<(Oid, PathBuf, LineMap), Error> {
+    // TODO: cache the result of this function as it will likely get called many times
+    // with the exact same arguments repeatedly
+
+    let commit_obj = git_data.repo.revparse_single(rev)?;
+    let commit = commit_obj.as_commit().ok_or_else(|| Error::from_str("Commit_obj error"))?;
+    if commit.parent_ids().len() != 1 {
+        // If the commit didn't have a unique parent, let's abort
+        return Err(Error::from_str("No unique parent, don't know where to look for prev blame"));
+    }
+
+    let parent_commit = commit.parent(0)?;
+    let older_tree = parent_commit.tree()?;
+    let newer_tree = commit.tree()?;
+
+    let mut diff = git_data.repo.diff_tree_to_tree(Some(&older_tree), Some(&newer_tree), None)?;
+    diff.find_similar(Some(DiffFindOptions::new().renames(true)))?;
+
+    // There should be exactly one delta with the target_file as the "new file"
+    let mut deltas = diff.deltas().filter(|delta| delta.new_file().path() == Some(target_file));
+    let delta = match deltas.next() {
+        Some(d) => {
+            if deltas.next().is_some() {
+                warn!("Found extra delta entries with target {:?} in rev {}", target_file, rev);
+                return Err(Error::from_str("Too many deltas"));
+            }
+            d
+        }
+        None => {
+            warn!("Found zero delta entries with target {:?} in rev{}", target_file, rev);
+            return Err(Error::from_str("Zero deltas"));
+        }
+    };
+
+    if delta.old_file().id().is_zero() {
+        return Err(Error::from_str(&format!("Target {:?} added in rev {} with no ancestor",
+                                            target_file, rev)));
+    }
+
+    Ok((parent_commit.id(),
+        delta.old_file().path().ok_or_else(|| Error::from_str("Couldn't get old path"))?.to_path_buf(),
+        compute_line_map(&git_data.repo, delta.new_file().id(), delta.old_file().id())?))
+}
+
+/// Given a GitData, commit revision, target file, and line number in that file, this
+/// function tries to find the equivalent line in the parent revision, and provide the
+/// blame information for that line, along with the filename at that parent revision.
+/// The filename is necessary since the blame information may contain the special string
+/// "%" to indicate "the current file".
+pub fn find_prev_blame(
+    git_data: &GitData,
+    rev: &str,
+    target_file: &Path,
+    lineno: u32
+) -> Result<(String, PathBuf), Error> {
+    let (parent_commit, old_path, line_map) = map_to_previous_version(git_data, rev, target_file)?;
+
+    let old_lineno = line_map.map_line(lineno);
+    let parent_blame_oid = git_data.blame_map
+                                   .get(&parent_commit)
+                                   .ok_or_else(|| Error::from_str(&format!("Couldn't get blame rev for {:?}",
+                                                                           parent_commit)))?;
+    let parent_blame = git_data.blame_repo.as_ref().unwrap().find_commit(*parent_blame_oid)?;
+
+    match get_blame_lines(Some(git_data), &Some(parent_blame), target_file.to_str().unwrap()) {
+        Some(blame_lines) => {
+            let old_lineno_ix = old_lineno - 1; // line numbers are 1-based, array indexing is 0-based
+            Ok((blame_lines[old_lineno_ix as usize].clone(), old_path))
+        }
+        None => Err(Error::from_str("Unable to get blame lines for parent commit"))
     }
 }

--- a/tools/src/git_ops.rs
+++ b/tools/src/git_ops.rs
@@ -1,0 +1,45 @@
+use std::path::Path;
+
+use git2::{Commit, Repository, TreeEntry};
+
+use config::GitData;
+
+// Helpers to do things with git2
+
+fn latin1_to_string(bytes: Vec<u8>) -> String {
+    bytes.iter().map(|&c| c as char).collect()
+}
+
+pub fn decode_bytes(bytes: Vec<u8>) -> String {
+    match String::from_utf8(bytes.clone()) {
+        Ok(s) => s,
+        Err(_) => {
+            latin1_to_string(bytes)
+        }
+    }
+}
+
+pub fn read_blob_entry(repo: &Repository, entry: &TreeEntry) -> String {
+    let blob_obj = entry.to_object(repo).unwrap();
+    let blob = blob_obj.as_blob().unwrap();
+    let mut content = Vec::new();
+    content.extend(blob.content());
+    decode_bytes(content)
+}
+
+pub fn get_blame_lines(git_data: Option<&GitData>, blame_commit: &Option<Commit>, path: &str) -> Option<Vec<String>> {
+    match (git_data, blame_commit) {
+        (Some(&GitData {blame_repo: Some(ref blame_repo), ..}), &Some(ref blame_commit)) => {
+            let blame_tree = blame_commit.tree().ok()?;
+
+            match blame_tree.get_path(Path::new(path)) {
+                Ok(blame_entry) => {
+                    let blame_data = read_blob_entry(blame_repo, &blame_entry);
+                    Some(blame_data.lines().map(str::to_string).collect::<Vec<_>>())
+                },
+                Err(_) => None,
+            }
+        },
+        _ => None,
+    }
+}

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -17,6 +17,7 @@ pub mod languages;
 pub mod format;
 pub mod tokenize;
 pub mod links;
+pub mod git_ops;
 
 pub fn find_source_file(path: &str, files_root: &str, objdir: &str) -> String {
     if path.starts_with("__GENERATED__") {


### PR DESCRIPTION
Add code to "skip over" changesets listed in a .git-blame-ignore-revs file. The skipped changesets are still sent to the frontend, but are hidden by default. The user can expand to show them if desired.