### PR TITLE
Rewrite and simplify blame popup.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -57,10 +57,13 @@ table {
     box-sizing: border-box;
 }
 
-body {
+:root {
+    font: 12px/1.5 Arial, Helvetica, sans-serif;
     background-color: #fff;
     color: #333;
-    font: 12px/1.5 Arial, Helvetica, sans-serif;
+}
+
+body {
     margin: 0;
 }
 h4 {
@@ -622,13 +625,6 @@ span[data-symbols].hovered {
 }
 
 /* ## Blame ## */
-/* the role=cell that holds the role=button `.blame-strip`.  We created a class
-   for this so we could make it `position: relative` so it could create a new
-   containing block for the `.blame-popup` which cannot live beneath the
-   role=button `.blame-strip`. */
-.blame-container {
-  position: relative;
-}
 .blame-strip {
     display: block;
     width: 20px;
@@ -646,12 +642,10 @@ span[data-symbols].hovered {
 }
 
 .blame-popup {
-    display: inline !important;
-    /* positioned inside the .blame-container's containing block created by it
-       being position: relative */
     position: absolute;
+    /* positioned by BlamePopup in blame.js */
     top: 0;
-    left: 20px;
+    left: 0;
     width: 600px;
     padding: 10px;
     background: #404040;

--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -25,7 +25,7 @@ var BlamePopup = new class BlamePopup {
   detachFromCurrentOwner() {
     if (!this.popupOwner)
       return;
-    this.popupOwner.removeAttribute("aria-owns");
+    this.popupOwner.parentNode.removeAttribute("aria-owns");
     this.popupOwner.setAttribute("aria-expanded", "false");
     this.popupOwner = null;
   }
@@ -124,7 +124,8 @@ var BlamePopup = new class BlamePopup {
     this.popup.style.transform = `translatey(${top}px) translatex(${left}px)`;
     this.popup.innerHTML = content;
     this.popupOwner = this.blameElement;
-    this.popupOwner.setAttribute("aria-owns", "blame-popup");
+    // We set aria-owns on the parent role=cell instead of the button.
+    this.popupOwner.parentNode.setAttribute("aria-owns", "blame-popup");
     this.popupOwner.setAttribute("aria-expanded", "true");
   }
 

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -520,10 +520,7 @@ pub fn format_file_data(
             )),
             F::Indent(vec![
                 // Blame info.
-                F::T(format!(
-                    "<div role=\"cell\" class=\"blame-container\"><div{}></div></div>",
-                    blame_data
-                )),
+                F::T(format!("<div role=\"cell\"><div{}></div></div>", blame_data)),
                 // The line number.
                 F::T(format!(
                     "<div id=\"l{}\" role=\"cell\" class=\"line-number\">{}</div>",

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -498,9 +498,7 @@ pub fn format_file_data(
                                class, revs, filespecs, blame_linenos);
             data
         } else {
-            // If we have no blame data, we want the div here taking up space, but we don't want it
-            // to bother screen readers.
-            " class=\"blame-strip\" role=\"aria-hidden\"".to_owned()
+            " class=\"blame-strip\"".to_owned()
         };
 
         // If this line starts nesting, we need to create a div that exists strictly to contain the
@@ -922,7 +920,7 @@ pub fn format_diff(
                 format!(r#" class="blame-strip c{}" data-blame="{}#{}#{}" role="button" aria-label="blame" aria-expanded="false""#,
                         class, rev, filespec, blame_lineno)
             }
-            None => " class=\"blame-strip\" role=\"aria-hidden\"".to_owned(),
+            None => " class=\"blame-strip\"".to_owned(),
         };
 
         let line_str = if lineno > 0 {


### PR DESCRIPTION
With the goal of making it faster.

Right now the blame popup causes pretty expensive reflows, because it's
hosted inside the line strip.

This is completely unnecessary though, so this patch saves us some
per-line markup and makes it a top-level absolutely-positioned element,
and positions it dynamically.

This also uses aria-owns so that the accessibility semantics are the
same as before.