### PR TITLE
Bug 1671640 - Ensure stderr is properly captured

### DIFF
--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -4,7 +4,7 @@ import sys
 import subprocess
 
 def run(cmd, **extra):
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, **extra)
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **extra)
     (stdout, stderr) = p.communicate()
 
     if p.returncode:


### PR DESCRIPTION
Based on the code later in this function, it seems clear that the intent
is to capture stderr into the `stderr` variable. However that's not
actually happening. This patch corrects that and makes it happen.

A beneficial side-effect is that the codesearch warnings about ignoring
too-big files now don't end up in the indexer log and so won't trigger
warning emails.