### PR TITLE
Make NFS settings libvirt-specific

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "generic/ubuntu1804"
-  config.vm.box_version = "1.9.34"
+  config.vm.box_version = "2.0.6"
 
   config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
@@ -13,9 +13,9 @@ Vagrant.configure("2") do |config|
     v.cpus = 4
   end
 
-  config.vm.provider "libvirt" do |v|
+  config.vm.provider "libvirt" do |v, override|
     # Need to do this manually for libvirt...
-    config.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash"
+    override.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash"
 
     v.memory = 10000
     v.cpus = 4


### PR DESCRIPTION
Although our intent when adding libvirt was to add the NFS mount only in the
case of libvirt and not for virtualbox, we did not, so it was also being
added for virtualbox on OS X which did not work.  This corrects the syntax to
only enable NFS on libvirt.

This also has a ride-along of updating to the most recent released image
version, primarily because I tried this as part of my troubleshooting before
realizing what was going on, but it seems like an advantageous change.