### PR TITLE
Make some scripts work when ran from the VM in a git worktree.

### DIFF
--- a/infrastructure/aws/build-lambda-indexer-start.sh
+++ b/infrastructure/aws/build-lambda-indexer-start.sh
@@ -18,7 +18,7 @@ CONFIG_INPUT=$3
 BRANCH=$4
 CHANNEL=$5
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/../..)
 
 mkdir /tmp/lambda
 cp $MOZSEARCH_PATH/infrastructure/aws/trigger_indexer.py /tmp/lambda

--- a/infrastructure/indexer-run.sh
+++ b/infrastructure/indexer-run.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-export MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+export MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/..)
 export CONFIG_REPO=$(readlink -f $1)
 export WORKING=$(readlink -f $2)
 export PERMANENT=${3:+$(readlink -f $3)}

--- a/infrastructure/indexer-setup.sh
+++ b/infrastructure/indexer-setup.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-export MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+export MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/..)
 export CONFIG_REPO=$(readlink -f $1)
 CONFIG_INPUT="$2"
 export WORKING=$(readlink -f $3)

--- a/infrastructure/web-server-run.sh
+++ b/infrastructure/web-server-run.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/..)
 
 WORKING=$(readlink -f $2)
 CONFIG_FILE=$WORKING/config.json

--- a/infrastructure/web-server-setup.sh
+++ b/infrastructure/web-server-setup.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/..)
 
 CONFIG_REPO=$(readlink -f $1)
 CONFIG_INPUT="$2"

--- a/scripts/generate-config.sh
+++ b/scripts/generate-config.sh
@@ -10,7 +10,7 @@ then
     exit 1
 fi
 
-MOZSEARCH_PATH=$(cd $(dirname "$0") && git rev-parse --show-toplevel)
+MOZSEARCH_PATH=$(readlink -f $(dirname "$0")/..)
 
 CONFIG_REPO=$(readlink -f $1)
 CONFIG_INPUT="$2"


### PR DESCRIPTION
When you're in a worktree, the `.git` thing that gets to `/vagrant` is not the
repo itself but a reference like:

> gitdir: /home/emilio/src/moz/mozsearch/.git/worktrees/mozsearch-ubuntu-up

Which is obviously _not_ in the /vagrant directory, and thus git operations fail
from inside the virtual machine.