### PR TITLE
Bug 1595492 - switch over to new taskcluster CI.

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ steps in the next section.
 * You will also need to find the gecko-dev equivalent of the m-c base changeset
   that you did your try push on. You can obtain this by running this command,
   with `MOZILLA_MERCURIAL_HASH` filled in with the hg base revision of the try push.
+  **THE BELOW WILL NO LONGER WORK FOR NOW, APOLOGIES**.
 ```
 curl -X GET --header 'Accept: application/json' 'https://mapper.mozilla-releng.net/gecko-dev/rev/hg/MOZILLA_MERCURIAL_HASH'
 ```

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -128,7 +128,7 @@ rustup update
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js
-wget -nv https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
+wget -nv https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
 mkdir js
 pushd js
 unzip ../target.jsshell.zip

--- a/infrastructure/vagrant/indexer-provision.sh
+++ b/infrastructure/vagrant/indexer-provision.sh
@@ -6,7 +6,7 @@ set -o pipefail # Check all commands in a pipeline
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js
-wget -nv https://index.taskcluster.net/v1/task/gecko.v2.mozilla-central.nightly.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
+wget -nv https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
 mkdir js
 pushd js
 unzip ../target.jsshell.zip


### PR DESCRIPTION
Since trunk is broken, I'm going to speculatively land this and the other mozsearch-mozilla fix and then attempt try runs directly from lambda.  I'll ask for after-the-fact review on this and any additional fix-ups I need to perform.