### PR TITLE
Bug 1558970 - Ensure that the number before a long line is not shrunk

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -168,6 +168,7 @@ td#line-numbers {
     /* this was originally set on the ".file td:first-child" */
     color: #aaa;
     width: 8ex;
+    flex-shrink: 0;
 }
 .highlighted,
 .multihighlight {


### PR DESCRIPTION
Test case: https://searchfox.org/mozilla-central/rev/227f5329f75bd8b16c6b146a7414598a420260cb/toolkit/locales/en-US/toolkit/about/aboutAddons.ftl#141

Before patch: Line is shifted to the left.
After patch: Line is at its normal place. The line number is happily reunited with the column of other line numbers.