### PR TITLE
WIP dark-mode theming

### DIFF
--- a/scripts/output.js
+++ b/scripts/output.js
@@ -69,6 +69,7 @@ function generate(content, opt)
   <link href="/static/icons/search.png" rel="shortcut icon">
   <title>${title}</title>
 
+  <link href="/static/css/theme.css" rel="stylesheet" media="screen"/>
   <link href="/static/css/mozsearch.css" rel="stylesheet" media="screen"/>
   <link href="/static/css/icons.css" rel="stylesheet" media="screen" />
 </head>

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -75,11 +75,12 @@ a.type {
 
 .panel .accel,
 .panel .copy {
-  font-size: 10px;
-  border-radius: 2px;
-  padding: 1px 3px;
-  margin: 0 10px;
-  border: 1px solid #ddd;
+  background-color: var(--toolbarbutton-background);
+  color: var(--toolbarbutton-color);
+  box-sizing: content-box;
+  border: 1px solid var(--theme-toolbar-separator);
+  height: 1em;
+  padding: 3px;
 }
 
 .panel .accel {
@@ -97,13 +98,31 @@ a.type {
   box-sizing: content-box;
   cursor: pointer;
   vertical-align: middle;
-  background-image: url(/static/icons/copy.svg);
+  /* background-image: url(/static/icons/copy.svg); */
   background-position: center center;
-  background-color: #f5f5f5;
+  /* background-color: #f5f5f5; */
+}
+
+:root {
+  --copy-icon-dark: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path fill='%2338383d' d='M14.707 8.293l-3-3A1 1 0 0 0 11 5h-1V4a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 6 0H3a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3v3a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V9a1 1 0 0 0-.293-.707zM12.586 9H11V7.414zm-5-5H6V2.414zM6 7v2H3V2h2v2.5a.5.5 0 0 0 .5.5H8a2 2 0 0 0-2 2zm2 7V7h2v2.5a.5.5 0 0 0 .5.5H13v4z'/></svg>");
+  --copy-icon-light: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='16' height='16'><path fill='%23d7d7db' d='M14.707 8.293l-3-3A1 1 0 0 0 11 5h-1V4a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 6 0H3a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3v3a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V9a1 1 0 0 0-.293-.707zM12.586 9H11V7.414zm-5-5H6V2.414zM6 7v2H3V2h2v2.5a.5.5 0 0 0 .5.5H8a2 2 0 0 0-2 2zm2 7V7h2v2.5a.5.5 0 0 0 .5.5H13v4z'/></svg>");
+}
+
+.panel .copy {
+  background-image: var(--copy-icon-dark);
+}
+
+/* HACK(nika): just copy the svg into a url & change colors :s */
+@media (prefers-color-scheme: dark) {
+  .panel .copy {
+    background-image: var(--copy-icon-light);
+  }
 }
 
 .panel .copy:hover {
-  background-color: white;
+  /* FIXME: This is super broken!!! */
+  background-color: var(--theme-toolbar-selected-color);
+  background-image: var(--copy-icon-dark);
 }
 
 .panel .copy:active {

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -8,22 +8,25 @@
 }
 
 :root {
-  /* ### Highlighting ### */
-  /* Selected source line background color.  This is used when clicking on a
-   line-number (optionally holding ctrl or shift) to select it/a range. */
-  --highlighted-bgcolor: rgb(255, 255, 204);
-
-  /* ### Sticky Headers ### */
-
-  /* The background color applied to code lines that start a block and stick
-   around until the block is closed. (They have the "stuck" class applied.) */
-  --sticky-header-bgcolor: #ffe;
-
   /* ### Blame ### */
   /* Static blame zebra stripe colors. This may change in the future to be
    zebra-striping with logarithmic age coloring. */
-  --blame-c1: lightgray;
-  --blame-c2: darkgray;
+  --blame-c1: var(--grey-30);
+  --blame-c2: var(--grey-43);
+
+  --sf-highlight-background: rgb(255, 255, 204);
+  --sf-source-line-color: var(--theme-body-color);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --blame-c1: var(--grey-55);
+    --blame-c2: var(--grey-70);
+
+    --sf-highlight-background: rgb(57, 57, 42);
+    /* slightly more contrast is useful for reading in dark mode */
+    --sf-source-line-color: var(--theme-text-color-strong);
+  }
 }
 
 /**
@@ -48,8 +51,8 @@ table {
 
 :root {
   font: 12px/1.5 Arial, Helvetica, sans-serif;
-  background-color: #fff;
-  color: #333;
+  background-color: var(--theme-body-background);
+  color: var(--theme-body-color);
 }
 
 body {
@@ -79,7 +82,7 @@ table#file {
   width: 100%;
 }
 table.folder-content thead tr:first-child {
-  color: #555;
+  color: var(--theme-body-text-color-inactive);
   padding: 0.5em;
 }
 table th {
@@ -98,12 +101,10 @@ table th {
 }
 table.folder-content thead tr:first-child,
 table.folder-content tr:nth-child(even) {
-  background-color: #f5f5f5;
+  background-color: var(--theme-button-background);
 }
-table.folder-content tbody tr:hover,
-table tbody tr:hover,
-.context-menu a:hover {
-  background-color: #e8e8e8;
+table.folder-content tbody tr:hover {
+  background-color: var(--theme-button-active-background);
 }
 table.folder-content td {
   padding: 0;
@@ -150,7 +151,7 @@ td#line-numbers {
   text-align: right;
   padding: 0 0.5rem;
   /* this was originally set on the ".file td:first-child" */
-  color: #aaa;
+  color: var(--theme-text-color-inactive);
   width: 8ex;
   flex-shrink: 0;
   /* This prevents shift-clicking in non-gecko browsers from selecting all
@@ -161,7 +162,7 @@ td#line-numbers {
   user-select: none;
 }
 .highlighted {
-  background: none repeat scroll content-box 0 0 rgb(255, 255, 204) !important;
+  background: none repeat scroll content-box 0 0 var(--sf-highlight-background) !important;
 }
 .source-line {
   margin: 0;
@@ -169,10 +170,11 @@ td#line-numbers {
   display: inline-block;
   white-space: pre;
   flex-grow: 1;
+  color: var(--sf-source-line-color);
 }
 
 .source-line-with-number.stuck {
-  background: var(--sticky-header-bgcolor);
+  background: var(--theme-body-emphasized-background);
 }
 .source-line-with-number.last-stuck {
   box-shadow: 0px 4px 8px #0002;
@@ -268,7 +270,7 @@ body {
   /* even with our "stuck" and "last-stuck" classes, it's important to have an
    opaque background color for these because those classes don't take effect
    immediately. */
-  background-color: white;
+  background-color: var(--theme-body-background);
   top: calc(var(--nesting-level) * 12px * 1.3);
   z-index: calc(100 - var(--nesting-level));
 }
@@ -291,7 +293,7 @@ body {
 .left-column,
 .file td:first-child {
   text-align: right;
-  color: #aaa;
+  color: var(--theme-text-color-inactive);
   width: 8ex;
 }
 .results td {
@@ -344,7 +346,7 @@ body {
 
 .expando {
   cursor: pointer;
-  color: black;
+  color: var(--theme-body-color);
 }
 /* End search results */
 
@@ -360,10 +362,11 @@ body {
   /* absolutely positioned within the containing block of the <body> relative
      to the click event */
   position: absolute;
-  background-color: #fff;
+  background-color: var(--theme-popup-background);
+  color: var(--theme-popup-color);
   margin: 0;
   padding: 0;
-  border: 1px solid #333;
+  border: 1px solid var(--theme-popup-border-color);
   border-radius: 6px;
   border-top-left-radius: 0;
   width: auto;
@@ -373,6 +376,9 @@ body {
 .context-menu a {
   display: block;
   text-decoration: none;
+}
+.context-menu a:hover {
+  background-color: var(--theme-popup-dimmed);
 }
 .context-menu li:first-child a:hover {
   border-top-right-radius: 6px;
@@ -407,15 +413,15 @@ body {
 .bubble a:visited,
 .result-head a:link,
 .result-head a:visited {
-  color: #0095dd;
+  color: var(--theme-highlight-blue);
 }
 .breadcrumbs a:hover,
 .result-head a:hover {
-  color: #00539f;
+  color: var(--theme-highlight-bluegrey);
 }
 .breadcrumbs a:focus,
 .result-head a:focus {
-  color: #00539f;
+  color: var(--theme-highlight-bluegrey);
   text-decoration: none;
 }
 
@@ -434,9 +440,9 @@ body {
   position: fixed;
   top: 105px;
   right: 22px;
-  background-color: #fff;
-  border: 1px solid #e0e0e0;
-  border-right: 0;
+  background-color: var(--theme-popup-background);
+  color: var(--theme-popup-color);
+  border: 1px solid var(--theme-popup-border-color);
   min-width: 12rem;
   overflow-y: auto;
   overflow-x: hidden;
@@ -445,14 +451,17 @@ body {
 }
 #panel-toggle {
   display: inline-block;
-  background-color: #333;
-  color: #fff;
+  background-color: var(--theme-toolbar-background);
+  color: var(--theme-toolbar-selected-color);
   margin: 0;
   padding: 0.5rem 0.2rem 0.5rem 0.7rem;
   border: 0;
   width: 100%;
   text-align: left;
   cursor: pointer;
+}
+#panel-content {
+  border-top: 1px solid var(--theme-splitter-color);
 }
 .navpanel-icon {
   display: inline-block;
@@ -489,34 +498,39 @@ body {
 }
 .panel section a {
   display: inline-block;
-  background-color: #fff;
+  background-color: var(--theme-popup-background);
   width: 100%;
 }
 .panel section a:hover {
-  background-color: #e0e0e0;
+  background-color: var(--theme-popup-dimmed);
   text-decoration: none;
 }
 .panel section a:focus {
-  background-color: #e0e0e0;
+  background-color: var(--theme-popup-dimmed);
   text-decoration: underline;
 }
 
 /* Info Boxes */
 .info-box {
-  border: 1px solid gray;
   border-radius: 8px;
   padding: 0.8rem;
   margin: 0.5rem;
   font-size: 110%;
 }
 .info-box-error {
-  background-color: #ffeeee;
+  background-color: var(--theme-error-background);
+  color: var(--theme-error-color);
+  border: 1px solid var(--theme-error-border);
 }
 .info-box-warning {
-  background-color: #ffffee;
+  background-color: var(--theme-warning-background);
+  color: var(--theme-warning-color);
+  border: 1px solid var(--theme-warning-border);
 }
 .info-box-info {
-  background-color: #eeffee;
+  background-color: var(--theme-message-background);
+  color: var(--theme-message-color);
+  border: 1px solid var(--theme-message-border);
 }
 .info-box ul {
   padding-inline-start: 20px !important;
@@ -528,7 +542,7 @@ body {
 }
 .info-box .test-skip-info {
   font-family: monospace;
-  background-color: #eee;
+  background-color: var(--theme-body-emphasized-background);
   padding: 5px;
   margin: -5px;
 }
@@ -546,7 +560,8 @@ span[data-symbols]:hover {
   cursor: pointer;
 }
 span[data-symbols].hovered {
-  background-color: yellow;
+  background-color: var(--theme-contrast-background);
+  color: var(--theme-contrast-color);
 }
 
 /* Help screen */
@@ -633,11 +648,23 @@ span[data-symbols].hovered {
 .deemphasize {
   color: #8c8c8c !important;
 }
+
+/* FIXME: Use the old colors for the diffs in light mode, as the devtools
+ * add/remove colors seem less accessible than the existing ones. */
 .minus-line {
   background-color: rgb(255, 204, 204);
 }
 .plus-line {
   background-color: rgb(153, 204, 255);
+}
+
+@media (prefers-color-scheme: dark) {
+  .minus-line {
+    background-color: var(--diff-remove-background-color);
+  }
+  .plus-line {
+    background-color: var(--diff-add-background-color);
+  }
 }
 
 /* Search box */
@@ -676,13 +703,20 @@ input::placeholder {
   text-decoration: underline;
 }
 #search-box {
-  background-color: #f5f5f5;
-  background-image: linear-gradient(to bottom, #f8f8f8, #eaeaea);
-  border-bottom: 1px solid #6d6d6d;
-  border-top: 1px solid #f5f5f5;
-  color: #333;
+  background-color: var(--theme-toolbar-background);
+  border-bottom: 1px solid var(--theme-toolbar-separator);
+  border-top: 1px solid var(--theme-toolbar-separator);
+  color: var(--toolbarbutton-focus-color);
   padding: 0.8rem;
   width: 100%;
+}
+
+#search-box input {
+  padding: 8px;
+  background-color: var(--theme-body-background);
+  color: var(--theme-body-color);
+  border: 1px solid var(--theme-popup-border-color);
+  border-radius: 4px;
 }
 
 #search-box > fieldset {
@@ -700,7 +734,7 @@ input::placeholder {
 }
 #revision {
   padding-top: 0.2rem;
-  color: #656565;
+  color: var(--theme-toolbar-color);
 }
 #revision a {
   text-decoration: underline;
@@ -740,9 +774,9 @@ input::placeholder {
 }
 /* Message bubble */
 .bubble {
-  border: 1px solid #ccc;
+  border: 1px solid var(--theme-popup-border-color);
   border-radius: 9px;
-  color: #6c6c6c;
+  color: var(--theme-popup-color);
   display: none;
   font-size: 85%;
   padding: 0.1rem 30px 0.1rem 34px;
@@ -754,7 +788,7 @@ input::placeholder {
   content: "";
   position: absolute;
   border-style: solid;
-  border-color: #ccc transparent;
+  border-color: var(--theme-popup-border-color) transparent;
   /* reduce the damage in FF3.0 */
   display: block;
   width: 0;
@@ -770,7 +804,7 @@ input::placeholder {
   content: "";
   position: absolute;
   border-style: solid;
-  border-color: #fff transparent;
+  border-color: var(--theme-popup-background) transparent;
   /* reduce the damage in FF3.0 */
   display: block;
   width: 0;
@@ -782,13 +816,16 @@ input::placeholder {
   border-width: 0 9px 9px;
 }
 .bubble.info {
-  background: white url(/static/images/info.gif) 12px 0 / 3ex no-repeat;
+  background: var(--theme-popup-background) url(/static/images/info.gif) 12px 0 /
+    3ex no-repeat;
 }
 .bubble.warning {
-  background: white url("/static/images/warning.gif") 10px -2px / 3.5ex no-repeat;
+  background: var(--theme-popup-background) url("/static/images/warning.gif")
+    10px -2px / 3.5ex no-repeat;
 }
 .bubble.error {
-  background: white url(/static/images/error.gif) 12px 0 / 3ex no-repeat;
+  background: var(--theme-popup-background) url(/static/images/error.gif) 12px 0 /
+    3ex no-repeat;
 }
 .zero-size-container {
   position: relative;
@@ -857,7 +894,7 @@ input::placeholder {
 }
 
 .syn_type {
-  color: teal;
+  color: var(--teal-70);
 }
 
 .syn_def {
@@ -865,7 +902,7 @@ input::placeholder {
 }
 
 .syn_string {
-  color: green;
+  color: var(--theme-highlight-green);
 }
 
 .syn_comment {
@@ -878,7 +915,22 @@ input::placeholder {
 }
 
 .syn_regex {
-  color: #6d7b8d;
+  color: var(--theme-highlight-bluegrey);
+}
+
+@media (prefers-color-scheme: dark) {
+  .syn_type {
+    color: var(--theme-highlight-purple);
+  }
+
+  .syn_comment {
+    color: var(--theme-comment);
+  }
+
+  .syn_tag,
+  .syn_reserved {
+    color: var(--theme-highlight-blue);
+  }
 }
 
 /* ## Code Coverage Styling ## */

--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -1,0 +1,369 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+/* These theme colors are based on Firefox Devtools' theme variables */
+
+:root {
+  --theme-focus-border-color-textbox: #0675d3;
+  --theme-textbox-box-shadow: rgba(97, 181, 255, 0.75);
+
+  /* Text sizes */
+  --theme-body-font-size: 11px;
+  --theme-code-font-size: 11px;
+  --theme-code-line-height: calc(15 / 11);
+
+  /* Toolbar size (excluding borders) */
+  --theme-toolbar-height: 24px;
+
+  /* For accessibility purposes we want to enhance the focus styling. This
+   * should improve keyboard navigation usability. */
+  --theme-focus-outline: 1px dotted var(--theme-focus-outline-color);
+  --theme-focus-box-shadow-textbox: 0 0 0 1px var(--theme-textbox-box-shadow);
+
+  /* Standardizes the height of items in the Watch Expressions and XHR Breakpoints panes */
+  --expression-item-height: 20.5px;
+
+  /* The photon animation curve */
+  --animation-curve: cubic-bezier(0.07, 0.95, 0, 1);
+
+  /*
+   * Photon Colors CSS Variables v3.3.2
+   * - Colors are taken from https://github.com/FirefoxUX/photon-colors/blob/master/photon-colors.css
+   * - We only add Photon color variables that we are actually using; unused
+   *   variables will fail browser/base/content/test/static/browser_parsable_css.js
+   * - We added a few unofficial colors: a few intermediary values (e.g. Blue 45),
+   *   and lighter variants for the dark theme (e.g. Red 20, Red 40).
+   */
+  --magenta-50: #ff1ad9;
+  --magenta-65: #dd00a9;
+  --magenta-70: #b5007f;
+
+  --purple-50: #9400ff;
+  --purple-60: #8000d7;
+
+  --blue-30: #75baff;
+  --blue-40: #45a1ff;
+  --blue-50: #0a84ff;
+  --blue-50-a30: rgba(10, 132, 255, 0.3);
+  --blue-55: #0074e8;
+  --blue-60: #0060df;
+  --blue-70: #003eaa;
+  --blue-80: #002275;
+
+  --teal-60: #00c8d7;
+  --teal-70: #008ea4;
+
+  --green-50: #30e60b;
+  --green-60: #12bc00;
+  --green-70: #058b00;
+
+  --yellow-50: #ffe900;
+  --yellow-60: #d7b600;
+  --yellow-65: #be9b00;
+  --yellow-70: #a47f00;
+  --yellow-80: #715100;
+
+  --red-20: #ffb3d2;
+  --red-40: #ff3b6b;
+  --red-50: #ff0039;
+  --red-60: #d70022;
+  --red-70: #a4000f;
+
+  --grey-10: #f9f9fa;
+  --grey-10-a15: rgba(249, 249, 250, 0.15);
+  --grey-10-a20: rgba(249, 249, 250, 0.2);
+  --grey-10-a25: rgba(249, 249, 250, 0.25);
+  --grey-10-a30: rgba(249, 249, 250, 0.3);
+  --grey-20: #ededf0;
+  --grey-25: #e0e0e2;
+  --grey-30: #d7d7db;
+  --grey-35: #c3c3c6;
+  --grey-40: #b1b1b3;
+  --grey-43: #a4a4a4;
+  --grey-45: #939395;
+  --grey-50: #737373;
+  --grey-55: #5c5c5f;
+  --grey-60: #4a4a4f;
+  --grey-70: #38383d;
+  --grey-80: #2a2a2e;
+  --grey-85: #1b1b1d;
+  --grey-90: #0c0c0d;
+  --grey-90-a05: rgba(12, 12, 13, 0.05);
+  --grey-90-a10: rgba(12, 12, 13, 0.1);
+  --grey-90-a15: rgba(12, 12, 13, 0.15);
+  --grey-90-a20: rgba(12, 12, 13, 0.2);
+  --grey-90-a30: rgba(12, 12, 13, 0.3);
+}
+
+:root {
+  --theme-body-background: white;
+  --theme-body-emphasized-background: var(--grey-10);
+  --theme-sidebar-background: white;
+
+  /* Toolbar */
+  --theme-tab-toolbar-background: var(--grey-10);
+  --theme-toolbar-background: var(--grey-10);
+  --theme-toolbar-color: var(--grey-90);
+  --theme-toolbar-selected-color: var(--blue-60);
+  --theme-toolbar-highlighted-color: var(--green-60);
+  --theme-toolbar-background-hover: rgba(221, 225, 228, 0.66);
+  --theme-toolbar-background-alt: #f5f5f5;
+  --theme-toolbar-hover: var(--grey-20);
+  --theme-toolbar-hover-active: var(--grey-20);
+  --theme-toolbar-separator: var(--grey-90-a10);
+
+  /* Toolbar buttons */
+  --toolbarbutton-background: var(--grey-10);
+  --toolbarbutton-hover-background: var(--grey-20);
+  --toolbarbutton-focus-background: var(--grey-20);
+  --toolbarbutton-focus-color: var(--grey-70);
+  --toolbarbutton-checked-background: var(--blue-55);
+  --toolbarbutton-checked-focus-background: var(--blue-60);
+  --toolbarbutton-checked-color: #ffffff;
+
+  /* Buttons */
+  --theme-button-background: rgba(12, 12, 13, 0.05);
+  --theme-button-active-background: rgba(12, 12, 13, 0.1);
+
+  /* Accordion headers */
+  --theme-accordion-header-background: var(--theme-toolbar-background);
+  --theme-accordion-header-hover: var(--theme-toolbar-hover);
+
+  /* Selection */
+  --theme-selection-background: var(--blue-55);
+  --theme-selection-background-hover: #f0f9fe;
+  --theme-selection-focus-background: var(--toolbarbutton-hover-background);
+  --theme-selection-color: #ffffff;
+
+  /* Border color that splits the toolbars/panels/headers. */
+  --theme-splitter-color: var(--grey-25);
+  --theme-emphasized-splitter-color: var(--grey-30);
+  --theme-emphasized-splitter-color-hover: var(--grey-40);
+
+  /* Icon colors */
+  --theme-icon-color: rgba(12, 12, 13, 0.8);
+  --theme-icon-dimmed-color: rgba(135, 135, 137, 0.9);
+  --theme-icon-checked-color: var(--blue-60);
+  --theme-icon-error-color: var(--red-60);
+  --theme-icon-warning-color: var(--yellow-65);
+
+  /* Text color */
+  --theme-comment: var(--grey-50);
+  --theme-body-color: var(--grey-70);
+  --theme-text-color-alt: var(--grey-50);
+  --theme-text-color-inactive: var(--grey-40);
+  --theme-text-color-strong: var(--grey-90);
+  --theme-stack-trace-text: var(--red-70);
+
+  --theme-highlight-green: var(--green-70);
+  --theme-highlight-blue: var(--blue-55);
+  --theme-highlight-purple: var(--blue-70);
+  --theme-highlight-red: var(--magenta-65);
+  --theme-highlight-yellow: #fff89e;
+
+  /* These theme-highlight color variables have not been photonized. */
+  --theme-highlight-bluegrey: #0072ab;
+  --theme-highlight-lightorange: #d97e00;
+  --theme-highlight-orange: #f13c00;
+  --theme-highlight-pink: #b82ee5;
+  --theme-highlight-gray: #dde1e4;
+
+  /* For accessibility purposes we want to enhance the focus styling. This
+   * should improve keyboard navigation usability. */
+  --theme-focus-outline-color: #000000;
+
+  /* Colors used in Graphs, like performance tools. Similar colors to Chrome's timeline. */
+  --theme-graphs-green: #85d175;
+  --theme-graphs-blue: #83b7f6;
+  --theme-graphs-bluegrey: #0072ab;
+  --theme-graphs-purple: #b693eb;
+  --theme-graphs-yellow: #efc052;
+  --theme-graphs-orange: #d97e00;
+  --theme-graphs-red: #e57180;
+  --theme-graphs-grey: #cccccc;
+  --theme-graphs-full-red: #f00;
+  --theme-graphs-full-blue: #00f;
+
+  /* Common popup styles(used by HTMLTooltip and autocomplete) */
+  --theme-popup-background: Field;
+  --theme-popup-color: FieldText;
+  --theme-popup-border-color: ThreeDShadow;
+  --theme-popup-dimmed: hsla(0, 0%, 80%, 0.3);
+
+  /* Styling for devtool buttons */
+  --theme-toolbarbutton-background: none;
+  --theme-toolbarbutton-color: var(--grey-70);
+  --theme-toolbarbutton-hover-background: var(--grey-90-a05);
+  --theme-toolbarbutton-checked-background: var(--grey-90-a10);
+  --theme-toolbarbutton-checked-color: var(--grey-90);
+  --theme-toolbarbutton-checked-hover-background: var(--grey-90-a15);
+  --theme-toolbarbutton-checked-hover-color: var(--grey-90);
+  --theme-toolbarbutton-active-background: var(--grey-90-a20);
+  --theme-toolbarbutton-active-color: var(--grey-90);
+
+  /* Warning colors */
+  --theme-warning-background: hsl(54, 100%, 92%);
+  --theme-warning-border: rgba(215, 182, 0, 0.28); /* Yellow 60 + opacity */
+  --theme-warning-color: var(--yellow-80);
+
+  /* Error colors */
+  --theme-error-background: hsl(344, 73%, 97%);
+  --theme-error-border: rgba(215, 0, 34, 0.12); /* Red 60 + opacity */
+  --theme-error-color: var(--red-70);
+
+  /* Message colors */
+  --theme-message-background: var(--theme-body-background);
+  --theme-message-border: #f2f2f4; /* between Grey 10 and Grey 20 */
+  --theme-message-color: var(--theme-text-color-strong);
+
+  /* Flashing colors used to highlight updates */
+  --theme-contrast-background: #fff699;
+  /* = Yellow 50-a40 on white */
+  --theme-contrast-background-alpha: rgba(255, 233, 0, 0.4);
+  /* Yellow 50-a40 */
+  --theme-contrast-color: black;
+  --theme-contrast-border: var(--yellow-60);
+
+  --diff-add-background-color: #f1feec;
+  --diff-add-text-color: #54983f;
+  --diff-remove-background-color: #fbf2f5;
+  --diff-remove-text-color: #bf7173;
+  --diff-source-background: var(--theme-toolbar-background);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --theme-body-background: #232327;
+    --theme-body-emphasized-background: var(--grey-70);
+    --theme-sidebar-background: #18181a;
+
+    /* Toolbar */
+    --theme-tab-toolbar-background: var(--grey-90);
+    --theme-toolbar-background: #18181a;
+    --theme-toolbar-color: var(--grey-40);
+    --theme-toolbar-selected-color: white;
+    --theme-toolbar-highlighted-color: var(--green-50);
+    --theme-toolbar-background-hover: #232327;
+    --theme-toolbar-background-alt: var(--grey-85);
+    --theme-toolbar-hover: #232327;
+    --theme-toolbar-hover-active: #252526;
+    --theme-toolbar-separator: var(--grey-10-a20);
+
+    /* Toolbar buttons */
+    --toolbarbutton-background: var(--grey-70);
+    --toolbarbutton-hover-background: var(--grey-70);
+    --toolbarbutton-focus-background: var(--grey-60);
+    --toolbarbutton-focus-color: var(--grey-30);
+    --toolbarbutton-checked-background: #204e8a;
+    --toolbarbutton-checked-focus-background: var(--blue-60);
+    --toolbarbutton-checked-color: #ffffff;
+
+    /* Buttons */
+    --theme-button-background: rgba(249, 249, 250, 0.1);
+    --theme-button-active-background: rgba(249, 249, 250, 0.15);
+
+    /* Accordion headers */
+    --theme-accordion-header-background: #232327;
+    --theme-accordion-header-hover: #2a2a2e;
+
+    /* Selection */
+    --theme-selection-background: #204e8a;
+    --theme-selection-background-hover: #353b48;
+    --theme-selection-focus-background: var(--grey-60);
+    --theme-selection-color: #ffffff;
+
+    /* Border color that splits the toolbars/panels/headers. */
+    --theme-splitter-color: var(--grey-70);
+    --theme-emphasized-splitter-color: var(--grey-60);
+    --theme-emphasized-splitter-color-hover: var(--grey-50);
+
+    /* Icon colors */
+    --theme-icon-color: rgba(249, 249, 250, 0.7);
+    --theme-icon-dimmed-color: rgba(147, 147, 149, 0.9);
+    --theme-icon-checked-color: var(--blue-30);
+    --theme-icon-error-color: var(--red-40);
+    --theme-icon-warning-color: var(--yellow-60);
+
+    /* Text color */
+    --theme-comment: var(--grey-45);
+    --theme-body-color: var(--grey-40);
+    --theme-text-color-alt: var(--grey-45);
+    --theme-text-color-inactive: var(--grey-50);
+    --theme-text-color-strong: var(--grey-30);
+    --theme-stack-trace-text: var(--red-50);
+
+    --theme-highlight-green: #86de74;
+    --theme-highlight-blue: #75bfff;
+    --theme-highlight-purple: #b98eff;
+    --theme-highlight-red: #ff7de9;
+    --theme-highlight-yellow: #fff89e;
+
+    /* These theme-highlight color variables have not been photonized. */
+    --theme-highlight-bluegrey: #5e88b0;
+    --theme-highlight-lightorange: #d99b28;
+    --theme-highlight-orange: #d96629;
+    --theme-highlight-pink: #df80ff;
+    --theme-highlight-gray: #e9f4fe;
+
+    /* For accessibility purposes we want to enhance the focus styling. This
+   * should improve keyboard navigation usability. */
+    --theme-focus-outline-color: #ced3d9;
+
+    /* Colors used in Graphs, like performance tools. Mostly similar to some "highlight-*" colors. */
+    --theme-graphs-green: #70bf53;
+    --theme-graphs-blue: #46afe3;
+    --theme-graphs-bluegrey: #5e88b0;
+    --theme-graphs-purple: #df80ff;
+    --theme-graphs-yellow: #d99b28;
+    --theme-graphs-orange: #d96629;
+    --theme-graphs-red: #eb5368;
+    --theme-graphs-grey: #757873;
+    --theme-graphs-full-red: #f00;
+    --theme-graphs-full-blue: #00f;
+
+    /* Common popup styles(used by HTMLTooltip and autocomplete) */
+    --theme-popup-background: var(--grey-60);
+    --theme-popup-color: rgb(249, 249, 250);
+    --theme-popup-border-color: #27272b;
+    --theme-popup-dimmed: rgba(249, 249, 250, 0.1);
+
+    /* Styling for devtool buttons */
+    --theme-toolbarbutton-background: none;
+    --theme-toolbarbutton-color: var(--grey-40);
+    --theme-toolbarbutton-hover-background: var(--grey-10-a15);
+    --theme-toolbarbutton-checked-background: var(--grey-10-a20);
+    --theme-toolbarbutton-checked-color: var(--grey-30);
+    --theme-toolbarbutton-checked-hover-background: var(--grey-10-a25);
+    --theme-toolbarbutton-checked-hover-color: var(--grey-30);
+    --theme-toolbarbutton-active-background: var(--grey-10-a30);
+    --theme-toolbarbutton-active-color: var(--grey-30);
+
+    /* Warning colors */
+    --theme-warning-background: hsl(42, 37%, 19%);
+    --theme-warning-border: hsl(60, 30%, 26%);
+    --theme-warning-color: hsl(43, 94%, 81%);
+
+    --theme-error-background: hsl(345, 23%, 24%);
+    --theme-error-border: hsl(345, 30%, 35%);
+    --theme-error-color: var(--red-20);
+
+    --theme-message-background: var(--theme-body-background);
+    --theme-message-border: var(--theme-splitter-color);
+    --theme-message-color: var(--theme-text-color-strong);
+
+    /* Flashing colors used to highlight updates */
+    --theme-contrast-background: #4f4b1f;
+    /* = Yellow 50-a20 on body background */
+    --theme-contrast-background-alpha: rgba(255, 233, 0, 0.15);
+    /* Yellow 50-a15 */
+    --theme-contrast-color: white;
+    --theme-contrast-border: var(--yellow-65);
+
+    --diff-add-background-color: rgba(18, 188, 0, 0.15);
+    --diff-add-text-color: #12bc00;
+    --diff-remove-background-color: rgba(255, 0, 57, 0.15);
+    --diff-remove-text-color: #ff0039;
+    --diff-source-background: #222225;
+  }
+}

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -125,7 +125,7 @@ pub fn generate_formatted(
 }
 
 pub fn generate_header(opt: &Options, writer: &mut dyn Write) -> Result<(), &'static str> {
-    let css = ["mozsearch.css", "icons.css"];
+    let css = ["theme.css", "mozsearch.css", "icons.css"];
     let css_tags = css.iter().map(|c| {
         F::T(format!(
             r#"<link href="/static/css/{}" rel="stylesheet" media="screen"/>"#,


### PR DESCRIPTION
VSCode really wanted to format the CSS with prettier based on the `.prettierrc`, so the first patch in this series is reformatting everything with that tool. It'll be easier to see the specific changes by looking at the second patch.

This patch still has some remaining issues, such as issues with the ccov bar's colouring, less accessible diff colouring, and a super janky setup for the copy button, so isn't quite ready to merge yet.