### PR TITLE
Bug 1558616 - Fix scrolling logic. r=kats

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -14,6 +14,10 @@
   --highlighted-bgcolor: rgb(255, 255, 204);
 
   /* ### Sticky Headers ### */
+  /* Basically, what's the highest number we have a `.nesting-depth-N` selector
+     for. This is only used by the `.goto` scroll-padding as a constant.  */
+  --max-sticky-lines: 10;
+
   /* The background color applied to code lines that start a block and stick
      around until the block is closed. (They have the "stuck" class applied.) */
   --sticky-header-bgcolor: #ddf;
@@ -154,6 +158,10 @@ td#line-numbers {
 }
 
 .line-number {
+    /* this needs to create a containing block for the .goto synthetic anchor
+       elements which are created as children of .line-number elements, at least
+       as long as .goto is position: absolute. */
+    position: relative;
     display: inline-block;
     cursor: pointer;
     -moz-user-select: none;
@@ -259,6 +267,8 @@ body {
 
 .nesting-container {
   display: block;
+  /* create a containing block that bounds the position: sticky
+     .source-line-with-number div necessary for sticky operation. */
   position: relative;
 }
 .nesting-depth-1,
@@ -271,6 +281,7 @@ body {
 .nesting-depth-8,
 .nesting-depth-9,
 .nesting-depth-10 {
+  /* be sticky, contained within a .nesting-container */
   position: sticky;
   /* even with our "stuck" and "last-stuck" classes, it's important to have an
      opaque background color for these because those classes don't take effect
@@ -405,6 +416,8 @@ body {
 
 /* Context menu */
 .context-menu {
+    /* absolutely positioned within the containing block of the <body> relative
+       to the click event */
     position: absolute;
     background-color: #fff;
     margin: 0;
@@ -478,6 +491,9 @@ body {
 
 /* Navigation panel */
 .panel {
+    /* (position:fixed is always relative to the viewport's initial containing
+       block, so it doesn't matter where this node lives in the DOM, apart from
+       accessibility tree purposes.) */
     position: fixed;
     top: 105px;
     right: 22px;
@@ -575,9 +591,30 @@ span[data-symbols].hovered {
     margin-bottom: 10%;
 }
 
-/* Line number goto */
+/* ## Line number goto ##
+
+   `scrollIntoView` in dxr.js creates a synthetic anchor element for the current
+   hash string (which may be more than just "#200" and instead could be
+   "#200-220" or "#220,225,227" or something like that) and gives it this class.
+   The element is made a child of the .line-number element.
+
+   See the method's documentation for more context.
+*/
 .goto {
-    top: -200px;
+    /* The negative top allows us to control how much visible padding there
+       should be.  This needs to be large enough so that the "position: sticky"
+       stuck lines don't obscure the line we're trying to display.  Previously
+       this was necessary because the search header was position: fixed and we
+       needed to avoid being obscured by that.
+
+       The negative top could be eliminated and replaced with use of the CSS
+       scroll-padding mechanism introduced in Firefox 68 (currently beta).
+       However, we can't actually get rid of the synthetic anchor.  And since
+       scroll-padding isn't on release yet, we're sticking with this for now. */
+    top: calc(var(--max-sticky-lines) * 12px * -1.3);
+    /* and for the negative top to work, we need to be position: absolute and
+       .line-number needs to be position: relative to create a containing block
+       that we can offset against. */
     position: absolute;
 }
 
@@ -612,6 +649,8 @@ span[data-symbols].hovered {
 }
 .blame-popup {
     display: inline !important;
+    /* positioned inside the .blame-container's containing block created by it
+       being position: relative */
     position: absolute;
     top: 0;
     left: 20px;

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -468,7 +468,6 @@ $(function () {
   $(document).ready(function () {
     if (window.location.hash.substring(1)) {
       var toHighlight = getSortedHashLines(),
-      jumpPosition = $('#l' + toHighlight.lineStart).offset(),
       highlights = toHighlight.highlights,
       ranges = toHighlight.ranges;
 
@@ -489,14 +488,6 @@ $(function () {
         }
       }
 
-      //for directly linked line(s), scroll to the offset minus 150px for fixed search bar height
-      //but only scrollTo if the offset is more than 150px in distance from the top of the page
-      jumpPosition = parseInt(jumpPosition.top, 10) - 150;
-      if (jumpPosition >= 0) {
-        document.getElementById('scrolling').scrollTo(0, jumpPosition);
-      } else {
-        document.getElementById('scrolling').scrollTo(0, 0);
-      }
       //tidy up an incoming url that might be typed in manually
       setWindowHash();
     }

--- a/static/js/dxr.js
+++ b/static/js/dxr.js
@@ -1,12 +1,24 @@
 /**
- * Because we have a fixed header and often link to anchors inside pages, we can
- * run into the situation where the highled anchor is hidden behind the header.
- * This ensures that the highlighted anchor will always be in view.
- * @param {string} id = The id of the highlighted table row
+ * Creates a synthetic anchor for all hash configurations, even ones that
+ * highlight more than one line and therefore can't be understood by the
+ * browser's native anchor-seeking like "#200-205" and "#200,205".
+ *
+ * Even if it seemed like a good idea to attempt to manually trigger this
+ * scrolling on load and the "hashchange" event, Firefox notably will manually
+ * seek to an anchor if you press the enter key in the location bar and have not
+ * changed the hash.  This is a UX flow used by many developers, so it's
+ * essential the synthetic anchor is in place.  For this reason, any
+ * manipulation of history state via replaceState must call this method.
+ *
+ * This synthetic anchor also doubles as a means of creating sufficient padding
+ * so that "position:sticky" stuck lines don't obscure the line we're seeking
+ * to.  (That's what the "goto" class accomplishes.)  Please see mosearch.css
+ * for some additional details and context here.
+ *
+ * NOTE: This method should probably be renamed (in a future patch, not this
+ * patch, reviewers ;)
  */
 function scrollIntoView(id, navigate = true) {
-  // TEMPORARY HACK DISABLING THIS METHOD.  SEE BUG 1558616.
-  return;
   if (document.getElementById(id)) {
     return;
   }


### PR DESCRIPTION
- Restores the .line-number containing block necessary for scrollIntoView to
  work.
- Documents the position: relative/absolute instances in the CSS that I
  currently understand enough to document, possibly because I recently
  regressed them.
- Improve the documentation on scrollIntoView.
- Update the .goto padding to be based on our current position: sticky sizing.
  The math works out to -156 so this is actually a reduction right now.
- Remove the redundant manual JS scrolling that happens on startup.