### PR TITLE
Small context menu event handling fix

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -15,7 +15,7 @@ var ContextMenu = new (class ContextMenu {
 
     window.addEventListener("mousedown", () => this.hide());
     window.addEventListener("pageshow", () => this.hide());
-    window.addEventListener("click", () => this.tryShowOnClick(event));
+    window.addEventListener("click", event => this.tryShowOnClick(event));
   }
 
   fmt(s, data) {


### PR DESCRIPTION
Curiously enough this works both in current-ish Firefoxes and Chrome, but is it really legal JS?