### PR TITLE
Bug 1694210 - Update AMI image name refs, use python2 for logs

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -286,7 +286,7 @@ new target group.
 
 The EC2 instances for indexing and web serving are started using a
 custom Amazon Machine Image (AMI). This is the disk image used for
-booting the machine. These AMIs are based off Ubuntu 18.04, but
+booting the machine. These AMIs are based off Ubuntu 20.04, but
 additional software has been installed for all the basic dependencies,
 like clang for the indexing machine and nginx for the web server.
 
@@ -337,7 +337,7 @@ AWS console, sshing into it, and `tail`ing the provision.log file to
 check for completion), you can use the AWS console to generate an AMI from the
 instance. Select the instance in the console, then choose "Actions,
 Image, Create Image". The Image Name must be changed to
-`indexer-18.04` or `web-server-18.04`. The other values can remain as
+`indexer-20.04` or `web-server-20.04`. The other values can remain as
 before. (Note: make sure to delete any old AMIs of the same name
 before doing this.) Once the AMI is created, new jobs will use it
 automatically.

--- a/infrastructure/aws/indexer-provision.sh
+++ b/infrastructure/aws/indexer-provision.sh
@@ -21,4 +21,6 @@ date
 
 wget -nv https://s3.amazonaws.com/aws-cloudwatch/downloads/latest/awslogs-agent-setup.py
 chmod +x awslogs-agent-setup.py
-sudo ./awslogs-agent-setup.py -n -r us-west-2 -c ./cloudwatch.cfg
+# Currently this claims to only work with Python 2.6 - 3.5, so we use python2
+# which will use Python 2.7.
+sudo python2 ./awslogs-agent-setup.py -n -r us-west-2 -c ./cloudwatch.cfg

--- a/infrastructure/aws/trigger-web-server.py
+++ b/infrastructure/aws/trigger-web-server.py
@@ -54,7 +54,7 @@ availability_zone = volumes['Volumes'][0]['AvailabilityZone']
 
 print('Starting web server instance...')
 
-images = ec2.describe_images(Filters=[{'Name': 'name', 'Values': ['web-server-18.04']}])
+images = ec2.describe_images(Filters=[{'Name': 'name', 'Values': ['web-server-20.04']}])
 image_id = images['Images'][0]['ImageId']
 
 r = ec2.run_instances(

--- a/infrastructure/aws/trigger_indexer.py
+++ b/infrastructure/aws/trigger_indexer.py
@@ -28,7 +28,7 @@ sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh "{branch}" "{channel}" "{
 
     block_devices = []
 
-    images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-18.04']}])
+    images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-20.04']}])
     image_id = images['Images'][0]['ImageId']
 
     launch_spec = {


### PR DESCRIPTION
The VM triggering scripts need to know the revised AMI name that we're
going to use.  Also, during provisioning, the awslogs-agent-setup.py
script failed to execute properly because the embedded hash-bang was
for "python", so we now explicitly run it with python2 because our
python3 is too new.

After this I'll also regenerate the lambda jobs.