### PR TITLE
indexer: Fix the build with trunk clang and with assertions enabled.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -34,7 +34,7 @@
 #include "JSONFormatter.h"
 #include "StringOperations.h"
 
-#if CLANG_VERSION_FULL < 800
+#if CLANG_VERSION_MAJOR < 8
 // Starting with Clang 8.0 some basic functions have been renamed
 #define getBeginLoc getLocStart
 #define getEndLoc getLocEnd
@@ -997,7 +997,7 @@ public:
   SourceRange getFunctionPeekRange(FunctionDecl* D) {
     // We always start at the start of the function decl, which may include the
     // return type on a separate line.
-    SourceLocation Start = D->getLocStart();
+    SourceLocation Start = D->getBeginLoc();
 
     // By default, we end at the line containing the function's name.
     SourceLocation End = D->getLocation();
@@ -1020,7 +1020,7 @@ public:
   }
 
   SourceRange getTagPeekRange(TagDecl* D) {
-    SourceLocation Start = D->getLocStart();
+    SourceLocation Start = D->getBeginLoc();
 
     // By default, we end at the line containing the name.
     SourceLocation End = D->getLocation();
@@ -1177,7 +1177,7 @@ public:
     // class name.
     if (isa<CXXDestructorDecl>(D)) {
       const char *P = SM.getCharacterData(Loc);
-      assert(*p == '~');
+      assert(*P == '~');
       P++;
 
       unsigned Skipped = 1;
@@ -1198,7 +1198,7 @@ public:
   }
 
   bool VisitCXXConstructExpr(CXXConstructExpr *E) {
-    SourceLocation Loc = E->getLocStart();
+    SourceLocation Loc = E->getBeginLoc();
     normalizeLocation(&Loc);
     if (!isInterestingLocation(Loc)) {
       return true;


### PR DESCRIPTION
CLANG_VERSION_FULL is a macro that lives in mozilla-central, so it doesn't exist
while building the indexer. Just use the macro clang provides.