### PR TITLE
Bug 1687185 - Disable daily cron jobs. r=kats

### DIFF
--- a/infrastructure/aws/index.sh
+++ b/infrastructure/aws/index.sh
@@ -24,6 +24,19 @@ EC2_INSTANCE_ID=$(wget -q -O - http://instance-data/latest/meta-data/instance-id
 
 export AWS_ROOT=$(realpath $MOZSEARCH_PATH/infrastructure/aws)
 
+# Daily cron jobs can include things like the `locate` `updatedb` script which
+# can end up tying up the indexer's mount point.  These are run via `run-parts`
+# which only runs executable files, so we remove that bit from all of the daily
+# jobs.  We do this here as part of running the indexer rather than as part of
+# provisioning because we don't want to disable the cron jobs in our local
+# testing VMs, etc.
+#
+# We also disable weekly cron jobs because we don't need them either.  We don't
+# bother with any of the longer time intervals because the directories are
+# currently empty and so the globbing gets more complicated for no point.
+echo "Disabling daily and weekly cron jobs for this indexing run"
+sudo chmod -x /etc/cron.daily/* /etc/cron.weekly/*
+
 echo "Creating index-scratch on local instance SSD"
 ${AWS_ROOT}/mkscratch.sh
 


### PR DESCRIPTION
updatedb can end up tying up the indexing partition in a bad way, so disable
it and all the other daily and weekly cron jobs that we weren't actually
running until we just recently started trying to run jobs for the 22:00 UTC
mozilla-central nightly.