### PR TITLE
Bug 1670314 - Followup for release channel rename

### DIFF
--- a/infrastructure/aws/trigger-web-server.py
+++ b/infrastructure/aws/trigger-web-server.py
@@ -158,9 +158,9 @@ for reservation in r['Reservations']:
         for tag in tags:
             if tag['Key'] == 'web-server':
                 t = dateutil.parser.parse(tag['Value'])
-                # Leave one old release-channel server around so we can switch
+                # Leave one old release1-channel server around so we can switch
                 # to it in an emergency.
-                if channel != "release" or datetime.now() - t >= timedelta(1.5):
+                if channel != "release1" or datetime.now() - t >= timedelta(1.5):
                     kill = True
 
         if kill:


### PR DESCRIPTION
I forgot that we have the release channel hard-coded in one more spot,
where we decide to terminate the old web-server. We have code to
special-case the release (now release1) channel so that we can roll
back to a day-old web server for m-c in case of emergency. This patch
updates the channel name there so we preserve the old behaviour.