### PR TITLE
Bug 1698236 - Use clang 11 and build c++17-style

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -8,10 +8,19 @@ set -o pipefail # Check all commands in a pipeline
 # will be used by the Firefox build process.  If you have a "mach bootstrap"ped
 # system then you can see the current version locally via
 # "~/.mozbuild/clang/bin/clang --version"
-CLANG_VERSION=9
+#
+# Note that for the most recent LLVM/clang release (ex: right now v13), you
+# would actually want to leave this empty.  Check out https://apt.llvm.org/ for
+# the latest info in all cases.
+CLANG_SUFFIX=-11
 # Bumping the priority with each version upgrade lets running the provisioning
 # script on an already provisioned machine do the right thing alternative-wise.
-CLANG_PRIORITY=411
+# Actually, we no longer support re-provisioning, but it's fun to increment
+# numbers.
+CLANG_PRIORITY=412
+# The clang packages build the Ubuntu release name in; let's dynamically extract
+# it since I, asuth, once forgot to update this.
+UBUNTU_RELEASE=$(lsb_release -cs)
 
 sudo apt-get update
 # necessary for apt-add-repository to exist
@@ -61,15 +70,15 @@ if [ ! -d bazel ]; then
 fi
 
 # Clang
-wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-sudo apt-add-repository "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${CLANG_VERSION} main"
+wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo apt-add-repository "deb https://apt.llvm.org/${UBUNTU_RELEASE}/ llvm-toolchain-${UBUNTU_RELEASE}${CLANG_SUFFIX} main"
 sudo apt-get update
-sudo apt-get install -y clang-${CLANG_VERSION} libclang-${CLANG_VERSION}-dev
+sudo apt-get install -y clang${CLANG_SUFFIX} libclang${CLANG_SUFFIX}-dev
 
 # Setup direct links to clang
-sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config-${CLANG_VERSION} ${CLANG_PRIORITY}
-sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CLANG_VERSION} ${CLANG_PRIORITY}
-sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CLANG_VERSION} ${CLANG_PRIORITY}
+sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config${CLANG_SUFFIX} ${CLANG_PRIORITY}
+sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang${CLANG_SUFFIX} ${CLANG_PRIORITY}
+sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++${CLANG_SUFFIX} ${CLANG_PRIORITY}
 
 # Install zlib.h (needed for NSS build)
 sudo apt-get install -y zlib1g-dev

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -13,7 +13,7 @@ source $INDEX_ROOT/config
 cd $INDEX_ROOT/files
 for f in *.cpp
 do
-  $CXX -DTEST_MACRO1 -DTEST_MACRO2 $f -std=c++14 -c -o $OBJDIR/${f%%.cpp}.o -Wall
+  $CXX -DTEST_MACRO1 -DTEST_MACRO2 $f -std=c++17 -c -o $OBJDIR/${f%%.cpp}.o -Wall
 done
 
 export CARGO_TARGET_DIR=$OBJDIR
@@ -68,9 +68,9 @@ find $OBJDIR -type f -name "*.json" | parallel -q --halt now,fail=1 sed --in-pla
 # rather than bailing out. This simulates that case.
 BUILD_TIME_FILE=BuildTimeFile.cpp
 echo "int main() { return 0; }" > $BUILD_TIME_FILE
-$CXX -DTEST_MACRO1 -DTEST_MACRO2 $BUILD_TIME_FILE -std=c++14 -c -o $OBJDIR/BuildTimeFile.o -Wall
+$CXX -DTEST_MACRO1 -DTEST_MACRO2 $BUILD_TIME_FILE -std=c++17 -c -o $OBJDIR/BuildTimeFile.o -Wall
 rm BuildTimeFile.cpp
 
 GENERATED_FILE=$OBJDIR/GeneratedFile.cpp
 echo "int main() { return 0; }" > $GENERATED_FILE
-$CXX -DTEST_MACRO1 -DTEST_MACRO2 $GENERATED_FILE -std=c++14 -c -o $OBJDIR/GeneratedFile.o -Wall
+$CXX -DTEST_MACRO1 -DTEST_MACRO2 $GENERATED_FILE -std=c++17 -c -o $OBJDIR/GeneratedFile.o -Wall


### PR DESCRIPTION
I tested this with `vagrant destroy` followed by `vagrant up` followed by (in the VM via `vagrant ssh`) `cd /vagrant; make build-test-repo`.  Note that I did experience weirdness with a missing symbol on the ItaniumMangleContext during clang analysis which I believe ended up being due to the "make" in /vagrant/clang-plugin deciding not to actually rebuild things under clang 11 because we didn't express a dependency on the compiler and those object files/the binary existing outside of the VM itself because we don't use a bindir.  So if you're testing and not using a fresh checkout, you may need to first do a "make clean" in /vagrant/clang-plugin.

I'll plan to re-provision the indexer once this lands even though it hopefully doesn't matter.