### PR TITLE
Bug 1550236 - Upgrade clang in vagrant build to clang 8. r=kats

### DIFF
--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -1,6 +1,8 @@
+CC = clang
+CXX = clang++
 LLVM_CONFIG ?= llvm-config
 LLVM_LDFLAGS := $(shell ${LLVM_CONFIG} --ldflags)
-CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -Wall -Wno-strict-aliasing \
+CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing \
 	$(if $(DEBUG),-O0 -g)
 LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
 

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -4,11 +4,17 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+# We currently try to keep the version of clang we use matching the one that
+# will be used by the Firefox build process.  If you have a "mach bootstrap"ped
+# system then you can see the current version locally via
+# "~/.mozbuild/clang/bin/clang --version"
+CLANG_VERSION=8
+
 sudo apt-get update
 # necessary for apt-add-repository to exist
 sudo apt-get install -y software-properties-common
 
-sudo add-apt-repository ppa:git-core/ppa    # For latest git
+sudo add-apt-repository -y ppa:git-core/ppa    # For latest git
 sudo apt-get update
 
 sudo apt-get install -y git
@@ -31,9 +37,9 @@ popd
 
 # Clang
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-6.0 main"
+sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${CLANG_VERSION} main"
 sudo apt-get update
-sudo apt-get install -y clang-6.0 clang-6.0-dev
+sudo apt-get install -y clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev
 
 # Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
 sudo apt-get install -y zip unzip mercurial g++ make autoconf2.13 yasm libgtk2.0-dev libgtk-3-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libcurl4-openssl-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex libx11-xcb-dev ccache libgconf2-dev
@@ -45,9 +51,9 @@ sudo apt-get install -y parallel realpath python-virtualenv python-pip
 sudo apt-get install -y python-dev libffi-dev cmake
 
 # Setup direct links to clang
-sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-6.0 400
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-6.0 400
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-6.0 400
+sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${CLANG_VERSION} 410
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} 410
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} 410
 
 # Install Rust. We need rust nightly to use the save-analysis
 curl https://sh.rustup.rs -sSf | sh -s -- -y


### PR DESCRIPTION
Upgrades to clang-8.  There have been some packaging name changes, with
places where "6.0" was previously used now just being "8".  I added a variable
for the version, but if the naming scheme changes again, that doesn't really
save any effort.  I bumped the alternatives priority so that if someone runs
this on an already-provisioned vagrant, they should get the right thing.

The `add-apt-repository ppa:git-core/ppa` was prompting me when I manually
ran the provisioner script, so I added a `-y`.  (Presumably when run
non-interactively without a pty the prompt wasn't happening, or the fact that
I was running this on an already-provisioned vagrant.)

I also forced the clang-plugin Makefile to use "clang++" since my vagrant
instance was defaulting to g++ (which was really g++, not clang++) if I just
typed make.