### PR TITLE
Bug 1674601 - Make the blame/coverage strips a bit more touch friendly

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -601,6 +601,8 @@ span[data-symbols].hovered {
     height: 16px;
     padding: 0;
     margin: 0;
+    touch-action: none; /* fallback for FF pre-85 which didn't support touch-action:pinch-zoom */
+    touch-action: pinch-zoom;
 }
 /* blame zebra stripes: we alternate colors whenever the revision a line is from
    changes between lines. */
@@ -946,6 +948,8 @@ body.old-rev #fixed-header .search-box {
     height: 16px;
     padding: 0;
     margin: 0;
+    touch-action: none; /* fallback for FF pre-85 which didn't support touch-action:pinch-zoom */
+    touch-action: pinch-zoom;
 }
 
 .cov-interpolated.cov-miss {


### PR DESCRIPTION
Instead of using the touch-generated mouse events to control the blame popup,
add touch event listeners to manage it directly. This patch allows the user
to drag their finger around on the blame strip, and have the blame popup update
to whatever is under the cursor. The touch-action CSS property is used to
disable browser-based panning while the finger is being dragged in such a
manner. This UX makes it somewhat easier to trigger the blame popup for a
given line using touch, where the finger is less precise of a pointer than
a mouse cursor. When triggered via touch, the blame popup remains visible
until it is dismissed by scrolling or "clicking" (i.e. tapping) elsewhere.