### PR TITLE
Redirect /repo-name to /repo-name/source

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -168,6 +168,8 @@ for repo in config['trees']:
         'default_type text/html;',
         'add_header Cache-Control "must-revalidate";',
     ])
+    
+    location('/%(repo)s', ['return 301 $scheme://$host$request_uri/source;`])
 
     location('/%(repo)s/raw-analysis', [
         'root %(doc_root)s;',

--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -169,7 +169,7 @@ for repo in config['trees']:
         'add_header Cache-Control "must-revalidate";',
     ])
     
-    location('/%(repo)s', ['return 301 $scheme://$host$request_uri/source;`])
+    location('/%(repo)s', ['return 301 $scheme://$host$request_uri/source;'])
 
     location('/%(repo)s/raw-analysis', [
         'root %(doc_root)s;',


### PR DESCRIPTION
Currently it's a 404. It'd be nice to just type searchfox.org/mozilla-central to browse the source. Maybe a nice follow-up would be to also redirect repo-name/path to repo-name/source/path but that's more complicated.

I didn't actually try this locally, but I think it should work? Maybe it needs to be moved below the other directives?