### PR TITLE
Bug 1708021 - Advance by word rather than character when looking for …

### DIFF
--- a/scripts/idl-analyze.py
+++ b/scripts/idl-analyze.py
@@ -13,7 +13,7 @@ def find_line_column(text, token, pos):
         if text[pos] == '\n':
             return (0, 0)
 
-        pos += 1
+        pos = text.find(' ', pos) + 1
 
     line = 0
     while pos > linebreaks[line]:


### PR DESCRIPTION
…token position

Advancing by character results in doing things like matching "URI" to the
latter part of "nsIURI", which results in bad column numbers. This fixes
that by just skipping words whose first |len(token)| characters don't
match the token.