### PR TITLE
Bug 1627129 - Switch from port 8001 to 16995 for vagrant port forwarding. r=kats

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The above process will:
 - Setup the webserver for the test repo.
 - Run the webserver for the test repo.
 
-After that, you can connect to http://localhost:8001/ and see Searchfox at work!
+After that, you can connect to http://localhost:16995/ and see Searchfox at work!
 
 Once you've done that, you might want to read the next section to understand
 what was happening under the hood.
@@ -207,8 +207,8 @@ requests, we can start the server as follows:
 ```
 
 At this point, you should be able to visit the server, which is
-running on port 80 inside the VM and port 8001 outside the VM. Visit
-`http://localhost:8001/` to do so.
+running on port 80 inside the VM and port 16995 outside the VM. Visit
+`http://localhost:16995/` to do so.
 
 ## Indexing Mozilla code locally
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/web-server-provision.sh"
 
-  config.vm.network :forwarded_port, guest: 80, host: 8001
+  config.vm.network :forwarded_port, guest: 80, host: 16995
 
   config.vm.provider "virtualbox" do |v, override|
     override.vm.synced_folder './', '/vagrant'

--- a/docs/newrepo.md
+++ b/docs/newrepo.md
@@ -99,6 +99,6 @@ make build-mozilla-repo
 ```
 
 This will spew out a lot of output as it does stuff, and either end in an error (which you will need to debug), or deploy
-the web server in your vagrant VM which you will be able to access from http://localhost:8001/.
+the web server in your vagrant VM which you will be able to access from http://localhost:16995/.
 
 Once any issues are debugged, push a PR with your changes to the `mozsearch-mozilla` repo.


### PR DESCRIPTION
The remaining places that mention port 8001 in the codebase are:
- Places related to web-server.rs which continues to bind to local port 8001,
  specifically:
  - `tools/src/bin/web-server.rs`: The web server itself.
  - `scripts/nginx-setup.py`: Establishing the nginx mapping to the web server.
- The un-maintained awesomebar webextension that looks like it was pointing
  directly at web-server.rs for searchfox run locally outside of the VM.  (Or
  for a browser run inside the VM.)