### PR TITLE
Templates

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -27,9 +27,9 @@ popd
 
 # Clang
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-4.0 main"
+sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
 sudo apt-get update
-sudo apt-get install -y clang-4.0 clang-4.0-dev
+sudo apt-get install -y clang-6.0 clang-6.0-dev
 
 # Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
 sudo apt-get install -y zip unzip mercurial g++ make autoconf2.13 yasm libgtk2.0-dev libgtk-3-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libcurl4-openssl-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex libx11-xcb-dev ccache libgconf2-dev
@@ -41,9 +41,9 @@ sudo apt-get install -y parallel realpath python-virtualenv python-pip
 sudo apt-get install -y python-dev libffi-dev cmake
 
 # Setup direct links to clang
-sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-4.0 400
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-4.0 400
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-4.0 400
+sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-6.0 400
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 400
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 400
 
 # Install Rust. We need rust nightly to use the save-analysis
 curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/tests/tests/files/templates5.cpp
+++ b/tests/tests/files/templates5.cpp
@@ -1,0 +1,8 @@
+#include "templates5.h"
+
+bool func() {
+  nsTArray<int> intarray(3);
+  nsTArray<float> floatarray(3.5);
+  return intarray.Contains(5, 3) ||
+         floatarray.Contains(3.5, 5);
+}

--- a/tests/tests/files/templates5.h
+++ b/tests/tests/files/templates5.h
@@ -1,0 +1,12 @@
+template<typename T>
+class nsTArray {
+public:
+  nsTArray(const T& aT) : myT(aT) {}
+
+  template<typename Foo = T>
+  bool Contains(T aT, Foo foo) {
+    return myT == aT || myT == foo;
+  }
+private:
+  T myT;
+};


### PR DESCRIPTION
I spent a little bit of time this morning trying to set up a small testcase to investigate bug 1511025. I didn't get too far but I discovered that
- clang-4.0 generates some junk that clang-6.0 does not. So it's worth upgrading our clang to get results more representative of what's happening in m-c
- the included templates5.* testcase doesn't actually reproduce the behaviours from bug 1511025 but does show some other weird behaviours, so it's probably good to have anyway

For reference my workflow here is to (a) come up with a small testcase that reproduces the behaviours and save the generated analysis data, and then (b) iterate on editing MozsearchIndexer.cpp locally in the VM and regenerating the analysis until it looks sane, and then (c) do try pushes/dev pushes with the modifications to see how it fares on m-c generally. These patches help with (a) and (b)