### PR TITLE
Bug 1414954 - fix context reversal and override default livegrep context_lines

### DIFF
--- a/router/codesearch.py
+++ b/router/codesearch.py
@@ -27,7 +27,12 @@ def collateMatches(matches):
         }
 
         if len(m.context_before):
-            line['context_before'] = list(m.context_before)
+            # The before context is provided in reverse order which is not what
+            # we want.
+            before = list(m.context_before)
+            # This does not return the list, so it's on its own line.
+            before.reverse()
+            line['context_before'] = before
         if len(m.context_after):
             line['context_after'] = list(m.context_after)
 
@@ -80,7 +85,7 @@ def startup_codesearch(data):
     args = ['codesearch', '-grpc', 'localhost:' + str(data['codesearch_port']),
             '--noreuseport',
             '-load_index', data['codesearch_path'],
-            '-max_matches', '1000', '-timeout', '10000']
+            '-max_matches', '1000', '-timeout', '10000', '-context_lines', '0']
 
     daemonize(args)
     time.sleep(5)


### PR DESCRIPTION
:kats noticed that the context_before lines are reversed (thank you!)

Also, the livegrep server assumes a default context_lines of 3 and cannot be
convinced to provide 0 lines of context if that default is non-zero, so we
now also explicitly provide a directive of 0 lines of context when spawning.