### PR TITLE
Update livegrep for native submodule support

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -21,9 +21,9 @@ rm -rf bazel
 mkdir bazel
 pushd bazel
 # Note that bazel unzips itself so we can't just pipe it to sudo bash.
-curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
-chmod +x bazel-0.16.1-installer-linux-x86_64.sh
-sudo ./bazel-0.16.1-installer-linux-x86_64.sh
+curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-linux-x86_64.sh
+chmod +x bazel-0.22.0-installer-linux-x86_64.sh
+sudo ./bazel-0.22.0-installer-linux-x86_64.sh
 popd
 
 # Clang
@@ -55,11 +55,9 @@ rustup uninstall stable
 
 # Install codesearch.
 rm -rf livegrep
-git clone -b mozsearch-version3 https://github.com/mozsearch/livegrep
+git clone -b mozsearch-version4 https://github.com/mozsearch/livegrep
 pushd livegrep
-# The last two options turn off the bazel sandbox, which doesn't work
-# inside an LDX container.
-bazel build //src/tools:codesearch --spawn_strategy=standalone --genrule_strategy=standalone
+bazel build //src/tools:codesearch
 sudo install bazel-bin/src/tools/codesearch /usr/local/bin
 popd
 # Remove ~2G of build artifacts that we don't need anymore

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -15,9 +15,9 @@ rm -rf bazel
 mkdir bazel
 pushd bazel
 # Note that bazel unzips itself so we can't just pipe it to sudo bash.
-curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/0.16.1/bazel-0.16.1-installer-linux-x86_64.sh
-chmod +x bazel-0.16.1-installer-linux-x86_64.sh
-sudo ./bazel-0.16.1-installer-linux-x86_64.sh
+curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/0.22.0/bazel-0.22.0-installer-linux-x86_64.sh
+chmod +x bazel-0.22.0-installer-linux-x86_64.sh
+sudo ./bazel-0.22.0-installer-linux-x86_64.sh
 popd
 
 # pygit2
@@ -41,7 +41,7 @@ rustup uninstall stable
 
 # Install codesearch.
 rm -rf livegrep
-git clone -b mozsearch-version3 https://github.com/mozsearch/livegrep
+git clone -b mozsearch-version4 https://github.com/mozsearch/livegrep
 pushd livegrep
 bazel build //src/tools:codesearch
 sudo install bazel-bin/src/tools/codesearch /usr/local/bin
@@ -53,7 +53,10 @@ rm -rf .cache/bazel
 sudo pip install grpcio grpcio-tools
 rm -rf livegrep-grpc
 mkdir livegrep-grpc
-python -m grpc_tools.protoc --python_out=livegrep-grpc --grpc_python_out=livegrep-grpc -I livegrep/src/proto livegrep/src/proto/livegrep.proto
+python -m grpc_tools.protoc --python_out=livegrep-grpc --grpc_python_out=livegrep-grpc -I livegrep/ livegrep/src/proto/config.proto
+python -m grpc_tools.protoc --python_out=livegrep-grpc --grpc_python_out=livegrep-grpc -I livegrep/ livegrep/src/proto/livegrep.proto
+touch livegrep-grpc/src/__init__.py
+touch livegrep-grpc/src/proto/__init__.py
 # Add the generated modules to the python path
 SITEDIR=$(python -m site --user-site)
 mkdir -p "$SITEDIR"

--- a/router/codesearch.py
+++ b/router/codesearch.py
@@ -6,20 +6,18 @@ import time
 from logger import log
 
 import grpc
-import livegrep_pb2
-import livegrep_pb2_grpc
+from src.proto import livegrep_pb2
+from src.proto import livegrep_pb2_grpc
 
 def collateMatches(matches):
     paths = {}
     for m in matches:
-        # If the tree name ends in "-subrepo", then we need to adjust the
-        # path to account for the fact that the subrepo root is in a subfolder
-        # of the main repo.
+        # For results in the "mozilla-subrepo" repo, which is the mozilla/
+        # subfolder of comm-central, we need to adjust the path to reflect
+        # the fact that it's in the subfolder.
         path = m.path
-        subrepo_suffix = '-subrepo'
-        if m.tree.endswith(subrepo_suffix):
-            subrepo_name = m.tree[0:(len(m.tree)-len(subrepo_suffix))]
-            path = subrepo_name + '/' + path
+        if m.tree == 'mozilla-subrepo':
+            path = 'mozilla/' + path
 
         paths.setdefault(path, []).append({
             'lno': m.line_number,

--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -45,16 +45,9 @@ if 'git_path' in tree:
     livegrep_config['repositories'].append({
         'name': tree_name,
         'path': tree['git_path'],
-        'revisions': ['HEAD']
+        'revisions': ['HEAD'],
+        'walk_submodules': True
     })
-
-    submodules = run(['git', 'submodule', 'foreach', '--recursive', '-q', 'echo $sm_path'], cwd=tree['git_path'])
-    for submod in submodules.splitlines():
-        livegrep_config['repositories'].append({
-            'name': submod + '-subrepo',
-            'path': tree['git_path'] + '/' + submod + '/',
-            'revisions': ['HEAD']
-        })
 
     # comm-central has a mozilla subfolder which is another git repo, so
     # add that to the livegrep config as well


### PR DESCRIPTION
This is currently deployed to kats.searchfox.org. Note that this requires reprovisioning the AMIs.