### PR TITLE
Prevent index out of bounds error

### DIFF
--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -181,7 +181,11 @@ fn main() {
                     let left_offset = lines[(peek_start - 1) as usize].1;
 
                     for peek_line_index in peek_start..peek_end + 1 {
-                        let &(ref peek_line, peek_offset) = &lines[(peek_line_index - 1) as usize];
+                        let index = (peek_line_index - 1) as usize;
+                        if index == lines.len() {
+                            break;
+                        }
+                        let &(ref peek_line, peek_offset) = &lines[index];
 
                         for _i in left_offset..peek_offset {
                             peek_lines.push(' ');


### PR DESCRIPTION
While running indexer-run.sh, I got the following error:

```
ile __GENERATED__/DerivedSources/WebCore/UserAgentStyleSheetsData.cpp
thread 'main' panicked at 'index out of bounds: the len is 3375 but the index is 3375', src/bin/crossref.rs:184:62
stack backtrace:
   0:     0x55ee6634e004 - backtrace::backtrace::libunwind::trace::hb22594cb18e10e5c
                               at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/libunwind.rs:86
   1:     0x55ee6634e004 - backtrace::backtrace::trace_unsynchronized::h16b214339bb6fc7a
                               at /cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.46/src/backtrace/mod.rs:66
   2:     0x55ee6634e004 - std::sys_common::backtrace::_print_fmt::h7222d3d3f553cdc0
                               at src/libstd/sys_common/backtrace.rs:78
   3:     0x55ee6634e004 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::hc151e5fbac24cf0d
                               at src/libstd/sys_common/backtrace.rs:59
   4:     0x55ee6637175c - core::fmt::write::hcfa31bab8de537aa
                               at src/libcore/fmt/mod.rs:1069
   5:     0x55ee6634c1a3 - std::io::Write::write_fmt::h6d23590b06df348c
                               at src/libstd/io/mod.rs:1439
   6:     0x55ee663504a5 - std::sys_common::backtrace::_print::hcfd6856b403ab6a9
                               at src/libstd/sys_common/backtrace.rs:62
   7:     0x55ee663504a5 - std::sys_common::backtrace::print::h0a381ddda3e1134f
                               at src/libstd/sys_common/backtrace.rs:49
   8:     0x55ee663504a5 - std::panicking::default_hook::{{closure}}::hf70c6757c4f5673a
                               at src/libstd/panicking.rs:198
   9:     0x55ee663501e2 - std::panicking::default_hook::hcfc4438d15121b47
                               at src/libstd/panicking.rs:218
  10:     0x55ee66350b02 - std::panicking::rust_panic_with_hook::h1f5679c7113de543
                               at src/libstd/panicking.rs:511
  11:     0x55ee663506eb - rust_begin_unwind
                               at src/libstd/panicking.rs:419
  12:     0x55ee66370181 - core::panicking::panic_fmt::hb64626454b9e16aa
                               at src/libcore/panicking.rs:111
  13:     0x55ee66370142 - core::panicking::panic_bounds_check::ha1549b520239b17e
                               at src/libcore/panicking.rs:69
  14:     0x55ee661d3dce - <usize as core::slice::SliceIndex<[T]>>::index::h24e722bb6cc88b01
                               at /rustc/a5fb9ae5b2ed3cb011ada9dc1e8633aa0927f279/src/libcore/slice/mod.rs:2848
  15:     0x55ee661d3dce - core::slice::<impl core::ops::index::Index<I> for [T]>::index::h23c1b92037ed5b99
                               at /rustc/a5fb9ae5b2ed3cb011ada9dc1e8633aa0927f279/src/libcore/slice/mod.rs:2708
  16:     0x55ee661d3dce - <alloc::vec::Vec<T> as core::ops::index::Index<I>>::index::hf6d8ad4d19145e9e
                               at /rustc/a5fb9ae5b2ed3cb011ada9dc1e8633aa0927f279/src/liballoc/vec.rs:1891
  17:     0x55ee661d3dce - crossref::main::hd6921c2654cece4b
                               at src/bin/crossref.rs:184
  18:     0x55ee661c6663 - std::rt::lang_start::{{closure}}::hc8f2ccada6435e8f
                               at /rustc/a5fb9ae5b2ed3cb011ada9dc1e8633aa0927f279/src/libstd/rt.rs:67
  19:     0x55ee66350f48 - std::rt::lang_start_internal::{{closure}}::hc2b73c723490ccff
                               at src/libstd/rt.rs:52
  20:     0x55ee66350f48 - std::panicking::try::do_call::h9d842114687d95ee
                               at src/libstd/panicking.rs:331
  21:     0x55ee66350f48 - std::panicking::try::h4192d56d98230e30
                               at src/libstd/panicking.rs:274
  22:     0x55ee66350f48 - std::panic::catch_unwind::ha9fa7b436bc32bb1
                               at src/libstd/panic.rs:394
  23:     0x55ee66350f48 - std::rt::lang_start_internal::h9936fac81b4b9f49
                               at src/libstd/rt.rs:51
  24:     0x55ee661d4b48 - main
  25:     0x7f5e4e682b97 - __libc_start_main
  26:     0x55ee661bec7a - _start
  27:                0x0 - <unknown>
```

It seems the problem is an index out of bounds error.