### PR TITLE
Bug 1577060 - Support ClassField nodes. r=kats,emilio

### DIFF
--- a/tests/tests/files/some_javascript.js
+++ b/tests/tests/files/some_javascript.js
@@ -1,10 +1,78 @@
 // random bits of javascript
 
-class Foo {
-  static bar(baz) {
+const str_computed_field_num = 'computed_field_num';
+
+class ClassWithProperties {
+
+  pub_field_undefined;
+
+  pub_field_num = 1;
+
+  pub_field_dict = {
+    field_sub_prop: 2,
+    field_sub_dict: {
+      field_sub_sub_prop: 3
+    }
+  };
+
+  pub_field_func = function(b) {
+    return b * 2;
+  };
+
+  pub_field_arrow_func = b => {
+    return b * 2;
+  };
+
+  // Computed property name syntax.
+  [str_computed_field_num] = 3;
+
+  // PRIVATE FIELDS AREN'T SUPPORTED YET.
+  // These next 2 simply won't emit anything in the AST right now.
+  /*
+  #priv_field_undefined;
+
+  #priv_field_num = 10;
+  */
+
+  // This generates a syntax error even if I wrap the object initializer in
+  // parens.  The spec is very dry and I'm having trouble figuring out if this
+  // is actually legal or not.
+  /*
+  #priv_field_dict = {
+    sub_prop: 12
+  };
+  */
+
+  // This also doesn't work.
+  /*
+  #priv_field_func = b => {
+    return b * 2;
+  };
+  */
+
+  // Disabled by bug 1559269 for now.
+  /*
+  consumes_priv_field_num() {
+    return this.#priv_field_num;
+  }
+  */
+}
+
+class ClassWithStaticMethods {
+  static theStaticMethod(baz) {
     return baz;
   }
 }
+
+let obj_dict = {
+  obj_prop: 2,
+  obj_sub_dict: {
+    obj_sub_prop: 3,
+    obj_sub_sub_dict: {
+      obj_sub_sub_prop: 4
+    }
+  }
+};
 
 function Laser() {
 }
@@ -30,7 +98,6 @@ Laser.prototype.randoObj = {
   nestedObj: {},
 
   baz: function() {
-    
   }
 };
 


### PR DESCRIPTION
Bug 1499448 added support for the new ES class field syntax.  It also included
some provisional support for private fields which were largely disabled in
bug 1559269.

See https://github.com/tc39/proposal-class-fields for info on the spec.

This patch:
- Corrects ClassMethod processing to also generate "class#method" in addition to
  just "#method".  While figuring out how to implement ClassField I realized
  that we already did this for ObjectExpression/ObjectPattern, but not
  ClassMethod.  Our context would be right, but we'd be missing cross-reference
  symbols for the qualified name.
- Makes us process ClassField nodes similarly to how we process ObjectPattern.
  We emit an unqualified and qualified name (similar to the corrected
  ClassMethod), and we process the "init" (compare with prop's "value") with the
  name of the field pushed onto the contextStack.