### PR TITLE
Normalize away commas from rust symbols

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help:
 
 .DEFAULT_GOAL := help
 
-.PHONY: help check-in-vagrant build-clang-plugin build-rust-tools test-rust-tools build-test-repo build-mozilla-repo
+.PHONY: help check-in-vagrant build-clang-plugin build-rust-tools test-rust-tools build-test-repo build-mozilla-repo baseline comparison
 
 check-in-vagrant:
 	@[ -d /vagrant ] || (echo "This command must be run inside the vagrant instance" > /dev/stderr; exit 1)
@@ -34,3 +34,27 @@ build-mozilla-repo: check-in-vagrant build-clang-plugin build-rust-tools
 	/vagrant/infrastructure/indexer-run.sh ~/mozilla-config ~/mozilla-index
 	/vagrant/infrastructure/web-server-setup.sh ~/mozilla-config ~/mozilla-index ~
 	/vagrant/infrastructure/web-server-run.sh ~/mozilla-config ~/mozilla-index ~
+
+# To test changes to indexing, run this first to generate the baseline. Then
+# make your changes, and run `make comparison`. Note that we generate
+# the index into ~/diffable and move it to ~/baseline so that when we
+# generate the index with modifications we can also generate it into the same
+# ~/diffable folder. This eliminates spurious diff results that might
+# come from different absolute paths during the index generation step
+baseline: check-in-vagrant build-clang-plugin build-rust-tools
+	rm -rf ~/diffable ~/baseline
+	mkdir -p ~/diffable
+	/vagrant/infrastructure/indexer-setup.sh /vagrant/tests ~/diffable
+	MOZSEARCH_DIFFABLE=1 /vagrant/infrastructure/indexer-run.sh /vagrant/tests ~/diffable
+	mv ~/diffable ~/baseline
+
+comparison: check-in-vagrant build-clang-plugin build-rust-tools
+	rm -rf ~/diffable ~/modified
+	mkdir -p ~/diffable
+	/vagrant/infrastructure/indexer-setup.sh /vagrant/tests ~/diffable
+	MOZSEARCH_DIFFABLE=1 /vagrant/infrastructure/indexer-run.sh /vagrant/tests ~/diffable
+	mv ~/diffable ~/modified
+	@echo "------------------- Below is the diff between baseline and modified. ---------------------"
+	diff -u -r -x objdir ~/baseline/tests ~/modified/tests || true
+	@echo "------------------- Above is the diff between baseline and modified. ---------------------"
+	@echo "--- Run 'diff -u -r -x objdir ~/{baseline,modified}/tests | less' to see it in a pager ---"

--- a/scripts/output-dir.js
+++ b/scripts/output-dir.js
@@ -218,7 +218,7 @@ function readPathFile(pathFile, structure)
 
 function recursiveGenerate(dir, path)
 {
-  generateDirectory(dir, path == "" ? "/" : path, {tree: treeName, includeDate: true});
+  generateDirectory(dir, path == "" ? "/" : path, {tree: treeName, includeDate: os.getenv("MOZSEARCH_DIFFABLE") === undefined});
 
   for (let [filename, node] of dir) {
     if (node instanceof FileInfo) {

--- a/tests/tests/files/simple.rs
+++ b/tests/tests/files/simple.rs
@@ -71,3 +71,13 @@ fn simple_fn() {
         _ => println!("Boo"),
     }
 }
+
+struct MultiParams<'a, T> {
+    myvar: T,
+    another_var: &'a u32,
+}
+
+impl<'a, T> MultiParams<'a, T> {
+    fn fn_with_params_in_signature(&self) {
+    }
+}

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -63,7 +63,23 @@ fn crate_independent_qualname(
         return def.name.clone();
     }
 
-    format!("{}{}", crate_id.name, def.qualname)
+    fn normalize(qualname: &str) -> String {
+        // Downstream processing of the symbol doesn't deal well with
+        // these characters, so replace them with underscores
+        let mut normalized = qualname.replace(",", "_").replace(" ", "_");
+
+        // Some of the qualified names don't start with ::, for example:
+        //   __self_0_0$282
+        //   <Loader>::new
+        // Since we're mashing it with the crate_id.name later it's nice to
+        // insert the :: to make it more readable
+        if !normalized.starts_with("::") {
+            normalized.insert_str(0, "::");
+        }
+        normalized
+    }
+
+    format!("{}{}", crate_id.name, normalize(&def.qualname))
 }
 
 impl Defs {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -217,7 +217,12 @@ pub fn format_code(jumps: &HashMap<String, Jump>, format: FormatAs,
         output_lines.push(fixup(output));
     }
 
-    (output_lines, json::encode(&Json::Array(generated_json)).unwrap())
+    let analysis_json = if env::var("MOZSEARCH_DIFFABLE").is_err() {
+        json::encode(&Json::Array(generated_json)).unwrap()
+    } else {
+        format!("{}", json::as_pretty_json(&Json::Array(generated_json)))
+    };
+    (output_lines, analysis_json)
 }
 
 pub fn format_file_data(cfg: &config::Config,


### PR DESCRIPTION
The commas cause problems, see https://bugzilla.mozilla.org/show_bug.cgi?id=1512044

This also adds some Makefile goop to be able to test changes more easily. I ran the patch on the test repo locally and it fixed the issue with the testcase. I kicked off a push on the `kats` channel which I'll verify in the morning.