### PR TITLE
Bug 1627814 - Make rebuilding repos more idempotent

### DIFF
--- a/scripts/mkdirs.sh
+++ b/scripts/mkdirs.sh
@@ -4,6 +4,12 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+rm -rf $INDEX_ROOT/analysis
+rm -rf $INDEX_ROOT/file
+rm -rf $INDEX_ROOT/dir
+rm -rf $INDEX_ROOT/description
+rm -rf $INDEX_ROOT/templates
+
 mkdir -p $INDEX_ROOT/analysis
 mkdir -p $INDEX_ROOT/file
 mkdir -p $INDEX_ROOT/dir

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -7,7 +7,7 @@ set -o pipefail # Check all commands in a pipeline
 mkdir -p $OBJDIR
 
 # Add the special clang flags.
-$MOZSEARCH_PATH/scripts/indexer-setup.py >> $INDEX_ROOT/config
+$MOZSEARCH_PATH/scripts/indexer-setup.py > $INDEX_ROOT/config
 source $INDEX_ROOT/config
 
 cd $INDEX_ROOT/files

--- a/tests/tests/setup
+++ b/tests/tests/setup
@@ -4,5 +4,4 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-rm -f $INDEX_ROOT/tests
 ln -s -f $CONFIG_REPO/tests/files $INDEX_ROOT


### PR DESCRIPTION
- Remove a totally useless rm -f command that deletes a dir that is never created
- Ensure the compiler env vars that are written don't accumulate on rebuilds
- Delete dirs that contain data generated per indexing run, so that we don't have
  leftover stale data mingling with new data on rebuilds.