### PR TITLE
Bug 1558616 - Temporary hack fix from IRC. r=kats

### DIFF
--- a/static/js/dxr.js
+++ b/static/js/dxr.js
@@ -5,6 +5,8 @@
  * @param {string} id = The id of the highlighted table row
  */
 function scrollIntoView(id, navigate = true) {
+  // TEMPORARY HACK DISABLING THIS METHOD.  SEE BUG 1558616.
+  return;
   if (document.getElementById(id)) {
     return;
   }


### PR DESCRIPTION
So this is just the hack I made on the web-server today to stop the dxr scrollIntoView logic from interfering with the code-highlighter.js logic on load.  In theory there might be some regressions for this for people who use the line highlighting mechanism and forward/backward on the browser somehow.  But since most "go to define" traversals result in separate windows/documents, I'm not sure if that's actually anyone.

Feel free to merge if you think having the hack permanently in place for now is better than not.