### PR TITLE
Delete old running indexers when spawning new ones

### DIFF
--- a/infrastructure/aws/attach-index-volume.py
+++ b/infrastructure/aws/attach-index-volume.py
@@ -43,4 +43,11 @@ instance.attach_volume(VolumeId=volumeId, Device='xvdf')
 
 awslib.await_volume(client, volumeId, 'available', 'in-use')
 
+instance.modify_attribute(BlockDeviceMappings=[{
+    'DeviceName': 'xvdf',
+    'Ebs': {
+        'DeleteOnTermination': True,
+    },
+}])
+
 print(volumeId)

--- a/infrastructure/aws/terminate-indexer.py
+++ b/infrastructure/aws/terminate-indexer.py
@@ -4,26 +4,11 @@
 # Usage: terminate-indexer.py <indexer-instance-id>
 
 from __future__ import absolute_import
-from __future__ import print_function
 import sys
 import boto3
-from pprint import pprint
 
 client = boto3.client('ec2')
 
 indexerInstanceId = sys.argv[1]
-
-# Note that we don't auto-delete these volumes, because this script
-# is invoked by the indexer itself to self-terminate, but in that
-# case we don't actually want the volume to be deleted as it will
-# continue to be used by the web-server instance.
-for volume in client.describe_volumes()['Volumes']:
-    for attachment in volume['Attachments']:
-        if attachment['InstanceId'] == indexerInstanceId and not attachment['DeleteOnTermination']:
-            print("Volume %s is attached to the indexer and won't be deleted; you may want to delete it if not needed any more" % volume['VolumeId'])
-            if len(volume['Attachments']) > 1:
-                print("But watch out! The volume is attached to multiple instances")
-                pprint(volume['Attachments'])
-
 terminate = [indexerInstanceId]
 client.terminate_instances(InstanceIds=terminate)


### PR DESCRIPTION
If we have an existing "running" indexer for a channel and we're spawning a new one for that channel, the old one shouldn't be needed any more, so we can terminate it. This makes it nicer from a dev point of view, if e.g. you uncover a mistake just after kicking off an indexer, because you can just start a new one and the old one will get terminated automatically.

It also takes care of the case where release indexers fail to shut down because of an error early during the update script (see bug 1471993). In this scenario, the next day's lambda job will terminate the running indexer as a failsafe, and so the indexer should not be kicking around for more than 24 hours at the outside.

As a bonus, this sets the TerminateOnDeletion flag for index volumes so manual deletion of those is unnecessary. A lot of the existing AWS setup can be done more smartly and this is one example of that.