### PR TITLE
Bug 1627529 follow-up - Force-create the symbolic link to avoid error…

### DIFF
--- a/tests/tests/setup
+++ b/tests/tests/setup
@@ -5,4 +5,4 @@ set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
 rm -f $INDEX_ROOT/tests
-ln -s $CONFIG_REPO/tests/files $INDEX_ROOT
+ln -s -f $CONFIG_REPO/tests/files $INDEX_ROOT


### PR DESCRIPTION
…ing out if build-test-repo is run twice in a row