### PR TITLE
Bug 1603193 - Move bulk of VM update steps into extensible scripts. r=kats

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -140,22 +140,6 @@ echo Branch is $BRANCH
 echo Mozsearch repository is $MOZSEARCH_REPO
 echo Config repository is $CONFIG_REPO
 
-# Update Rust (make sure we have the latest version).
-# We need rust nightly to use the save-analysis, and firefox requires recent
-# versions of Rust.
-rustup update
-
-# Install SpiderMonkey.
-rm -rf jsshell-linux-x86_64.zip js
-wget -nv https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
-mkdir js
-pushd js
-unzip ../target.jsshell.zip
-sudo install js /usr/local/bin
-sudo install *.so /usr/local/lib
-sudo ldconfig
-popd
-
 # Install mozsearch.
 rm -rf mozsearch
 git clone -b $BRANCH $MOZSEARCH_REPO mozsearch
@@ -164,19 +148,17 @@ git submodule init
 git submodule update
 popd
 
-pushd mozsearch/clang-plugin
-make
-popd
-
-pushd mozsearch/tools
-cargo build --release --verbose
-popd
-
 # Install files from the config repo.
 git clone $CONFIG_REPO config
 pushd config
 git checkout $BRANCH || true
 popd
+
+date
+
+# Let mozsearch tell us what commonly changing dependencies to install plus
+# perform any build steps.
+mozsearch/infrastructure/indexer-update.sh
 
 date
 THEEND

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# This script is run on the indexer by the `update.sh` script created by the
+# provisioning process.  Its purpose is to:
+# 1. Download/update dependencies that change frequently and need to be
+#    up-to-date for indexing/analysis reasons (ex: spidermonkey for JS, rust).
+# 2. Perform the build steps for mozsearch.
+#
+# When developing, this is also a good place to:
+# - Install any additional dependencies you might need.
+# - Perform any new build steps your changes need.
+#
+# However, when it comes time to land, it's preferable to make sure that
+# dependencies that don't change should just be installed once at provisioning
+# time.
+#
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Update Rust (make sure we have the latest version).
+# We need rust nightly to use the save-analysis, and firefox requires recent
+# versions of Rust.
+rustup update
+
+# Install SpiderMonkey.
+rm -rf jsshell-linux-x86_64.zip js
+wget -nv https://firefox-ci-tc.services.mozilla.com/api/index/v1/task/gecko.v2.mozilla-central.latest.firefox.linux64-opt/artifacts/public/build/target.jsshell.zip
+mkdir js
+pushd js
+unzip ../target.jsshell.zip
+sudo install js /usr/local/bin
+sudo install *.so /usr/local/lib
+sudo ldconfig
+popd
+
+pushd mozsearch/clang-plugin
+make
+popd
+
+pushd mozsearch/tools
+cargo build --release --verbose
+popd

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -124,9 +124,6 @@ echo Branch is $BRANCH
 echo Mozsearch repository is $MOZSEARCH_REPO
 echo Config repository is $CONFIG_REPO
 
-# Update Rust (make sure we have the latest version).
-rustup update
-
 # Install mozsearch.
 rm -rf mozsearch
 git clone -b $BRANCH $MOZSEARCH_REPO mozsearch
@@ -135,15 +132,17 @@ git submodule init
 git submodule update
 popd
 
-pushd mozsearch/tools
-cargo build --release --verbose
-popd
-
 # Install files from the config repo.
 git clone $CONFIG_REPO config
 pushd config
 git checkout $BRANCH || true
 popd
+
+date
+
+# Let mozsearch tell us what commonly changing dependencies to install plus
+# perform any build steps.
+mozsearch/infrastructure/web-server-update.sh
 
 date
 THEEND

--- a/infrastructure/web-server-update.sh
+++ b/infrastructure/web-server-update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# This script is run on the web server by the `update.sh` script created by the
+# provisioning process.  Its purpose is to:
+# 1. Download/update dependencies that change frequently and need to be
+#    up-to-date.  Currently this is rust and we stay up-to-date for consistency
+#    with the indexer.
+# 2. Perform any necessary build steps for mozsearch for web serving.
+#
+# When developing, this is also a good place to:
+# - Install any additional dependencies you might need.
+# - Perform any new build steps your changes need.
+#
+# However, when it comes time to land, it's preferable to make sure that
+# dependencies that don't change should just be installed once at provisioning
+# time.
+#
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+# Update Rust (make sure we have the latest version).
+rustup update
+
+pushd mozsearch/tools
+cargo build --release --verbose
+popd


### PR DESCRIPTION
Move from having high-churn dependency updates (rust/spidermonkey) and build
steps being permanently baked into the provisioning-generated `update.sh` and
instead have them live in the mozsearch repo.  This makes it easier for
branches to try things without needing to re-provision.