### PR TITLE
Bug 1583031 - Have rust analysis run (optionally) per-platform

### DIFF
--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -4,27 +4,54 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-if [ $# -ne 2 ]
+if [ $# -lt 2 ]
 then
-    echo "Usage: rust-analyze.sh config-file.json tree_name"
+    echo "Usage: rust-analyze.sh config-file.json tree_name [platform-filter]"
     exit 1
 fi
 
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
+# Our current rust-indexer implementation can get confused if it's given the
+# same crate but for different platforms at the same time.  So we provide an
+# optional mechanism that takes a platform name per mozsearch-mozilla
+# convention and:
+# - filters the `find` invocations to only pick up output for that platform.
+# - puts the output in `analysis-linux64` for example instead of just
+#   `analysis`.
+PLATFORM=${3:-}
+
+# Figure out the name of the platform specific dir used for the rust stuff.
+declare -A RUST_PLAT_DIRS
+RUST_PLAT_DIRS["linux64"]="x86_64-unknown-linux-gnu"
+RUST_PLAT_DIRS["macosx64"]="x86_64-apple-darwin"
+RUST_PLAT_DIRS["win64"]="x86_64-pc-windows-msvc"
+RUST_PLAT_DIRS["android-armv7"]="thumbv7neon-linux-androideabi"
+
+# Hacky mechanism where we take a rust objdir value like x86_64-unknown-linux-gnu
+# to filter the rust analysis to just that.
+PLATFORM_SAVE_FILTER=${PLATFORM:+${RUST_PLAT_DIRS[$PLATFORM]}/debug/deps/}
+PLATFORM_FILTER=${PLATFORM:+${RUST_PLAT_DIRS[$PLATFORM]}/}
+PLATFORM_SUFFIX=${PLATFORM:+-$PLATFORM}
+
 if [ -d "$OBJDIR" ]; then
-  ANALYSIS_DIRS="$(find $OBJDIR -type d -name save-analysis)"
+  # Bail if the build step already performed rust analysis.
+  if [ -f "$OBJDIR/rust-analyzed" ]; then
+    exit 0
+  fi
+
+  ANALYSIS_DIRS="$(find $OBJDIR -type d -path \*/${PLATFORM_SAVE_FILTER}save-analysis)"
   if [ "x$ANALYSIS_DIRS" = "x" ]; then
     exit 0 # Nothing to analyze really.
   fi
   # If we have rust stdlib sources and analysis data, pick that up too
   if [ -d "$INDEX_ROOT/rustlib" ]; then
-    ANALYSIS_DIRS="$ANALYSIS_DIRS $(find $INDEX_ROOT/rustlib -type d -name analysis)"
+    ANALYSIS_DIRS="$ANALYSIS_DIRS $(find $INDEX_ROOT/rustlib -type d -path \*/${PLATFORM_FILTER}analysis)"
   fi
   $MOZSEARCH_PATH/tools/target/release/rust-indexer \
     "$FILES_ROOT" \
-    "$INDEX_ROOT/analysis" \
+    "$INDEX_ROOT/analysis${PLATFORM_SUFFIX}" \
     "$OBJDIR" \
     "$INDEX_ROOT/rustlib/src/rust/src" \
     $ANALYSIS_DIRS


### PR DESCRIPTION
This patch combined with the mozsearch-mozilla patch causes us to process the rust save-analysis data into the per-platform analysis directories, and then merge the results.

With these changes, I got a config.json run to seem to complete happily where:
- https://asuth.searchfox.org/mozilla-central/source/servo/components/style/values/specified/text.rs is no longer broken.  (Note that I've just triggered a mozilla-releases.json indexer run, so while the webserver for mozilla-central will stay up, the load balancer config will end up shifting away and the URL will become a 503 or whatever.  Feel free to inspect via ssh or reconfigure the load balancers if desired.)
- We end up with an analysis file in the expected place that looks right.
- Because our scripts still delete the per-platform analysis directories, it's a little harder to verify that those look right.

Note that I am still planning to improve the formatting logic in a separate patch so that the HTML can never get broken again, but I was trying hard to make sure I wasn't ignoring other correctness issues, which indeed is what I found with us processing all platforms together.  (This patch should also speed us up because we will run all 4 platforms in parallel.)