### PR TITLE
Bug 1693352 - Increase web-server.rs thread count to 4.

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -118,7 +118,7 @@ if nginx_cache_dir:
     print('')
 
 print('''# we are in the "http" context here.
-log_format custom_cache_log '[$time_local] [Cache:$upstream_cache_status] [$host] [Remote_Addr: $remote_addr] - $remote_user - $server_name to: $upstream_addr: "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" ' ;
+log_format custom_cache_log '[$time_local] [Cache:$upstream_cache_status] [$request_time] [$host] [Remote_Addr: $remote_addr] - $remote_user - $server_name to: $upstream_addr: "$request" $status $body_bytes_sent "$http_referer" "$http_user_agent" ' ;
 
 map $status $expires {
   default 2m;

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -313,5 +313,7 @@ fn main() {
     }
 
     println!("On 8001");
-    let _listening = hyper::Server::http("0.0.0.0:8001").unwrap().handle(handler);
+    // Use 4 threads instead of the 2 that would be automatically chosen on our
+    // AWS boxes.
+    let _listening = hyper::Server::http("0.0.0.0:8001").unwrap().handle_threads(handler, 4);
 }


### PR DESCRIPTION
This also adds $request_time to the nginx HTTP log output which indicates how
long the request took in seconds with a millisecond resolution.

I checked locally that I can see the extra logging and that the web-server process goes from 4 threads to 6 threads.  I'm assuming the other threads are interesting support threads that don't feel the name to give themselves interesting names.