### PR TITLE
Bug 1607031 - Make regexp scanning stop at end of string. a=bustage-fix

### DIFF
--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -417,6 +417,10 @@ pub fn tokenize_c_like(string: &str, spec: &LanguageSpec) -> Vec<Token> {
                 });
             } else if next_token_maybe_regexp_literal && spec.regexp_literals {
                 loop {
+                    if cur_pos.get() == chars.len() {
+                        debug!("Invalid regexp literal");
+                        return tokenize_plain(string);
+                    }
                     let (_, next) = get_char();
                     if next == '/' {
                         break;


### PR DESCRIPTION
Changes in bug 1588908 surfaced an existing logic problem in regexp scanning
that assumes the text to be tokenized is sufficiently well-formed so that
scanning will end before we run out of string.  This corrects that issue.


I've tested this locally on the indexer and this corrects the problem, with `RUST_LOG=debug` reporting 3 separate invalid regexp literals for the "mozilla-mobile" "focus-android/app/src/androidTest/assets/ad.html" file.

I'm going to land this as a bustage-fix with after-the-fact review because it's a weekend at the end of a long holiday period and I think I've properly identified what's going on, but there's probably more to do, if only to add some more comments to the source.