### PR TITLE
Add some support for classifying third-party code.

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -119,7 +119,7 @@ class SearchResults(object):
 
     max_count = 1000
     max_work = 750
-    path_precedences = ['normal', 'test', 'generated']
+    path_precedences = ['normal', 'thirdparty', 'test', 'generated']
     key_precedences = ["Files", "IDL", "Definitions", "Assignments", "Uses", "Declarations", "Textual Occurrences"]
 
     def categorize_path(self, path):
@@ -138,6 +138,8 @@ class SearchResults(object):
 
         if '__GENERATED__' in path:
             return 'generated'
+        elif path.startswith('third_party/'):
+            return "thirdparty"
         elif is_test(path):
             return 'test'
         else:

--- a/static/js/dxr.js
+++ b/static/js/dxr.js
@@ -439,6 +439,7 @@ function populateResults(data, full, jumpToSingle) {
       normal: null,
       test: "Test files",
       generated: "Generated code",
+      thirdparty: "Third-party code",
     };
 
     var html = "";

--- a/tests/tests/files/third_party/a_file
+++ b/tests/tests/files/third_party/a_file
@@ -1,0 +1,1 @@
+This is a file in the magical third_party folder, that shows up in a separate section in the search results.


### PR DESCRIPTION
Replaces #358 since I can't push to that branch. This is the same patch (and retains authorship) but tweaks the order of sections in the results page, changes a pair of " quotes to ' quotes for consistency, and adds a third_party/ folder to the test repo for testing purposes.