### PR TITLE
Bug 1558942 - Stop using generated content for line numbers in favor of user-select: none/-moz-user-select:none. r=kats

### DIFF
--- a/docs/a11y.md
+++ b/docs/a11y.md
@@ -40,7 +40,7 @@ Here's an example of a 1-row source listing:
 <div id="file" class="file" role="table">
   <div role="row" class="source-line-with-number">
     <div role="cell"><div class="blame-strip c1" data-blame="a015fb538abbbdcbfe404c320a8fefdc07a6a54e#%#1" role="button" aria-label="blame" aria-expanded="false"></div></div>
-    <div id="l1" role="cell" class="line-number" data-line-number="1"></div>
+    <div id="l1" role="cell" class="line-number">1</div>
     <code role="cell" class="source-line" id="line-1"><span class="syn_comment" >/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */</span>
   </code>
 </div>

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -153,15 +153,14 @@ td#line-numbers {
   display: flex;
 }
 
-/* In order to display the line numbers and have them visible to screen readers
-   but not appear in any copy-and-pasted selection, we create a before
-   pseudo-element with generated content. */
-.line-number::before {
-    content: attr(data-line-number);
-}
 .line-number {
     display: inline-block;
     cursor: pointer;
+    -moz-user-select: none;
+    -o-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -ms-user-select: none;
     user-select: none;
     text-align: right;
     padding: 0 0.5rem;

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -59,7 +59,7 @@ $("#scrolling").on('scroll', function() {
       return null;
     }
 
-    let num = parseInt(elem.dataset.lineNumber, 10);
+    let num = parseInt(elem.id.slice(1), 10);
     if (isNaN(num) || num < 0) {
       return null;
     }
@@ -109,7 +109,7 @@ $("#scrolling").on('scroll', function() {
         break;
       }
 
-      let lineNum = parseInt(elem.dataset.lineNumber, 10);
+      let lineNum = parseInt(elem.id.slice(1), 10);
 
       let expectedLineNum = sanityCheckLineNum - MAX_NESTING + iLine;
       if (lineNum !== expectedLineNum) {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -523,7 +523,7 @@ pub fn format_file_data(
                 F::T(format!("<div role=\"cell\" class=\"blame-container\"><div{}></div></div>", blame_data)),
                 // The line number.
                 F::T(format!(
-                    "<div id=\"l{}\" role=\"cell\" class=\"line-number\" data-line-number=\"{}\"></div>",
+                    "<div id=\"l{}\" role=\"cell\" class=\"line-number\">{}</div>",
                     lineno, lineno
                 )),
                 // The source line.
@@ -925,10 +925,10 @@ pub fn format_diff(
         };
 
         let line_str = if lineno > 0 {
-            format!("<div id=\"l{}\" role=\"cell\" class=\"line-number\" data-line-number=\"{}\"></div>",
+            format!("<div id=\"l{}\" role=\"cell\" class=\"line-number\">{}</div>",
                     lineno, lineno)
         } else {
-            "<div role=\"cell\" class=\"line-number\" data-line-number=\"&nbsp;\"></div>".to_owned()
+            "<div role=\"cell\" class=\"line-number\">&nbsp;</div>".to_owned()
         };
 
         let content = entity_replace(content.to_owned());


### PR DESCRIPTION
I've tested with NVDA on Windows Firefox release and copy-and-paste worked as expected as did NVDA.  (Although Firefox locked up for a long time producing the accessibility data on just MozsearchIndexer.cpp... :frowning_face: )