### PR TITLE
Bug 1694210 - Explicitly use up-to-date version of certifi

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -101,6 +101,9 @@ THEEND
 virtualenv --python=python3 env
 source env/bin/activate
 pip install boto3 awscli mozilla-aws-cli-mozilla
+# Make sure that we have an up-to-date version of certifi for certificate
+# validation.  See comments in build-lambda-indexer-start.sh for more context.
+pip install --upgrade certifi
 ```
 
 With this in place, you can use the `maws` (Mozilla-AWS) tool to obtain

--- a/infrastructure/aws/build-lambda-indexer-start.sh
+++ b/infrastructure/aws/build-lambda-indexer-start.sh
@@ -36,6 +36,13 @@ EOF
 pushd /tmp/lambda
 virtualenv --python=python3 env
 env/bin/pip install boto3
+# Because our virtualenv doesn't specify --no-seed/--without-pip, it may pull
+# packages from your machine into the virtualenv which can include a potentially
+# out-of-date version of certifi.  For example, on asuth's Ubuntu 20.04 machine,
+# certifi==2019.11.28 is installed via a debian package somehow.  Without an
+# explicit upgrade, we end up trying to use that version which will fail to
+# validate the AWS server's certificate.
+env/bin/pip install --upgrade certifi
 cp -r env/lib/python3*/site-packages/* .
 rm -rf env
 


### PR DESCRIPTION
### Current Commit Message

On my machine, the current virtualenv steps resulted in certifi
version 2019.11.28 being installed into the virtualenv as created by
the lambda.zip creation process.  The resulting lambda jobs failed to
authenticate the AWS server.

This patch is a hack in the sense that I want the lambda jobs to be
happy again (and they now are, with the changes in this patch), but I'm
not sure it's the right answer.  My thoughts here were:
1. Validating certificates seems good, why not.
2. Upgrading certifi makes the lambda job work.

By default, virtualenv uses a seeding mechanism to install things beyond
just python / python3 / python 3.N links into the env/bin directory.
This is documented at
https://virtualenv.pypa.io/en/latest/user_guide.html but I haven't
fully processed it in detail.

The short story of my investigation is:
- Passing `--no-seed` leaves us with only the python aliases which is
  explicitly not what we want.
- Just passing "certifi" to install commands is insufficient to force
  a more recent version than was available in the seeding process.
- Explicitly triggering an upgrade gets us the current certifi version.

### Question/ Current Status

The lambda jobs are operational right now with these changes, but I'm not sure this is actually the right course of action.  As I understand it, certifi bundles the mozilla certificate store and that's then used for validation, but I'm not sure if uninstalling it would still result in certificates being validated, just using the machine's local store instead of python's, etc.

I was also a bit surprised about virtualenv pulling that package in, but as covered above, my very quick efforts to make the virtualenv more minimal immediately stopped pip from appearing in the virtualenv which was very much not what was desired.

So for now I won't land this, but want to make it clear that the lambda jobs already have this change inside them.