### PR TITLE
Add some support for classifying third-party code.

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -119,7 +119,7 @@ class SearchResults(object):
 
     max_count = 1000
     max_work = 750
-    path_precedences = ['normal', 'test', 'generated']
+    path_precedences = ['normal', 'test', 'generated', 'thirdparty']
     key_precedences = ["Files", "IDL", "Definitions", "Assignments", "Uses", "Declarations", "Textual Occurrences"]
 
     def categorize_path(self, path):
@@ -138,6 +138,8 @@ class SearchResults(object):
 
         if '__GENERATED__' in path:
             return 'generated'
+        elif path.startswith("third_party/"):
+            return "thirdparty"
         elif is_test(path):
             return 'test'
         else:

--- a/static/js/dxr.js
+++ b/static/js/dxr.js
@@ -439,6 +439,7 @@ function populateResults(data, full, jumpToSingle) {
       normal: null,
       test: "Test files",
       generated: "Generated code",
+      thirdparty: "Third-party code",
     };
 
     var html = "";


### PR DESCRIPTION
This adds some support for classifying files as third-party code. It would be possible to do better by looking at `tools/rewriting/ThirdPartyPaths.txt`. I was looking for use of our vendored python code in-tree, and it would be handy to filter out the third-party code on searchfox, and this would be enough to cover that case. I've not had to deal with any of the other third-party code in-tree so I don't have a feeling for whether the classification of the other paths in  `tools/rewriting/ThirdPartyPaths.txt` would be useful.

I've not setup vagrant to test this, so this code is untested.