### PR TITLE
Bug 1545956 - Reorder apt install order so add-apt-repository is available. r=kats

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -4,12 +4,15 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+sudo apt-get update
+# necessary for apt-add-repository to exist
+sudo apt-get install -y software-properties-common
+
 sudo add-apt-repository ppa:git-core/ppa    # For latest git
 sudo apt-get update
 
 sudo apt-get install -y git
 sudo apt-get install -y curl
-sudo apt-get install -y software-properties-common
 
 # dos2unix is used to normalize generated files from windows
 sudo apt-get install -y dos2unix


### PR DESCRIPTION
`vagrant up` fails without this reordering because `add-apt-repository` is
attempted to be used before it's installed as part of the
`software-properties-common` package.