### PR TITLE
Bug 1684471 - Make checkout command unambiguous in some cases.

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -159,7 +159,7 @@ popd
 # Install files from the config repo.
 git clone $CONFIG_REPO config
 pushd config
-git checkout $BRANCH || true
+git checkout $BRANCH -- || true
 popd
 
 date

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -141,7 +141,7 @@ popd
 # Install files from the config repo.
 git clone $CONFIG_REPO config
 pushd config
-git checkout $BRANCH || true
+git checkout $BRANCH -- || true
 popd
 
 date


### PR DESCRIPTION
The ambiguity can arise if there is a file/folder in the config
repo with the same name as the branch we're trying to check out. Adding
the double-dash resolves the ambiguity.