### PR TITLE
explicitly specify shared folder for virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,7 +8,9 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :forwarded_port, guest: 80, host: 8001
 
-  config.vm.provider "virtualbox" do |v|
+  config.vm.provider "virtualbox" do |v, override|
+    override.vm.synced_folder './', '/vagrant'
+
     v.memory = 10000
     v.cpus = 4
   end


### PR DESCRIPTION
This causes the VirtualBox UI on OS X to say "Shared Folders: 1" instead of "Shared Folders: 0", which was the case without this change.  (It also was the case for removing the libvirt directives from the file.)  This shouldn't technically be necessary based on the docs, but it's not clear what's up.

Provisioning is still ongoing, but doing `vagrant ssh` while provisioning is ongoing allowed me to see that `/vagrant` was mounted and visible, so I'm going to insta-merge this.