### PR TITLE
Bug 1515107 - Advance the cur_datum across columns as well

### DIFF
--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -81,10 +81,18 @@ pub fn format_code(jumps: &HashMap<String, Jump>, format: FormatAs,
 
         let column = (token.start - line_start) as u32;
 
-        // This should never happen, but sometimes the analysis
-        // has bugs in it. This works around them.
+        // Advance cur_datum as long as analysis[cur_datum] is pointing
+        // to tokens we've already gone past. This effectively advances
+        // cur_datum such that `analysis[cur_datum]` is the analysis data
+        // for our current token (if there is any).
         while cur_datum < analysis.len() &&
             cur_line as u32 > analysis[cur_datum].loc.lineno
+        {
+            cur_datum += 1
+        }
+        while cur_datum < analysis.len() &&
+            cur_line as u32 == analysis[cur_datum].loc.lineno &&
+            column > analysis[cur_datum].loc.col_start
         {
             cur_datum += 1
         }


### PR DESCRIPTION
This seems to be a silly error where we don't advance cur_datum properly.
We advance it to the correct line but fail to advance it over to the
correct column. So in some cases we don't find the analysis data for the
token, even though it is present in the dataset.

We have scenarios in simple.rs that are fixed by this patch, and I've pushed a test run to the `kats` channel to verify it fixes bug 1515107.