### PR TITLE
Bug 1646118 - Increase crontab time

### DIFF
--- a/infrastructure/aws/make-crontab.py
+++ b/infrastructure/aws/make-crontab.py
@@ -12,7 +12,7 @@ dest_email = sys.argv[2]
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 
-delta = datetime.timedelta(hours=6)
+delta = datetime.timedelta(hours=10)
 when = datetime.datetime.now() + delta
 s = when.strftime('%M %H %d %m *')
 


### PR DESCRIPTION
The releases indexer is now doing beta, release, esr68, and esr78, all
of which are massive and so it takes more than 6 hours to do it all.