### PR TITLE
Bug 1694210 - Update VMs to Ubuntu 20.04 LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu1804"
-  config.vm.box_version = "2.0.6"
+  config.vm.box = "generic/ubuntu2004"
+  config.vm.box_version = "3.2.6"
 
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -28,9 +28,12 @@ sudo -i -u ubuntu ~ubuntu/provision.sh > ~ubuntu/provision.log 2>&1
 echo "Provisioning complete." >> ~ubuntu/provision.log
 '''.format(script=script)
 
-# us-west-2	bionic	18.04 LTS	amd64	hvm:ebs-ssd	20191113	ami-0a7d051a1c4b54f65	hvm
-# ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20191113 - ami-0a7d051a1c4b54f65
-image_id = 'ami-0a7d051a1c4b54f65'
+# Performing lookup from https://cloud-images.ubuntu.com/locator/ec2/ we get:
+# us-west-2	focal	20.04 LTS	amd64	hvm:ebs-ssd	20210129	ami-0928f4202481dfdf6	hvm
+# and then clicking on the AMI link (already logged into EC2) and hitting
+# "previous" we get the full path:
+# ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210129 - ami-0928f4202481dfdf6
+image_id = 'ami-0928f4202481dfdf6'
 
 launch_spec = {
     'ImageId': image_id,

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -39,8 +39,6 @@ sudo apt-get install -y gdb python3-dbg
 
 # Other
 sudo apt-get install -y parallel python3-virtualenv python3-pip
-# Silence parallel citation warning
-echo "will cite" | parallel --citation
 
 # we want to be able to extract stuff from json and yaml
 sudo apt-get install -y jq

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -26,8 +26,6 @@ sudo apt-get install -y gdb python3-dbg
 
 # Other
 sudo apt-get install -y parallel unzip python3-pip
-# Silence parallel citation warning
-echo "will cite" | parallel --citation
 
 # and we want to be able to extract stuff from json and yaml
 sudo apt-get install -y jq


### PR DESCRIPTION
The primary motivation is to get a newer version of curl with relevant
bugfixes.  The secondary motivation is that our lives are made simpler
by staying up to date with releases.

The only necessary change for the Vagrant VM was to remove the GNU
parallel citation workaround, see
https://bugzilla.mozilla.org/show_bug.cgi?id=1694210#c1

Other notes not part of the commit message:
- I've only run this locally on Vagrant libvirt so far.  I would ideally like to merge this and then do the provisioning so I can provision from master rather than on my own branch.
  - I did look at switching to official Ubuntu images for vagrant, but if you run the search https://app.vagrantup.com/boxes/search?utf8=%E2%9C%93&sort=downloads&provider=&q=ubuntu+20.04 you'll find that the official "ubuntu/focal64" only has a virtualbox image and no libvirt (or hyperv or parallels or vmware_desktop) images.
- I may need to iterate on the provisioning, but I figure that will all be trivial given the local `vagrant destroy; vagrant up` and the `make build-test-repo` and `make build-searchfox-repo` things checked out fine.