### PR TITLE
Bug 1616104 - Move line numbers out of X selection on Chrome

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -148,6 +148,15 @@ td#line-numbers {
   display: flex;
 }
 
+/* Line numbers are text nodes before the actual source lines,
+   and styled with "user-select:none" to hide them from text selections.
+   This does not work in Chrome ( https://crbug.com/850685 ), so we work around
+   the issue by moving the content to an attribute and using generated content.
+ */
+.line-number[data-line-number]::before {
+    content: attr(data-line-number);
+}
+
 .line-number {
     /* this needs to create a containing block for the .goto synthetic anchor
        elements which are created as children of .line-number elements, at least

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -496,3 +496,17 @@ $(function () {
   });
 
 });
+
+// We use user-select:none to hide line numbers from text selections. That
+// does however not work in Chrome (https://crbug.com/850685)
+// or Safari (https://bugzilla.mozilla.org/show_bug.cgi?id=1616104#c1).
+// As a work-around, move all line numbers into pseudo-elements when the user
+// selects something for the first time.
+if (navigator.userAgent.indexOf('Firefox') == -1) {
+  document.addEventListener('selectstart', function() {
+    for (let lineno of document.querySelectorAll('.line-number')) {
+      lineno.dataset.lineNumber = lineno.textContent;
+      lineno.textContent = '';
+    }
+  }, { once: true });
+}


### PR DESCRIPTION
This is sad, but needed to work around https://bugs.chromium.org/p/chromium/issues/detail?id=850685

I limited the condition to non-Firefox for now, but if you prefer, I can invert the check, to specifically target Chrome, and maybe even specifically Linux.