### PR TITLE
Bug 1674616 - Fix raw-analysis URL endpoint.

### DIFF
--- a/scripts/compress-outputs.sh
+++ b/scripts/compress-outputs.sh
@@ -66,4 +66,4 @@ function idempotently_gzip_dir_no_touch {
 }
 
 compress_dir_with_touch "${INDEX_ROOT}/dir/"
-idempotently_gzip_dir_no_touch "${INDEX_ROOT}/analysis/"
+compress_dir_with_touch "${INDEX_ROOT}/analysis/"


### PR DESCRIPTION
The /raw-analysis/ URLs also use try_files, and therefore need the zero-length
non-gzip'd files to exist.