### PR TITLE
panel: Make clicking on the permalink panel when already in there copy to clipboard

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -20,15 +20,17 @@ var Panel = new (class Panel {
     );
 
     if (this.permalinkNode) {
+      this.permalinkNode.title += " (double-click to copy)";
       this.permalinkNode.addEventListener("click", event => {
         if (event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
           return;
         }
-        window.history.pushState(
-          { permalink: event.target.href },
-          window.title,
-          event.target.href
-        );
+        let url = event.target.href;
+        if (window.location.href == url) {
+          navigator.clipboard.writeText(url);
+        } else {
+          window.history.pushState({ permalink: url }, window.title, url);
+        }
         event.preventDefault();
       });
     }


### PR DESCRIPTION
Rather than pushing duplicate entries to session history.

I think this is nicer than context-menu + copy link location, or click +
copy urlbar, which are the other two alternatives to do this.