### PR TITLE
[wip] Move to Ubuntu 18.04 LTS.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,22 @@
 Vagrant.configure("2") do |config|
-  # We use this image to get a large (160GB) disk rather than the normal 40GB.
-  config.vm.box = "cbednarski/ubuntu-1604-large"
-  config.vm.box_version = "0.1.0"
+  config.vm.box = "generic/ubuntu1804"
+  config.vm.box_version = "1.9.34"
 
   config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/web-server-provision.sh"
 
-  config.vm.network :forwarded_port, guest: 80, host: 8000
+  config.vm.network :forwarded_port, guest: 80, host: 8001
 
   config.vm.provider "virtualbox" do |v|
+    v.memory = 10000
+    v.cpus = 4
+  end
+
+  config.vm.provider "libvirt" do |v|
+    # Need to do this manually for libvirt...
+    config.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash"
+
     v.memory = 10000
     v.cpus = 4
   end

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -37,15 +37,15 @@ popd
 
 # Clang
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${CLANG_VERSION} main"
+sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main"
 sudo apt-get update
 sudo apt-get install -y clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev
 
-# Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
-sudo apt-get install -y zip unzip mercurial g++ make autoconf2.13 yasm libgtk2.0-dev libgtk-3-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libcurl4-openssl-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex libx11-xcb-dev ccache libgconf2-dev
-
 # Other
-sudo apt-get install -y parallel realpath python-virtualenv python-pip
+sudo apt-get install -y parallel python-virtualenv python-pip
+
+# Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
+wget -O bootstrap.py https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py && python bootstrap.py --application-choice=browser --no-interactive && rm bootstrap.py
 
 # pygit2
 sudo apt-get install -y python-dev libffi-dev cmake

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -24,7 +24,7 @@ popd
 sudo apt-get install -y python-virtualenv python-dev libffi-dev cmake
 
 # Other
-sudo apt-get install -y parallel realpath unzip python-pip
+sudo apt-get install -y parallel unzip python-pip
 
 # Nginx
 sudo apt-get install -y nginx


### PR DESCRIPTION
And also allow libvirt as a back end, so I don't have to deal with incompatible
VirtualBox drivers :(

I _think_ the main issue here is that the disk space goes down to the regular
one (40GB), which may be not enough for mozilla-index...

Testing that with the indexing atm. But test repo and provisioning works fine.

Also I guess we'd need to update the AMIs and such...

I got into this because I wanted to hack on Searchfox and Virtualbox is 
unusable in my current kernel...