### PR TITLE
Optimize the build-blame tool

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "malloc_size_of 0.0.1",
  "malloc_size_of_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memmap 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-analysis 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.19.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -24,6 +24,7 @@ malloc_size_of = { path = "./malloc_size_of" }
 jemalloc-sys = "0.3.2"
 jemallocator = "0.3.2"
 unicode-normalization = "0.1.12"
+num_cpus = "1"
 
 # Build release mode with line number info for easier debugging when
 # we hit panics in production

--- a/tools/src/bin/build-blame.rs
+++ b/tools/src/bin/build-blame.rs
@@ -118,17 +118,12 @@ fn unmodified_lines(
 
 fn blame_for_path(
     diff_data: &DiffData,
-    git_repo: &git2::Repository,
     commit: &git2::Commit,
+    blob: &git2::Blob,
     blame_repo: &git2::Repository,
     blame_parents: &[git2::Commit],
     path: &Path,
 ) -> Result<String, git2::Error> {
-    let blob = commit
-        .tree()?
-        .get_path(path)?
-        .to_object(git_repo)?
-        .peel_to_blob()?;
     let linecount = count_lines(&blob);
     // TODO: drop this author field entirely, I don't think it gets consumed by anything
     let commit_id = commit.id();
@@ -286,8 +281,8 @@ fn build_blame_tree(
             Some(ObjectType::Blob) => {
                 let blame_text = blame_for_path(
                     diff_data,
-                    git_repo,
                     commit,
+                    &entry.to_object(git_repo)?.peel_to_blob()?,
                     blame_repo,
                     blame_parents,
                     &path,


### PR DESCRIPTION
This series of patches separates the work that build-blame does into "compute" and "writing to repo". The compute step is then parallelized across n-1 threads, leaving 1 thread for the "writing to repo". If n=2 the bottleneck is the compute side, but on the indexer we generally run with n=8 which makes the writing to repo part the bottleneck. So some additional patches then reduce the amount of time spent in the get_path function which was showing up as expensive in profiles. There's still more that can/should be done to optimize the writing thread, but I need to go do other things now.

Note that I initially parallelized using rayon, but it turns out that creating and destroying the `git2::Repository` objects is quite expensive (and they can't be shared across threads) so I wanted each worker thread to have a dedicated `git2::Repository` that it could use. I couldn't use rayon in this manner so I rolled my own simple round-robin threadpool thing which seems to work fine.

I've verified that the behaviour is still correct (produces hash-compatible blame repos with what we already have) and is much faster. How much faster depends on the repo, but usually on the order of 2-4x.