### PR TITLE
reorder git-cinnabar `pushd` to be correct

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -127,8 +127,8 @@ sudo apt-get install -y nodejs
 CINNABAR_REVISION=cb546ebfa6e2e4fbfa2b96f17f82e3883ae28ea2
 rm -rf git-cinnabar
 git clone https://github.com/glandium/git-cinnabar
-git checkout $CINNABAR_REVISION
 pushd git-cinnabar
+git checkout $CINNABAR_REVISION
 ./git-cinnabar download
 
 # These need to be symlinks rather than `install`d binaries because cinnabar

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -134,7 +134,7 @@ git checkout $CINNABAR_REVISION
 # These need to be symlinks rather than `install`d binaries because cinnabar
 # uses other python code from the repo.
 for file in git-cinnabar git-cinnabar-helper git-remote-hg; do
-  sudo ln -s $(pwd)/$file /usr/local/bin/$file
+  sudo ln -fs $(pwd)/$file /usr/local/bin/$file
 done
 
 popd


### PR DESCRIPTION
Provisioning failed on the checkout because it was in the wrong dir.