### PR TITLE
Bug 1641079 - Make `__GENERATED__/__RUST__` work.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,11 @@ Vagrant.configure("2") do |config|
 
   config.vm.provider "libvirt" do |v, override|
     # Need to do this manually for libvirt...
-    override.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash"
+    # local_lock makes flock() be local to the VM and avoids NFS trying to
+    # acquire locks via the NLM sideband protocol.  This is sane unless you
+    # are trying to run indexing inside the VM and outside the VM at the same
+    # time, which you should not do.
+    override.vm.synced_folder './', '/vagrant', type: 'nfs', nfs_udp: false, accessmode: "squash", mount_options: ['local_lock=all']
 
     v.memory = 10000
     v.cpus = 4

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -38,7 +38,6 @@ if [[ ! -f $OBJDIR/rust-analyzed ]]; then
     "$TREE_NAME" \
     "$OBJDIR" \
     "$OBJDIR" \
-    "$INDEX_ROOT/rustlib/src/rust/src" \
     "$INDEX_ROOT/analysis"
 fi
 

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -4,17 +4,15 @@
 # 1. Locates the rust save-analysis directories under the provided root.
 # 2. Invokes rust-indexer with those analysis directories and provides a number
 #    of path prefixes to help map file paths to searchfox's special
-#    __GENERATED__ and rust-specific __GENERATED__/__RUST__ prefixes.
-#   - Note that rust-indexer.rs also includes hardcoded crate name/prefix
-#     mappings to aid in this.
+#    __GENERATED__ prefix.
 
 set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-if [ $# -lt 6 ]
+if [ $# -lt 5 ]
 then
-    echo "Usage: rust-analyze.sh config-file.json tree_name rust_analysis_in generated_src stdlib_src sf_analysis_out"
+    echo "Usage: rust-analyze.sh config-file.json tree_name rust_analysis_in generated_src sf_analysis_out"
     exit 1
 fi
 
@@ -29,16 +27,11 @@ RUST_ANALYSIS_IN=$3
 # This is the objdir in self-built single-platform cases and generated-$PLATFORM
 # in multi-platform cases at the current time.
 GENERATED_SRC=$4
-# This is where we find the source code corresponding to __GENERATED__/__RUST__
-# files.  We expect this to be a subdirectory of objdir-$PLATFORM in
-# multi-platform cases and a subdirectory of objdir in single-platform cases
-# (although there probably won't be any stdlib source in that case).
-STDLIB_SRC=$5
 # This is where we write the resulting searchfox analysis files.  We expect
 # this to be a platform-specific directory like analysis-$PLATFORM in
 # multi-platform cases (which will be processed by merge-analyses) and analysis
 # in single-platform cases.
-SF_ANALYSIS_OUT=$6
+SF_ANALYSIS_OUT=$5
 
 if [ -d "$RUST_ANALYSIS_IN" ]; then
   ANALYSIS_DIRS="$(find $RUST_ANALYSIS_IN -type d -name save-analysis)"
@@ -59,6 +52,5 @@ if [ -d "$RUST_ANALYSIS_IN" ]; then
     "$FILES_ROOT" \
     "$SF_ANALYSIS_OUT" \
     "$GENERATED_SRC" \
-    "$STDLIB_SRC" \
     $ANALYSIS_DIRS
 fi


### PR DESCRIPTION
Note that there's also a commit in here for https://bugzilla.mozilla.org/show_bug.cgi?id=1607376 to fix the NFS mount.  I can land that separately but it was necessary for testing and I didn't want to risk making a foolish git mistake.

This eliminates the need to think of the rustlib source as a separate directory tree.  The mozsearch-mozilla patch puts the source under `generated-$platform/__RUST__` to begin with which eliminates the need for any extra mapping and enables the normal collapsing process to do its thing.

The full config.json run is up on https://asuth.searchfox.org/ with the check being for https://asuth.searchfox.org/mozilla-central/source/__GENERATED__/__RUST__/liballoc/collections/btree/map.rs noting that I guess we only get analysis for things that get used, as one can tell from looking at the raw-analysis for that file at https://asuth.searchfox.org/mozilla-central/raw-analysis/__GENERATED__/__RUST__/liballoc/collections/btree/map.rs but so like BTreeMap on line 124 at https://asuth.searchfox.org/mozilla-central/source/__GENERATED__/__RUST__/liballoc/collections/btree/map.rs#124 works.

Feel free to merge this and the other PR in the morning if it looks good.  Also feel free to change the check to something smarter if you think that the BTreeMap choice is risky.
