### PR TITLE
Bug 1414954 - Add secret codesearch support for getting lines of context.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -274,6 +274,17 @@ body {
 }
 /* Search results */
 
+/* Make context lines more subtle. */
+.results tr.before-context-line,
+.results tr.after-context-line {
+  opacity: 0.5;
+}
+
+/* Delineate the transition between consecutive groups. */
+tr.after-context-line + tr.before-context-line {
+  border-top: 1px solid gray;
+}
+
 .results tr:hover,
 .file tr:hover {
   background: none;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -222,9 +222,13 @@ function hashString(string) {
   return hash;
 }
 
-function classOfResult(pathkind, qkind) {
+function classOfResult(pathkind, qkind, isContext) {
   var klass = pathkind + ":" + qkind;
-  return "EXPANDO" + hashString(klass);
+  let cssClass = "EXPANDO" + hashString(klass);
+  if (isContext) {
+    cssClass += ` ${isContext}-context-line`;
+  }
+  return cssClass;
 }
 
 function onExpandoClick(event) {
@@ -327,13 +331,13 @@ function populateResults(data, full, jumpToSingle) {
     return html;
   }
 
-  function renderSingleSearchResult(pathkind, qkind, file, line) {
+  function renderSingleSearchResult(pathkind, qkind, file, line, isContext) {
     var [start, end] = line.bounds || [0, 0];
     var before = line.line.slice(0, start).replace(/^\s+/, "");
     var middle = line.line.slice(start, end);
     var after = line.line.slice(end).replace(/\s+$/, "");
 
-    var klass = classOfResult(pathkind, qkind);
+    var klass = classOfResult(pathkind, qkind, isContext);
     var html = "";
     html += "<tr class='" + klass + "'>";
     html +=
@@ -501,7 +505,25 @@ function populateResults(data, full, jumpToSingle) {
               return;
             }
 
+            if (line.context_before) {
+              let lineDelta = -line.context_before.length;
+              for (const lineStr of line.context_before) {
+                html += renderSingleSearchResult(
+                  pathkind, qkind, file,
+                  { lno: line.lno + lineDelta, line: lineStr }, 'before');
+                lineDelta++;
+              }
+            }
             html += renderSingleSearchResult(pathkind, qkind, file, line);
+            if (line.context_after) {
+              let lineDelta = 1;
+              for (const lineStr of line.context_after) {
+                html += renderSingleSearchResult(
+                  pathkind, qkind, file,
+                  { lno: line.lno + lineDelta, line: lineStr }, 'after');
+                lineDelta++;
+              }
+            }
           });
         }
       }


### PR DESCRIPTION
This implements an undocumented "context:N" search directive understood by
the parser (if it precedes the search query proper, as-is required by the
implementation of parse_search) that we propagate to livegrep which in turn
generously returns the context for us.

I'm calling this secret because I don't think the UX as provided by this
patch is appropriate for a supported feature, but I think this could be
useful for experimentation and iteration.  In particular, in this patch:
- Typing out context:N at the start of the search but having things not work
  if you put it at the end as an afterthought isn't great.
- I don't think adding a separate form input for lines of context is a great
  initial choice either.
- This doesn't work with any of the semantic responses, and doing so is both
  non-trivial and not something I think we should be freshly implementing in
  Python.
- On the actual result line where we have bounds, we normalize off leading
  whitespace whereas we leave the whitespace intact on the context lines and
  this looks weird.