### PR TITLE
Bug 1695242 - Don't hard-code blame strip box heights

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -598,7 +598,7 @@ span[data-symbols].hovered {
 .blame-strip {
     display: block;
     width: 20px;
-    height: 16px;
+    height: 100%;
     padding: 0;
     margin: 0;
     touch-action: none; /* fallback for FF pre-85 which didn't support touch-action:pinch-zoom */
@@ -945,7 +945,7 @@ body.old-rev #fixed-header .search-box {
 .cov-strip {
     display: block;
     width: 5px;
-    height: 16px;
+    height: 100%;
     padding: 0;
     margin: 0;
     touch-action: none; /* fallback for FF pre-85 which didn't support touch-action:pinch-zoom */


### PR DESCRIPTION
16px is not guaranteed to fill the line (and it fact it does not if you use a big font-size, like webkit-search.igalia.com, or if you're zoomed in in some platforms).