### PR TITLE
Bug 1579428 - Update read-json.py to maintain object/dictionary ordering. r=kats

### DIFF
--- a/scripts/read-json.py
+++ b/scripts/read-json.py
@@ -2,8 +2,9 @@
 
 import json
 import sys
+from collections import OrderedDict
 
-j = json.load(open(sys.argv[1]))
+j = json.load(open(sys.argv[1]), object_pairs_hook=OrderedDict)
 components = sys.argv[2].split('/')
 for component in components:
     if component not in j:
@@ -13,8 +14,7 @@ for component in components:
 
 if type(j) == str or type(j) == unicode:
     print j
-elif type(j) == dict:
+elif type(j) == dict or type(j) == OrderedDict:
     print ' '.join(j.keys())
 else:
-    raise 'Unexpected type', j
-
+    raise Exception('Unexpected type', j)


### PR DESCRIPTION
This worked out okay in try runs, and I think it's beneficial for us to be able to control indexing ordering via the JSON config file.

Note that I'd initially missed the need to handle OrderedDict in the second hunk, which gave rise to the realization that our Exception raising code was not legit.