### PR TITLE
Bug 1637010 - Fix how the scroll position is computed for position:sticky line clicks

### DIFF
--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -225,7 +225,11 @@ var Highlight = new (class Highlight {
       // TODO(emilio): This should probably select the line as well, or something?
       let containingLine = event.target.closest(".source-line-with-number");
       if (containingLine && containingLine.classList.contains("stuck")) {
-        Sticky.scroller.scrollTop -= containingLine.offsetTop;
+        let nestingContainer = containingLine.closest(".nesting-container");
+        if (nestingContainer) {
+          Sticky.scroller.scrollTop -=
+              containingLine.offsetTop - nestingContainer.offsetTop;
+        }
         return;
       }
     }


### PR DESCRIPTION
The nesting container is rooted at the stuck line's original offset, so
scrolling up by the difference between the two correctly jumps to the line
number that was clicked.