### PR TITLE
Show up message about KEEP_WORKING variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ mkdir ~/mozilla-index
 /vagrant/infrastructure/indexer-run.sh ~/mozilla-config ~/mozilla-index
 ```
 
+Note: By default, `indexer-setup.sh` removes the contents of the working
+directory (in the example above, that's `~/mozilla-index`). In case you would
+like to keep the contents of the working directory, define KEEP_WORKING=1
+when calling `indexer-setup.sh`.
+
 ## Background on Mozsearch indexing
 
 The Mozsearch indexing process has three main steps, depicted here:

--- a/infrastructure/indexer-setup.sh
+++ b/infrastructure/indexer-setup.sh
@@ -16,7 +16,7 @@ CONFIG_INPUT="$2"
 export WORKING=$(readlink -f $3)
 
 if [ -z "${KEEP_WORKING:-}" ]; then
-    echo "Removing old contents of $WORKING/"
+    echo "Removing old contents of $WORKING/. Set KEEP_WORKING=1 to preserve the contents of $WORKING/."
     rm -rf $WORKING/*
 else
     echo "Keeping old contents of $WORKING/"


### PR DESCRIPTION
Although the KEEP_WORKING variable is meant to be used to preserve the current working directory, an user may rerun "indexer-setup.sh" without defining this variable, causing the removal of all contents inside the WORKING directory (repository checkout, blame information, etc).

This patch asks users to confirm whether they would like to remove the contents of WORKING directory, when KEEP_WORKING is not defined.