### PR TITLE
Bug 1627339 - Expose raw analysis files and {repo,objdir}-files. r=kats

### DIFF
--- a/infrastructure/web-server-setup.sh
+++ b/infrastructure/web-server-setup.sh
@@ -35,8 +35,14 @@ for TREE_NAME in $($MOZSEARCH_PATH/scripts/read-json.py $CONFIG_FILE trees)
 do
     mkdir -p $DOCROOT/file/$TREE_NAME
     mkdir -p $DOCROOT/dir/$TREE_NAME
+    mkdir -p $DOCROOT/raw-analysis/$TREE_NAME
+    mkdir -p $DOCROOT/file-lists/$TREE_NAME/file-lists
     ln -s $WORKING/$TREE_NAME/file $DOCROOT/file/$TREE_NAME/source
     ln -s $WORKING/$TREE_NAME/dir $DOCROOT/dir/$TREE_NAME/source
+    ln -s $WORKING/$TREE_NAME/analysis $DOCROOT/raw-analysis/$TREE_NAME/raw-analysis
+    for FILE_LIST in repo-files objdir-files; do
+        ln -s $WORKING/$TREE_NAME/$FILE_LIST $DOCROOT/file-lists/$TREE_NAME/file-lists/$FILE_LIST
+    done
 
     # Only update the help file if no default tree was specified OR
     # The tree was specified and this is that tree.


### PR DESCRIPTION
Expose the analysis files as "raw-analysis" and the "repo-files" and
"objdir-files" under "file-lists".  This is intended to make debugging
investigations easier as well as to enable extraction of per-file and
per-directory information without having to scrape the HTML output of
output-file.