### PR TITLE
Bug 1603193 - pygit2 bustage fix. a=bustage

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -95,17 +95,22 @@ rm -rf .cache/bazel
 sudo pip install boto3
 
 # Install pygit2.
-rm -rf libgit2-0.27.1
-wget -nv https://github.com/libgit2/libgit2/archive/v0.27.1.tar.gz
-tar xf v0.27.1.tar.gz
-rm -rf v0.27.1.tar.gz
-pushd libgit2-0.27.1
+# The 1.0 version has moved to python3, so we're currently holding ourselves
+# back to the 0.28.2 version.
+LIBGIT2_VERSION=0.28.4
+LIBGIT2_TARBALL=v$LIBGIT2_VERSION.tar.gz
+PYGIT2_VERSION=0.28.2
+rm -rf libgit2-*
+wget -nv https://github.com/libgit2/libgit2/archive/$LIBGIT2_TARBALL
+tar xf $LIBGIT2_TARBALL
+rm -rf $LIBGIT2_TARBALL
+pushd libgit2-$LIBGIT2_VERSION
 cmake .
 make
 sudo make install
 popd
 sudo ldconfig
-sudo pip install pygit2
+sudo pip install pygit2==$PYGIT2_VERSION
 
 # Install pandoc
 sudo apt-get install -y pandoc

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -86,17 +86,22 @@ echo "$PWD/livegrep-grpc" > "$SITEDIR/livegrep.pth"
 sudo pip install boto3
 
 # Install pygit2.
-rm -rf libgit2-0.27.1
-wget -nv https://github.com/libgit2/libgit2/archive/v0.27.1.tar.gz
-tar xf v0.27.1.tar.gz
-rm -rf v0.27.1.tar.gz
-pushd libgit2-0.27.1
+# The 1.0 version has moved to python3, so we're currently holding ourselves
+# back to the 0.28.2 version.
+LIBGIT2_VERSION=0.28.4
+LIBGIT2_TARBALL=v$LIBGIT2_VERSION.tar.gz
+PYGIT2_VERSION=0.28.2
+rm -rf libgit2-*
+wget -nv https://github.com/libgit2/libgit2/archive/$LIBGIT2_TARBALL
+tar xf $LIBGIT2_TARBALL
+rm -rf $LIBGIT2_TARBALL
+pushd libgit2-$LIBGIT2_VERSION
 cmake .
 make
 sudo make install
 popd
 sudo ldconfig
-sudo pip install pygit2
+sudo pip install pygit2==$PYGIT2_VERSION
 
 # Create update script.
 cat > update.sh <<"THEEND"


### PR DESCRIPTION
Running pip install with an unconstrainted pygit2 installed pygit2 1.0.0
which needed a more recent version of libgit2 and which also was incompatible
with Python2.7 (but only said the former, not the latter).

This change:
- Forces us to specifically install the last release of pygit2 prior to 1.0.0.
- Upgrades our libgit2 version to the most recent version.  I don't think this
  is strictly necessary with pygit2 at an older version, but I already had done
  the script changes necessary and things built correctly.  (And there doesn't
  seem to be an advantage to staying on an older version, especially given that
  when we do upgrade to pygit2 1.0.0 we will need an 0.28.x series release of
  libgit2 anyways.