### PR TITLE
Updates robots.txt to allow homepage indexing

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,6 +1,8 @@
-# Disallow everything
+# Disallow almost everything, but make the homepage accessible
 User-Agent: *
-Disallow: /
+Disallow: */search?q=*
+Disallow: */source*
+Disallow: /static/
 
 # ... except the nginx-served pregenerated content for the repos
 # that Mozilla is the canonical owner for. For things like whatwg-html
@@ -8,9 +10,9 @@ Disallow: /
 # searchfox because it is unlikely to be the best destination for them.
 # Also we don't allow crawls on mozilla-beta and other release repos
 # because it's better if people get directed to mozilla-central instead.
-Allow: /mozilla-central/source/
-Allow: /comm-central/source/
-Allow: /mozilla-mobile/source/
+Allow: /mozilla-central/source
+Allow: /comm-central/source
+Allow: /mozilla-mobile/source
 # There's a copy of mozilla-central inside comm-central, let's skip that
 # since we have a top-level mozilla-central instead.
 Disallow: /comm-central/source/mozilla/


### PR DESCRIPTION
As the homepage has no specific name we need to disable more things.

The current robots.txt also disallow everything

Allow: /mozilla-central/source/

which means the homepage of mozilla-central (`https://searchfox.org/mozilla-central/source`) is not accessible but the subdirectories are. (`https://searchfox.org/mozilla-central/source/*`) So I'm fixing this too.