### PR TITLE
Bug 1601451 - Move to Ubuntu 18.04 LTS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,31 @@ Searchfox locally using Vagrant.
 
 ## Vagrant setup for local development
 
-First, [install Vagrant](https://www.vagrantup.com/downloads.html) and
-[VirtualBox](https://www.virtualbox.org/wiki/Downloads) by
-following the instructions for your OS. Then clone Mozsearch and
-provision a Vagrant instance:
+First, [install Vagrant](https://www.vagrantup.com/downloads.html).  This is a
+virtualization automation tool.  It depends on a virtualization backend.
 
+Pick a virtualization backend and install it.  Your options are:
+- libvirt via [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt).
+  If you are on linux and aren't already using VirtualBox, it's the recommended
+  path.
+  - Follow the [installation instructions](https://github.com/vagrant-libvirt/vagrant-libvirt#installation).
+  - Note that if you didn't already have libvirt installed, then a new `libvirt`
+    group may just have been created and your existing logins won't have the
+    permissions necessary to talk to the management socket.  If you do
+    `exec su -l $USER` you can get access to your newly assigned group.
+- VirtualBox.  For platforms that aren't linux.  Visit the
+  [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads) and
+  following the instructions for your OS.
+
+Then clone Mozsearch and provision a Vagrant instance:
 ```
 git clone https://github.com/mozsearch/mozsearch
 cd mozsearch
 git submodule update --init
-vagrant up
+# if using libvirt
+vagrant up --provider libvirt
+# if using virtualbox
+vagrant up --provider virtualbox
 ```
 
 The last step will take some time (10 or 15 minutes on a fast laptop)
@@ -101,8 +116,8 @@ requests, we can start the server as follows:
 ```
 
 At this point, you should be able to visit the server, which is
-running on port 80 inside the VM and port 8000 outside the VM. Visit
-`http://localhost:8000/` to do so.
+running on port 80 inside the VM and port 8001 outside the VM. Visit
+`http://localhost:8001/` to do so.
 
 ## Indexing Mozilla code locally
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,20 @@ Pick a virtualization backend and install it.  Your options are:
     group may just have been created and your existing logins won't have the
     permissions necessary to talk to the management socket.  If you do
     `exec su -l $USER` you can get access to your newly assigned group.
-- VirtualBox.  For platforms that aren't linux.  Visit the
-  [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads) and
-  following the instructions for your OS.
+  - See troubleshooting below if you have problems.
+- VirtualBox.  For platforms that aren't linux.
+  - Visit the
+    [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads) and
+    follow the instructions for your OS.
+  - Run `vagrant plugin install vagrant-vbguest` to install a plugin that makes
+    sure the guest extensions that live inside the VM match the version of
+    virtualbox that you're using.  If you don't install this, you may see
+    errors about needing to setup a host network for NFS.  You don't.  You need
+    this plugin.
+    - You may need to `vagrant reload` and run `vagrant up` after the plugin
+      has been updated in the VM.  (That is, you might see the update happen and
+      then see the error.  The problem is the updated guest extension wasn't
+      immediately used, hence the need to reboot the VM.)
 
 Then clone Mozsearch and provision a Vagrant instance:
 ```
@@ -60,6 +71,22 @@ make
 # look in tools/target/release to find binaries.
 cd /vagrant/tools
 cargo build --release
+```
+
+### Troubleshooting
+
+#### libvirt
+
+If vagrant up times out in the "Mounting NFS shared folders..." step, chances
+are that you cannot access nfs from the virtual machine.
+
+Under stock Fedora 31, you probably need to allow libvirt to access nfs:
+
+```
+firewall-cmd --permanent --add-service=nfs --zone=libvirt
+firewall-cmd --permanent --add-service=rpc-bind --zone=libvirt
+firewall-cmd --permanent --add-service=mountd --zone=libvirt
+firewall-cmd --reload
 ```
 
 ## Testing locally using the test repository

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,15 +1,22 @@
 Vagrant.configure("2") do |config|
-  # We use this image to get a large (160GB) disk rather than the normal 40GB.
-  config.vm.box = "cbednarski/ubuntu-1604-large"
-  config.vm.box_version = "0.1.0"
+  config.vm.box = "generic/ubuntu1804"
+  config.vm.box_version = "1.9.34"
 
   config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/web-server-provision.sh"
 
-  config.vm.network :forwarded_port, guest: 80, host: 8000
+  config.vm.network :forwarded_port, guest: 80, host: 8001
 
   config.vm.provider "virtualbox" do |v|
+    v.memory = 10000
+    v.cpus = 4
+  end
+
+  config.vm.provider "libvirt" do |v|
+    # Need to do this manually for libvirt...
+    config.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash"
+
     v.memory = 10000
     v.cpus = 4
   end

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -260,7 +260,8 @@ For web serving, use this command:
 
 ```
 python infrastructure/aws/trigger-provision.py \
-  infrastructure/web-server-provision.sh
+  infrastructure/web-server-provision.sh \
+  infrastructure/aws/web-server-provision.sh
 ```
 
 The `trigger-provision.py` script starts a new EC2 instance and uses

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -25,8 +25,9 @@ sudo -i -u ubuntu ~ubuntu/provision.sh > ~ubuntu/provision.log 2>&1
 echo "Provisioning complete." >> ~ubuntu/provision.log
 '''.format(script=script)
 
-# ubuntu/images/hvm-ssd/ubuntu-xenial-16.04-amd64-server-20190816 - ami-0135f076a31aebe66
-image_id = 'ami-0135f076a31aebe66'
+# us-west-2	bionic	18.04 LTS	amd64	hvm:ebs-ssd	20191113	ami-0a7d051a1c4b54f65	hvm
+# ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20191113 - ami-0a7d051a1c4b54f65
+image_id = 'ami-0a7d051a1c4b54f65'
 
 launch_spec = {
     'ImageId': image_id,

--- a/infrastructure/aws/trigger-web-server.py
+++ b/infrastructure/aws/trigger-web-server.py
@@ -37,8 +37,8 @@ userData = '''#!/usr/bin/env bash
 cd ~ubuntu
 touch web_server_started
 sudo -i -u ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
-sudo -i -u ubuntu mozsearch/infrastructure/aws/web-serve.sh config "{config_input}"
-'''.format(branch=branch, channel=channel, mozsearch_repo=mozsearch_repo, config_repo=config_repo, config_input=config_input)
+sudo -i -u ubuntu mozsearch/infrastructure/aws/web-serve.sh config "{config_input}" "{volume_id}"
+'''.format(branch=branch, channel=channel, mozsearch_repo=mozsearch_repo, config_repo=config_repo, config_input=config_input, volume_id=volumeId)
 
 volumes = ec2.describe_volumes(VolumeIds=[volumeId])
 availability_zone = volumes['Volumes'][0]['AvailabilityZone']
@@ -53,7 +53,7 @@ if volumes['Volumes'][0]['Attachments']:
 
 print 'Starting web server instance...'
 
-images = ec2.describe_images(Filters=[{'Name': 'name', 'Values': ['web-server-16.04-ena']}])
+images = ec2.describe_images(Filters=[{'Name': 'name', 'Values': ['web-server-18.04']}])
 image_id = images['Images'][0]['ImageId']
 
 r = ec2.run_instances(

--- a/infrastructure/aws/trigger_indexer.py
+++ b/infrastructure/aws/trigger_indexer.py
@@ -18,7 +18,7 @@ sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh "{branch}" "{channel}" "{
 
     block_devices = []
 
-    images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-16.04-ena']}])
+    images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-18.04']}])
     image_id = images['Images'][0]['ImageId']
 
     launch_spec = {

--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# We want the NVME tools, that's how EBS gets mounted now on "nitro" instances.
+sudo apt-get install -y nvme-cli
+
+date

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -17,6 +17,25 @@ sudo apt-get install -y software-properties-common
 sudo add-apt-repository -y ppa:git-core/ppa    # For latest git
 sudo apt-get update
 
+# the base image we're building against is inherently not up-to-date (new base
+# images are released only monthly), so let's be consistently up-to-date.
+sudo DEBIAN_FRONTEND=noninteractive \
+  apt-get \
+  -o Dpkg::Options::=--force-confold \
+  -o Dpkg::Options::=--force-confdef \
+  -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+  dist-upgrade
+
+# unattended upgrades pose a problem for debugging running processes because we
+# end up running version N but have debug symbols for N+1 and that doesn't work.
+sudo apt-get remove -y unattended-upgrades
+# and we want to be able to debug python
+sudo apt-get install -y gdb
+sudo apt-get install -y python-dbg
+
+# we want to be able to extract stuff from json
+sudo apt-get install -y jq
+
 sudo apt-get install -y git
 sudo apt-get install -y curl
 

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -37,15 +37,15 @@ popd
 
 # Clang
 wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-${CLANG_VERSION} main"
+sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main"
 sudo apt-get update
 sudo apt-get install -y clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev
 
-# Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
-sudo apt-get install -y zip unzip mercurial g++ make autoconf2.13 yasm libgtk2.0-dev libgtk-3-dev libglib2.0-dev libdbus-1-dev libdbus-glib-1-dev libasound2-dev libcurl4-openssl-dev libiw-dev libxt-dev mesa-common-dev libgstreamer0.10-dev libgstreamer-plugins-base0.10-dev libpulse-dev m4 flex libx11-xcb-dev ccache libgconf2-dev
-
 # Other
-sudo apt-get install -y parallel realpath python-virtualenv python-pip
+sudo apt-get install -y parallel python-virtualenv python-pip
+
+# Firefox: https://developer.mozilla.org/en-US/docs/Mozilla/Developer_guide/Build_Instructions/Linux_Prerequisites
+wget -O bootstrap.py https://hg.mozilla.org/mozilla-central/raw-file/default/python/mozboot/bin/bootstrap.py && python bootstrap.py --application-choice=browser --no-interactive && rm bootstrap.py
 
 # pygit2
 sudo apt-get install -y python-dev libffi-dev cmake

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -6,6 +6,26 @@ set -o pipefail # Check all commands in a pipeline
 
 sudo add-apt-repository ppa:git-core/ppa    # For latest git
 sudo apt-get update
+
+# the base image we're building against is inherently not up-to-date (new base
+# images are released only monthly), so let's be consistently up-to-date.
+sudo DEBIAN_FRONTEND=noninteractive \
+  apt-get \
+  -o Dpkg::Options::=--force-confold \
+  -o Dpkg::Options::=--force-confdef \
+  -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+  dist-upgrade
+
+# unattended upgrades pose a problem for debugging running processes because we
+# end up running version N but have debug symbols for N+1 and that doesn't work.
+sudo apt-get remove -y unattended-upgrades
+# and we want to be able to debug python
+sudo apt-get install -y gdb
+sudo apt-get install -y python-dbg
+
+# and we want to be able to extract stuff from json
+sudo apt-get install -y jq
+
 sudo apt-get install -y git
 
 # Livegrep (Bazel is needed for Livegrep builds)

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -24,7 +24,7 @@ popd
 sudo apt-get install -y python-virtualenv python-dev libffi-dev cmake
 
 # Other
-sudo apt-get install -y parallel realpath unzip python-pip
+sudo apt-get install -y parallel unzip python-pip
 
 # Nginx
 sudo apt-get install -y nginx


### PR DESCRIPTION
This is Emilio's WIP commit (the commit summary slightly changed) from https://github.com/mozsearch/mozsearch/pull/248 plus an additional commit with:
- Updated documentation.  I probably missed some things, but I think I got at least some of the obvious ones!
- Enhancements to the NVME logic.  My hardcoded paths broke immediately.  Thankfully on 18.04 the nvme commands can dump JSON output and `jq` can let us filter it to get the information we need.  We no longer need to do `lsblk` because it's basically the same as the `nvme` calls.
  - We are able to match based on volume id and just the type of volume (instance disk versus EBS).
  - In theory we could also match by the pre-NVME device/mountpoint where the EBS attach would have happened from the "vs" vendor extended info data, but I couldn't get that dumped as part of any JSON output and then we're basically looking at extracting from an `od` style representation embedded in a larger textual representation (and my sed and awk skills are bad, so bad).
- Some package install changes:
  - Add debug info for python so we can get python stacktraces if router.py freaks out again
  - Disabled unattended upgrades so that our debug info is actually up-to-date
  - Added jq for JSON querying
- Some provisioning changes:
  - An extra AWS specific provisioning script for the web server so it can also get the nvme packages installed.
  - I force an unattended upgrade at provisioning time.  The ubuntu base image we were starting from already had like 50 out-of-date packages.  This isn't entirely essential but it's nice to make sure all the packages were installed from approximately the same time.  And if we re-provision without updating the base image, this does start to become essential.  The good news is that we know the unattended part works because I did mess this up initially and in testing experienced a prompt about a grub config file change.

I do have a successful https://dev.searchfox.org/ run up right now, and it all ran using the 18.04 AMI's I provisioned.  Merging this would want to happen concurrently with updating the lambdas, so this is a case where I won't request merging before the morning run.

One disclaimer: I ran the `vagrant up` before I made some additional ubuntu changes, so I or someone else should probably give that a try again before we merge this.  Also, I haven't tried it under virtualbox... I guess I should try that on OS X maybe?