### PR TITLE
Bug 1580266 - explicitly specify the default tree for help.html purposes. r=kats

### DIFF
--- a/infrastructure/web-server-setup.sh
+++ b/infrastructure/web-server-setup.sh
@@ -28,6 +28,8 @@ rm -rf $SERVER_ROOT/docroot
 mkdir -p $SERVER_ROOT/docroot
 DOCROOT=$(realpath $SERVER_ROOT/docroot)
 
+DEFAULT_TREE_NAME=$($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE default_tree)
+
 for TREE_NAME in $($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees)
 do
     mkdir -p $DOCROOT/file/$TREE_NAME
@@ -35,8 +37,13 @@ do
     ln -s $WORKING/$TREE_NAME/file $DOCROOT/file/$TREE_NAME/source
     ln -s $WORKING/$TREE_NAME/dir $DOCROOT/dir/$TREE_NAME/source
 
-    rm -f $DOCROOT/help.html
-    ln -s $WORKING/$TREE_NAME/help.html $DOCROOT
+    # Only update the help file if no default tree was specified OR
+    # The tree was specified and this is that tree.
+    if [ -z "$DEFAULT_TREE_NAME" -o "$DEFAULT_TREE_NAME" == "$TREE_NAME" ]
+    then
+        rm -f $DOCROOT/help.html
+        ln -s $WORKING/$TREE_NAME/help.html $DOCROOT
+    fi
 done
 
 python $MOZSEARCH_PATH/scripts/nginx-setup.py $CONFIG_FILE $DOCROOT "$USE_HSTS" > /tmp/nginx

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,6 +1,8 @@
 {
   "mozsearch_path": "$MOZSEARCH_PATH",
 
+  "default_tree": "tests",
+
   "trees": {
     "tests": {
       "index_path": "$WORKING/tests",


### PR DESCRIPTION
I think I did the shell stuff right.  It at least did the right thing locally, but please do sanity-check.  http://tldp.org/LDP/abs/html/comparison-ops.html says that "-o" does not short-circuit versus `||` which really doesn't matter either way in this case, but I never know whether it's better to avoid bash-isms if possible or what.