### PR TITLE
Bug 1579428 - Switch to m5d.2xlarge machines due to RAM contention. r=kats

### DIFF
--- a/infrastructure/aws/trigger_indexer.py
+++ b/infrastructure/aws/trigger_indexer.py
@@ -26,7 +26,7 @@ sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh "{branch}" "{channel}" "{
         'KeyName': 'Main Key Pair',
         'SecurityGroups': ['indexer-secure'],
         'UserData': user_data,
-        'InstanceType': 'c5d.2xlarge',
+        'InstanceType': 'm5d.2xlarge',
         'BlockDeviceMappings': block_devices,
         'IamInstanceProfile': {
             'Name': 'indexer-role',


### PR DESCRIPTION
As discussed at https://bugzilla.mozilla.org/show_bug.cgi?id=1567724#c19 it
appears that the indexing process is somewhat RAM limited.  While the machine
type is slightly more expensive ($0.452/hr vs. $0.384/hr is $0.068/hr), there
is at least a 40-minute runtime savings on output.sh which provides for 4.5
hours of the fancier machine type directly.  Additionally, we've been
thinking about adding the "ash" branch which would likely do even worse under
the existing c5d scheme if added to the mozilla-releases.json.

More significantly, I think we're pretty close to OOM's in the
mozilla-releases.json run and the human opportunity costs to re-triggering
those runs exceed the price differential by several orders of magnitude.

This will need the lambda functions to be regenerated to actually have an
effect.