### PR TITLE
Bug 1620597 - Handle the case where a commit replaces a submodule or …

### DIFF
--- a/blame/transform-repo.py
+++ b/blame/transform-repo.py
@@ -200,7 +200,7 @@ def blame_for_path(file_movement, commit, path):
             parent_path = file_movement[parent.id][blob.id].split('/')
 
         parent_blob = get_tree_data(old_repo, parent.tree, parent_path)
-        if not parent_blob:
+        if not parent_blob or not isinstance(parent_blob, pygit2.Blob):
             continue
 
         parent_blame_commit = blame_map[parent.id]


### PR DESCRIPTION
…folder with a file

If the repo has a folder at a particular path, and somebody adds a commit
that replaces the folder with a file, the blame script would fail because
it would assume that the object at that path in the parent commit was a file
and it would try diffing them. This patch adds a check to ensure that the
object at the path in the parent commit is in fact a file (Blob) before
continuing.