### PR TITLE
Bug 1707282 - Implement searchfox-tool command line tool.

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -7,6 +7,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
 
 [[package]]
+name = "ahash"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,7 +36,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -55,13 +61,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b98e84bbb4cbcdd97da190ba0c58a1bb0de2c1fdf67d159e192ed766aeca722"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1803c647a3ec87095e7ae7acfca019e98de5ec9a7d01343f611cf3152ed71a90"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -93,6 +110,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bit-set"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -109,9 +132,9 @@ checksum = "f59bbe95d4e52a6398ec21238d31577f2b28a9d86807f06ca59d191d8440d0bb"
 
 [[package]]
 name = "bitflags"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a606a02debe2813760609f57a64a2ffd27d9fdf5b2f133eaca0b248dd92cdd2"
+checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
@@ -146,6 +169,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +185,22 @@ name = "byteorder"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
+
+[[package]]
+name = "bytes"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
+dependencies = [
+ "byteorder",
+ "iovec",
+]
+
+[[package]]
+name = "bytes"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
@@ -172,6 +217,12 @@ name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
@@ -214,12 +265,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
 ]
 
 [[package]]
@@ -229,8 +296,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg 1.0.0",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
+]
+
+[[package]]
+name = "cssparser"
+version = "0.25.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe18ca4efb9ba3716c6da66cc3d7e673bf59fa576353011f48c4cfddbdd740e"
+dependencies = [
+ "autocfg 0.1.6",
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "matches",
+ "phf",
+ "proc-macro2",
+ "procedural-masquerade",
+ "quote",
+ "smallvec 0.6.14",
+ "syn",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb1c84e87c717666564ec056105052331431803d606bd45529b28547b611eef"
+dependencies = [
+ "phf_codegen",
+ "proc-macro2",
+ "procedural-masquerade",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -267,7 +366,7 @@ checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -283,6 +382,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56899898ce76aaf4a0f24d914c97ea6ed976d42fec6ad33fcbb0a1103e07b2b0"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03329ae10e79ede66c9ce4dc930aa8599043b0743008548680f25b91502d6"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "either"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -295,6 +409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8944dc8fa28ce4a38f778bd46bf7d923fe73eed5a439398507246c8e017e6f36"
 dependencies = [
  "log 0.4.8",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -328,10 +451,43 @@ version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da80be589a72651dcda34d8b35bcdc9b7254ad06325611074d9cc0fbb19f60ee"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "crc32fast",
+ "futures",
  "libc",
  "miniz_oxide",
+ "tokio-io",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding 2.1.0",
 ]
 
 [[package]]
@@ -341,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
 dependencies = [
  "libc",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -364,6 +520,61 @@ name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
+name = "futures"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a471a38ef8ed83cd6e40aa59c1ffe17db6855c18e3604d9c4ed8c08ebc28678"
+
+[[package]]
+name = "futures-channel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e682a68b29a882df0545c143dc3646daefe80ba479bcdede94d5a703de2871e2"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a57bead0ceff0d6dde8f465ecd96c9338121bb7717d3e7b108059531870c4282"
+
+[[package]]
+name = "futures-task"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a16bef9fc1a4dddb5bee51c989e3fbba26569cbb0e31f5b303c184e3dd33dae"
+
+[[package]]
+name = "futures-util"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feb5c238d27e2bf94ffdfd27b2c29e3df4a68c4193bb6427384259e2bf191967"
+dependencies = [
+ "autocfg 1.0.0",
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "generic-array"
@@ -389,16 +600,27 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
 name = "git2"
-version = "0.13.15"
+version = "0.13.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f267c9da8a4de3c615b59e23606c75f164f84896e97f4dd6c15a4294de4359"
+checksum = "17929de7239dea9f68aa14f94b2ab4974e7b24c1314275ffcc12a7758172fa18"
 dependencies = [
  "bitflags",
  "libc",
@@ -406,14 +628,79 @@ dependencies = [
  "log 0.4.8",
  "openssl-probe",
  "openssl-sys",
- "url 2.1.1",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "825343c4eef0b63f541f8903f395dc5beb362a979b5799a84062527ef1e37726"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "http"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
+dependencies = [
+ "bytes 1.0.1",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
+dependencies = [
+ "bytes 1.0.1",
+ "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "f3a87b616e37e93c22fb19bcd386f02f3af5ea98a25670ad0fce773de23c5e68"
+
+[[package]]
+name = "httpdate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05842d0d43232b23ccb7060ecb0f0626922c21f30012e97b767b30afd4a5d4b9"
 
 [[package]]
 name = "humantime"
@@ -434,13 +721,50 @@ dependencies = [
  "httparse",
  "language-tags",
  "log 0.3.9",
- "mime",
+ "mime 0.2.6",
  "num_cpus",
  "time",
  "traitobject",
  "typeable",
  "unicase",
  "url 1.7.2",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e5f105c494081baa3bf9e200b279e27ec1623895cd504c7dbef8d0b080fcf54"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes 1.0.1",
+ "hyper 0.14.7",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -466,6 +790,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg 1.0.0",
+ "hashbrown",
+]
+
+[[package]]
+name = "iovec"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "ipdl_parser"
 version = "0.1.0"
 dependencies = [
@@ -474,6 +817,12 @@ dependencies = [
  "lalrpop-util",
  "regex 0.2.11",
 ]
+
+[[package]]
+name = "ipnet"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
 
 [[package]]
 name = "itertools"
@@ -527,6 +876,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bdfbace3a0e81a4253f73b49e960b053e396a11012cbd49b9b74d6a2b67062"
+dependencies = [
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -592,16 +950,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "libc"
-version = "0.2.68"
+name = "lazycell"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea0c0405123bba743ee3f91f49b1c7cfb684eef0da0a50110f758ccf24cdff0"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
+name = "libc"
+version = "0.2.94"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.17+1.1.0"
+version = "0.12.20+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4ebdf65ca745126df8824688637aa0535a88900b83362d8ca63893bcf4e8841"
+checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
 dependencies = [
  "cc",
  "libc",
@@ -661,7 +1025,26 @@ version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
+]
+
+[[package]]
+name = "lol_html"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b59f94556144354f6abfb3fe175e8f2da290329f254ab4019e5096875f6056e3"
+dependencies = [
+ "bitflags",
+ "cfg-if 0.1.10",
+ "cssparser",
+ "encoding_rs",
+ "hashbrown",
+ "lazy_static",
+ "lazycell",
+ "memchr 2.2.1",
+ "safemem",
+ "selectors",
+ "thiserror",
 ]
 
 [[package]]
@@ -687,6 +1070,12 @@ name = "matches"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
+
+[[package]]
+name = "maybe-uninit"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
@@ -725,6 +1114,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,10 +1130,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
+dependencies = [
+ "libc",
+ "log 0.4.8",
+ "miow",
+ "ntapi",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8d96b2e1c8da3957d58100b09f102c6d9cfdfced01b7ec5a8974044bb09dbd4"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log 0.4.8",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
+name = "ntapi"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
+dependencies = [
+ "winapi 0.3.9",
+]
 
 [[package]]
 name = "num"
@@ -791,10 +1241,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "openssl"
+version = "0.10.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d7830286ad6a3973c0f1d9b73738f69c76b739301d0229c4b96501695cbe4c8"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -804,11 +1274,11 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.49"
+version = "0.9.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fad9e54bd23bd4cbbe48fdc08a1b8091707ac869ef8508edea2fec77dcc884"
+checksum = "b6b0d6fb7d80f877617dfcb014e605e2b5ab2fb0afdf27935219bb6bd984cb98"
 dependencies = [
- "autocfg 0.1.6",
+ "autocfg 1.0.0",
  "cc",
  "libc",
  "pkg-config",
@@ -844,13 +1314,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.7.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
 name = "phf_generator"
 version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.6.5",
 ]
 
 [[package]]
@@ -863,10 +1352,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "pin-project"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7509cc106041c40a4518d2af7a61530e1eed0e6285296a3d8c5472806ccc4a4"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c950132583b500556b1efd71d45b319029f2b71518d979fcc208e16b42426f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkg-config"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72d5370d90f49f70bd033c3d75e87fc529fbfff9d6f7cccef07d6170079d91ea"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "precomputed-hash"
@@ -875,13 +1402,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "proc-macro2"
+name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdc77cc74ec70ed262262942ebb7dac3d479e9e5cfa2da1841c0806f6cdabcc"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check 0.9.3",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "procedural-masquerade"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1383dff4092fe903ac180e391a8d4121cc48f08ccf850614b0290c6673b69d"
 
 [[package]]
 name = "quick-error"
@@ -906,15 +1463,27 @@ checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.6",
  "libc",
- "rand_chacha",
+ "rand_chacha 0.1.1",
  "rand_core 0.4.2",
- "rand_hc",
+ "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
  "rand_os",
  "rand_pcg",
  "rand_xorshift",
- "winapi 0.3.8",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.2",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -925,6 +1494,16 @@ checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
 dependencies = [
  "autocfg 0.1.6",
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -943,12 +1522,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
+name = "rand_core"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+dependencies = [
+ "getrandom 0.2.2",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -968,7 +1565,7 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -982,7 +1579,7 @@ dependencies = [
  "libc",
  "rand_core 0.4.2",
  "rdrand",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1020,13 +1617,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom",
- "redox_syscall",
+ "getrandom 0.1.14",
+ "redox_syscall 0.1.56",
  "rust-argon2",
 ]
 
@@ -1069,6 +1675,49 @@ name = "regex-syntax"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2296f2fac53979e8ccbc4a1136b25dcefd37be9ed7e4a1f6b05a6029c84ff124"
+dependencies = [
+ "base64 0.13.0",
+ "bytes 1.0.1",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper 0.14.7",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log 0.4.8",
+ "mime 0.3.16",
+ "native-tls",
+ "percent-encoding 2.1.0",
+ "pin-project-lite",
+ "serde",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "url 2.2.2",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "rls-analysis"
@@ -1137,6 +1786,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b08423011dae9a5ca23f07cf57dac3857f5c885d352b76f6d95f4aea9434d0"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "selectors"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b86b100bede4f651059740afc3b6cb83458d7401cb7c1ad96d8a11e91742c86"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "fxhash",
+ "log 0.4.8",
+ "matches",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "servo_arc",
+ "smallvec 0.6.14",
+ "thin-slice",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1158,13 +1859,35 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.40"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edfa57a7f8d9c1d260a549e7224100f6c43d43f9103e06dd8b4095a9b2b43ce9"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98238b800e0d1576d8b6e3de32827c2d74bee68bb97748dcf5071fb53965432"
+dependencies = [
+ "nodrop",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1180,16 +1903,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fa3938c99da4914afedd13bf3d79bcb6c277d1b2c398d23257a304d9e1b074"
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 
 [[package]]
+name = "slab"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
+
+[[package]]
+name = "smallvec"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
+dependencies = [
+ "maybe-uninit",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05720e22615919e4734f6a99ceae50d00226c3c5aca406e102ebc33298214e0a"
+
+[[package]]
+name = "socket2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
+dependencies = [
+ "libc",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
@@ -1238,10 +1998,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
-name = "syn"
-version = "1.0.5"
+name = "structopt"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66850e97125af79138385e9b88339cbcd037e3f28ceab8c5ad98e64f0f1f80bf"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
+dependencies = [
+ "clap",
+ "lazy_static",
+ "structopt-derive",
+]
+
+[[package]]
+name = "structopt-derive"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9505f307c872bab8eb46f77ae357c8eba1fdacead58ee5a850116b1d7f82883"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1261,6 +2045,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "rand 0.8.3",
+ "redox_syscall 0.2.8",
+ "remove_dir_all",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "term"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1268,7 +2066,7 @@ checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
 dependencies = [
  "byteorder",
  "dirs",
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1290,6 +2088,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "thin-slice"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
+
+[[package]]
+name = "thiserror"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,36 +2129,132 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 dependencies = [
  "libc",
- "redox_syscall",
- "winapi 0.3.8",
+ "redox_syscall 0.1.56",
+ "winapi 0.3.9",
+]
+
+[[package]]
+name = "tokio"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+dependencies = [
+ "autocfg 1.0.0",
+ "bytes 1.0.1",
+ "libc",
+ "memchr 2.2.1",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "tokio-macros",
+]
+
+[[package]]
+name = "tokio-io"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57fc868aae093479e3131e3d165c93b1c7474109d13c90ec0dda2a1bbfff0674"
+dependencies = [
+ "bytes 0.4.12",
+ "futures",
+ "log 0.4.8",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c49e3df43841dafb86046472506755d8501c5615673955f6aa17181125d13c37"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
+dependencies = [
+ "bytes 1.0.1",
+ "futures-core",
+ "futures-sink",
+ "log 0.4.8",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
 name = "tools"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "chrono",
  "clap",
  "env_logger",
  "flate2",
  "getopts",
  "git2",
- "hyper",
+ "hyper 0.10.16",
  "ipdl_parser",
  "jemalloc-sys",
  "jemallocator",
  "lazy_static",
  "linkify",
  "log 0.4.8",
+ "lol_html",
  "malloc_size_of",
  "malloc_size_of_derive",
  "memmap",
  "num_cpus",
  "regex 1.3.1",
+ "reqwest",
  "rls-analysis",
  "rls-data",
  "rustc-serialize",
+ "serde_json",
+ "shell-words",
+ "structopt",
+ "tokio",
  "unicode-normalization",
+ "url 2.2.2",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -1342,6 +2262,12 @@ name = "traitobject"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "typeable"
@@ -1367,7 +2293,7 @@ version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 dependencies = [
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
@@ -1385,8 +2311,14 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5479532badd04e128284890390c1e876ef7a993d0570b3597ae43dfa1d59afa4"
 dependencies = [
- "smallvec",
+ "smallvec 1.3.0",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"
@@ -1413,10 +2345,11 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.1.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
 dependencies = [
+ "form_urlencoded",
  "idna 0.2.0",
  "matches",
  "percent-encoding 2.1.0",
@@ -1430,9 +2363,9 @@ checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
 
 [[package]]
 name = "vcpkg"
-version = "0.2.7"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33dd455d0f96e90a75803cfeb7f948768c08d70a6de9a8d2362461935698bf95"
+checksum = "cbdbff6266a24120518560b5dc983096efb98462e51d0d68169895b237be3e5d"
 
 [[package]]
 name = "vec_map"
@@ -1447,10 +2380,110 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 
 [[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log 0.4.8",
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.2+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54ee1d4ed486f78874278e63e4069fc1ab9f6a18ca492076ffb90c5eb2997fd"
+dependencies = [
+ "cfg-if 1.0.0",
+ "serde",
+ "serde_json",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b33f6a0694ccfea53d94db8b2ed1c3a8a4c86dd936b13b9f0a15ec4a451b900"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log 0.4.8",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fba7978c679d53ce2d0ac80c8c175840feb849a161664365d1287b41f2e67f1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "088169ca61430fe1e58b8096c24975251700e7b1f6fd91cc9d59b04fb9b18bd4"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be2241542ff3d9f241f5e2cb6dd09b37efe786df8851c54957683a49f0987a97"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cff876b8f18eed75a66cf49b65e7f967cb354a7aa16003fb55dbfd25b44b4f"
+
+[[package]]
+name = "web-sys"
+version = "0.3.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e828417b379f3df7111d3a2a9e5753706cae29c41f7c4029ee9fd77f3e09e582"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "winapi"
@@ -1460,9 +2493,9 @@ checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
@@ -1486,7 +2519,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1501,6 +2534,15 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 dependencies = [
- "winapi 0.3.8",
+ "winapi 0.3.9",
  "winapi-util",
+]
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi 0.3.9",
 ]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -2,12 +2,14 @@
 name = "tools"
 version = "0.1.0"
 authors = ["Bill McCloskey <billm@mozilla.com>"]
+edition = "2018"
 
 [dependencies]
+async-trait = "0.1.50"
 chrono = "0.2"
 clap = "2"
 env_logger = "0.7.1"
-flate2 = "1"
+flate2 = { version = "1", features = ["tokio"] }
 getopts = "0.2.19"
 git2 = "0.13.15"
 hyper = "0.10"
@@ -17,15 +19,22 @@ jemallocator = "0.3.2"
 lazy_static = "1.1"
 linkify = "0.2.0"
 log = "0.4.0"
+lol_html = "0.3.0"
 malloc_size_of = { path = "./malloc_size_of" }
 malloc_size_of_derive = "0.1"
 memmap = "0.5.0"
 num_cpus = "1"
 regex = "1"
+reqwest = "0.11.3"
 rls-analysis = "0.17"
 rls-data = "0.19"
 rustc-serialize = "0.3.18"
+shell-words = "1.0.0"
+serde_json = "1.0.64"
+structopt = "0.3"
+tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 unicode-normalization = "0.1.12"
+url = "2.2.2"
 
 # Build release mode with line number info for easier debugging when
 # we hit panics in production

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -1,0 +1,126 @@
+use async_trait::async_trait;
+use flate2::read::GzDecoder;
+use serde_json::{from_str, Value};
+use std::io::Read;
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+use super::server_interface::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+use crate::config::{load, TreeConfigPaths};
+
+/// IO errors amount to a 404 for our purposes which means a sticky problem.
+impl From<std::io::Error> for ServerError {
+    fn from(err: std::io::Error) -> ServerError {
+        ServerError::StickyProblem(ErrorDetails {
+            layer: ErrorLayer::ServerLayer,
+            message: err.to_string(),
+        })
+    }
+}
+
+/// Read newline-delimited JSON that's been gzip-compressed.
+async fn read_gzipped_ndjson_from_file(path: &str) -> Result<Vec<Value>> {
+    let mut f = File::open(path).await?;
+    // We read the entirety to a buffer because
+    // https://github.com/serde-rs/json/issues/160 suggests that the buffered
+    // reader performance is likely to be much worse.
+    //
+    // When we want to go async here,
+    // https://github.com/rust-lang/flate2-rs/pull/214 suggests that we want to
+    // use the `async-compression` crate.
+    let mut buffer = Vec::new();
+    f.read_to_end(&mut buffer).await?;
+
+    let mut gz = GzDecoder::new(&buffer[..]);
+
+    let mut raw_str = String::new();
+    gz.read_to_string(&mut raw_str)?;
+
+    // let mut raw_str = String::new();
+    // f.read_to_string(&mut raw_str).await?;
+
+    raw_str
+        .lines()
+        .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+        .collect()
+}
+
+#[derive(Debug)]
+struct LocalIndex {
+    // We only hold onto the TreeConfigPaths portion of the config because the
+    // git data is not `Sync`.  Specifically, the compiler says:
+    //
+    // "within `TreeConfig`, the trait `Sync` is not implemented for
+    // `*mut libgit2_sys::git_repository`"
+    //
+    // When we need to do local git stuff, we will be able to accomplish this by
+    // creating a new `git2::Repository` on demand from the git path.  This is
+    // already done in `build-blame.rs` for its compute threads and that's
+    // likely the model we should use.
+    config_paths: TreeConfigPaths,
+    tree_name: String,
+}
+
+#[async_trait]
+impl AbstractServer for LocalIndex {
+    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<Vec<Value>> {
+        let full_path = format!("{}/analysis/{}.gz", self.config_paths.index_path, sf_path);
+        read_gzipped_ndjson_from_file(&full_path).await
+    }
+
+    async fn fetch_html(&self, sf_path: &str) -> Result<String> {
+        let full_path = format!("{}/file/{}.gz", self.config_paths.index_path, sf_path);
+
+        // If we were dealing with uncompressed files.
+        /*
+        let mut f = File::open(full_path).await?;
+        let mut raw_str = String::new();
+        f.read_to_string(&mut raw_str).await?;
+        */
+
+        let mut f = File::open(full_path).await?;
+        let mut buffer = Vec::new();
+        f.read_to_end(&mut buffer).await?;
+
+        // When we want to go async here,
+        // https://github.com/rust-lang/flate2-rs/pull/214 suggests that we want
+        // to use the `async-compression` crate.
+        let mut gz = GzDecoder::new(&buffer[..]);
+
+        let mut raw_str = String::new();
+        gz.read_to_string(&mut raw_str)?;
+
+        Ok(raw_str)
+    }
+
+    async fn perform_query(&self, _q: &str) -> Result<Value> {
+        // TODO: For this to work, we want to be able to directly invoke the
+        // underpinnings of the web server, which entails porting router.py into
+        // web-server.rs, an act which may involve building it on some of this
+        // infrastructure...
+        Err(ServerError::Unsupported)
+    }
+}
+
+pub fn make_local_server(
+    config_path: &str,
+    tree_name: &str,
+) -> Result<Box<dyn AbstractServer + Send + Sync>> {
+    let mut config = load(config_path, false);
+    let tree_config = match config.trees.remove(&tree_name.to_string()) {
+        Some(t) => t,
+        None => {
+            return Err(ServerError::StickyProblem(ErrorDetails {
+                layer: ErrorLayer::BadInput,
+                message: format!("bad tree name: {}", &tree_name),
+            }))
+        }
+    };
+
+    Ok(Box::new(LocalIndex {
+        // We don't need the blame_map and hg_map (yet)
+        config_paths: tree_config.paths,
+        tree_name: tree_name.to_string(),
+    }))
+}

--- a/tools/src/abstract_server/mod.rs
+++ b/tools/src/abstract_server/mod.rs
@@ -1,0 +1,7 @@
+mod local_index;
+mod remote_server;
+mod server_interface;
+
+pub use local_index::make_local_server;
+pub use remote_server::make_remote_server;
+pub use server_interface::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -1,0 +1,105 @@
+use async_trait::async_trait;
+use serde_json::{from_str, Value};
+use url::{ParseError, Url};
+
+use super::server_interface::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+/// reqwest won't return an error for an unhappy status code itself; someone
+/// would need to call `Response::error_from_status`, so for now we'll generally
+/// assume everything is some kind of transient problem.
+impl From<reqwest::Error> for ServerError {
+    fn from(err: reqwest::Error) -> ServerError {
+        ServerError::TransientProblem(ErrorDetails {
+            layer: ErrorLayer::ServerLayer,
+            message: err.to_string(),
+        })
+    }
+}
+
+impl From<ParseError> for ServerError {
+    fn from(err: ParseError) -> ServerError {
+        ServerError::StickyProblem(ErrorDetails {
+            layer: ErrorLayer::BadInput,
+            message: err.to_string(),
+        })
+    }
+}
+
+#[derive(Debug)]
+struct RemoteServer {
+    server_base_url: Url,
+    tree_base_url: Url,
+    source_base_url: Url,
+    raw_analysis_base_url: Url,
+    search_url: Url,
+}
+
+async fn get(url: Url) -> Result<reqwest::Response> {
+    //println!("Using URL {}", url);
+    let res = reqwest::get(url).await?;
+
+    if !res.status().is_success() {
+        if res.status().is_server_error() {
+            return Err(ServerError::TransientProblem(ErrorDetails {
+                layer: ErrorLayer::ServerLayer,
+                message: format!("Server status of {}", res.status()),
+            }));
+        } else {
+            return Err(ServerError::StickyProblem(ErrorDetails {
+                layer: ErrorLayer::DataLayer,
+                message: format!("Server status of {}", res.status()),
+            }));
+        }
+    }
+
+    Ok(res)
+}
+
+#[async_trait]
+impl AbstractServer for RemoteServer {
+    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<Vec<Value>> {
+        let url = self.raw_analysis_base_url.join(sf_path)?;
+        let raw_str = get(url).await?.text().await?;
+        raw_str
+            .lines()
+            .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+            .collect()
+    }
+
+    async fn fetch_html(&self, sf_path: &str) -> Result<String> {
+        let url = self.source_base_url.join(sf_path)?;
+        let html = get(url).await?.text().await?;
+        Ok(html)
+    }
+
+    async fn perform_query(&self, q: &str) -> Result<Value> {
+        // XXX can we just append a query string like this?
+        let url = self.search_url.join(q)?;
+        let raw_str = get(url).await?.text().await?;
+        match from_str(&raw_str) {
+            Ok(json) => Ok(json),
+            Err(err) => Err(ServerError::StickyProblem(ErrorDetails {
+                layer: ErrorLayer::ServerLayer,
+                message: err.to_string(),
+            })),
+        }
+    }
+}
+
+pub fn make_remote_server(
+    server_base_url: Url,
+    tree_name: &str,
+) -> Result<Box<dyn AbstractServer + Send + Sync>> {
+    let tree_base_url = server_base_url.join(&format!("{}/", tree_name))?;
+    let source_base_url = tree_base_url.join("source/")?;
+    let raw_analysis_base_url = tree_base_url.join("raw-analysis/")?;
+    let search_url = tree_base_url.join("search")?;
+
+    Ok(Box::new(RemoteServer {
+        server_base_url,
+        tree_base_url,
+        source_base_url,
+        raw_analysis_base_url,
+        search_url,
+    }))
+}

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -1,0 +1,106 @@
+use async_trait::async_trait;
+use serde_json::Value;
+
+pub type Result<T> = std::result::Result<T, ServerError>;
+
+// JSON parse errors are sticky data problems.
+impl From<serde_json::Error> for ServerError {
+    fn from(err: serde_json::Error) -> ServerError {
+        ServerError::StickyProblem(ErrorDetails {
+            layer: ErrorLayer::DataLayer,
+            message: err.to_string(),
+        })
+    }
+}
+
+/// Express whether the error seems to be happening in the server or the data.
+#[derive(Debug)]
+pub enum ErrorLayer {
+    /// The request itself has issues like a bad URL.
+    BadInput,
+    /// The error seems to involve server logic, so it may or may not be an issue
+    /// with the underlying data.
+    ServerLayer,
+    /// The error seems to be related to the indexed data in question rather
+    /// than the server, like the data was not indexed.
+    DataLayer,
+    /// We're not sure if it was a server issue or a data issue.
+    UnknownLayer,
+}
+
+/// ServerError payload to provide details about what went wrong for
+/// investigation purposes.  In the future, this could wrap the
+/// underlying errors we've seen.
+#[derive(Debug)]
+pub struct ErrorDetails {
+    /// Attempt to distinguish failures due to server bugs from failures due to
+    /// indexing bugs.  For example a 500 response from a server would be a
+    /// `ServerLayer` problem, but if a 404 was instead returned, that would be
+    /// a `DataLayer` problem.
+    pub layer: ErrorLayer,
+    /// Stringified version of the lower level error.
+    pub message: String,
+}
+
+/// Does a retry makes sense or not?
+///
+/// Actually performing retries could of course happen either below this
+/// abstraction layer or above it.  The argument for above is that the
+/// `cmd_pipeline` could make more informed scheduling decisions with
+/// appropriately long back-offs than this lower layer would be able to.  But
+/// that's all speculative at this point and this type is really being
+/// introduced because we need a unifying error type.
+#[derive(Debug)]
+pub enum ServerError {
+    /// An error that will persist for at least this index.  For example a 404.
+    StickyProblem(ErrorDetails),
+    /// An error that might go away if retried later.  For example a 504 "Gateway
+    /// timeout".
+    TransientProblem(ErrorDetails),
+    Unsupported,
+}
+
+/// Unified exposure for interacting with a local Searchfox index on disk or
+/// a remote searchfox server over HTTPS talking to the web-server.
+///
+/// The primary goal is for our tests to verify both our on-disk representations
+/// and that these are exposed to searchfox users correctly.  It's also our hope
+/// that this can be used by searchfox contributors to investigate problems and
+/// how things currently work more efficiently and enjoyably than manualy doing
+/// so.
+///
+/// ## Runtime Assumptions
+///
+/// We assume that we are operating in a tokio multi-threaded runtime and that
+/// all blocking operations for any implementations of these traits should
+/// responsibly make use of
+/// https://docs.rs/tokio/1.5.0/tokio/task/index.html#blocking-and-yielding so
+/// that full parallelism can be maintained.  In particular, this means that
+/// mmap-based lookups which can fault and block on IO should likely use
+/// https://docs.rs/tokio/1.5.0/tokio/task/index.html#block_in_place.
+///
+/// ## Abstraction Level / Library Use
+///
+/// Currently existing analysis-file processing and other logic:
+/// - Uses synchronous I/O
+/// - Uses rustc_serialize::json
+///
+/// In the end, it likely would make sense for the analysis mechanism to:
+/// - Support async I/O
+/// - Use serde_json
+/// - Use async streams via https://docs.rs/tokio-stream/0.1.5/tokio_stream/
+///   on a per-record or per-line granularity, quite possibly using our analysis
+///   types for analysis records instead of untyped JSON.
+///
+/// But I'm introducing this interface right now in an attempt to provide
+/// increased test coverage before making more extensive refactorings.  So for
+/// now, this interface will do the simplest thing possible.
+///
+#[async_trait]
+pub trait AbstractServer {
+    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<Vec<Value>>;
+
+    async fn fetch_html(&self, sf_path: &str) -> Result<String>;
+
+    async fn perform_query(&self, q: &str) -> Result<Value>;
+}

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -1,0 +1,60 @@
+use std::env::args_os;
+
+use serde_json::to_string_pretty;
+use tools::cmd_pipeline::{builder::build_pipeline, parser::OutputFormat, PipelineValues};
+
+#[tokio::main]
+async fn main() {
+    let os_args: Vec<String> = args_os()
+        .map(|os| os.into_string().unwrap_or("".to_string()))
+        .collect();
+
+    let (pipeline, output_format) = match build_pipeline(&os_args[0], &os_args[1]) {
+        Ok(pipeline) => pipeline,
+        Err(err) => {
+            panic!("You did not specify a good pipeline!\n {:?}", err);
+        }
+    };
+
+    let mut cur_values = PipelineValues::Void;
+
+    for cmd in pipeline.commands {
+        match cmd.execute(&pipeline.server, cur_values).await {
+            Ok(next_values) => {
+                cur_values = next_values;
+            }
+            Err(err) => {
+                println!("Pipeline Error!");
+                println!("{:?}", err);
+                return;
+            }
+        }
+    }
+
+    match cur_values {
+        PipelineValues::Void => {
+            println!("Void result.");
+        }
+        PipelineValues::HtmlExcerpts(he) => {
+            for file_excerpts in he.by_file {
+                //println!("HTML excerpts from: {}", file_excerpts.file);
+                for str in file_excerpts.excerpts {
+                    println!("{}", str);
+                }
+            }
+        }
+        PipelineValues::JsonRecords(jr) => {
+            for file_records in jr.by_file {
+                for value in file_records.records {
+                    if output_format == OutputFormat::Concise {
+                        println!("{}", value);
+                    } else if output_format == OutputFormat::Pretty {
+                        if let Ok(pretty) = to_string_pretty(&value) {
+                            println!("{}", pretty);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -1,0 +1,86 @@
+use crate::{cmd_pipeline::PipelineCommand, structopt::StructOpt};
+use url::Url;
+
+use crate::{
+    abstract_server::{
+        make_local_server, make_remote_server, ErrorDetails, ErrorLayer, Result, ServerError,
+    },
+    cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
+};
+
+use super::cmd_filter_analysis::FilterAnalysisCommand;
+use super::cmd_show_html::ShowHtmlCommand;
+
+use super::interface::ServerPipeline;
+
+/// Build a command pipeline from a shell-y string where we use pipe boundaries
+/// to delineate the separate pipeline steps.
+///
+/// The shell-words module is used to parse `arg_str` into shell words, which we
+/// then break into separate sub-commands whenever we see a `|`.  We then pass
+/// these sub-commands to the structopt parsing `from_iter` method, taking care
+/// to stuff our binary name into the first arg.
+pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, OutputFormat)> {
+    let all_args = match shell_words::split(arg_str) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            return Err(ServerError::StickyProblem(ErrorDetails {
+                layer: ErrorLayer::BadInput,
+                message: err.to_string(),
+            }));
+        }
+    };
+
+    let mut server = None;
+    let mut output_format = None;
+    let mut first_time = true;
+
+    let mut commands: Vec<Box<dyn PipelineCommand>> = vec![];
+
+    for arg_slices in all_args.split(|v| v == "|") {
+        let mut fake_args = vec![bin_name.to_string()];
+        fake_args.extend(arg_slices.iter().cloned());
+
+        let opts = match ToolOpts::from_iter_safe(fake_args) {
+            Ok(opts) => opts,
+            Err(err) => {
+                return Err(ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::BadInput,
+                    message: err.to_string(),
+                }));
+            }
+        };
+        //println!("Pipeline segment: {:?}", opts);
+
+        if first_time {
+            server = match Url::parse(&opts.server) {
+                Ok(url) => Some(make_remote_server(url, &opts.tree)?),
+                Err(_) => Some(make_local_server(&opts.server, &opts.tree)?),
+            };
+            output_format = Some(opts.output_format);
+            first_time = false;
+        }
+
+        match opts.cmd {
+            Command::Query(_q) => {}
+
+            Command::FilterAnalysis(fa) => {
+                commands.push(Box::new(FilterAnalysisCommand { args: fa }));
+            }
+
+            Command::ShowHtml(sh) => {
+                commands.push(Box::new(ShowHtmlCommand { args: sh }));
+            }
+
+            Command::IdentifierLookup(_il) => (),
+        }
+    }
+
+    Ok((
+        ServerPipeline {
+            server: server.unwrap(),
+            commands,
+        },
+        output_format.unwrap(),
+    ))
+}

--- a/tools/src/cmd_pipeline/cmd_filter_analysis.rs
+++ b/tools/src/cmd_pipeline/cmd_filter_analysis.rs
@@ -1,0 +1,120 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::interface::{
+    JsonRecords, PipelineCommand, PipelineValues, RecordType, SymbolicQueryOpts,
+};
+use crate::{
+    abstract_server::{AbstractServer, Result},
+    cmd_pipeline::interface::JsonRecordsByFile,
+};
+
+#[derive(Debug, StructOpt)]
+pub struct FilterAnalysis {
+    /// Tree-relative analysis file path
+    file: String,
+
+    #[structopt(long, short, possible_values = &RecordType::variants(), case_insensitive = true)]
+    record_type: Option<Vec<RecordType>>,
+
+    #[structopt(long, short)]
+    kind: Option<String>,
+
+    #[structopt(flatten)]
+    query_opts: SymbolicQueryOpts,
+}
+
+/// Filter a stream of analysis records via raw JSON manipulation rather than
+/// using the strongly typed `analysis.rs` types.
+pub struct FilterAnalysisCommand {
+    pub args: FilterAnalysis,
+}
+
+#[async_trait]
+impl PipelineCommand for FilterAnalysisCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        _input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let records = server.fetch_raw_analysis(&self.args.file).await?;
+        let mut filtered = records;
+
+        // ## Filter by record type
+        if let Some(record_types) = &self.args.record_type {
+            filtered = filtered
+                .into_iter()
+                .filter(|val| {
+                    // Record type is currently indicated via boolean presence of
+                    // "source", "target", or "structured" so check for the
+                    // stringified version of the enum value.
+                    for rt in record_types {
+                        if val.get(rt.to_string().to_lowercase()).is_some() {
+                            return true;
+                        }
+                    }
+                    false
+                })
+                .collect();
+        }
+
+        // ## Filter by kind
+        if let Some(kind) = &self.args.kind {
+            // kind varies by record type:
+            // - target: "kind" is a single valued attribute
+            // - source: kind is baked into the comma-delimited "syntax"
+            filtered = filtered
+                .into_iter()
+                .filter(
+                    |val| match (val["source"].is_number(), val["target"].is_number()) {
+                        // source: consult "syntax"
+                        (true, _) => match val["syntax"].as_str() {
+                            None => false,
+                            Some(actual) => actual.split(",").next().unwrap_or("") == kind,
+                        },
+                        // target: consult "kind"
+                        (false, true) => match val["kind"].as_str() {
+                            None => false,
+                            Some(actual) => actual == kind,
+                        },
+                        _ => false,
+                    },
+                )
+                .collect();
+        }
+
+        // ## Filter by symbol
+        if let Some(symbol) = &self.args.query_opts.symbol {
+            // "sym" is optionally
+            filtered = filtered
+                .into_iter()
+                .filter(|val| match val["sym"].as_str() {
+                    None => false,
+                    Some(actual) => actual.split(",").any(|s| s == symbol),
+                })
+                .collect();
+        }
+
+        // ## Filter by identifier
+        if let Some(identifier) = &self.args.query_opts.identifier {
+            filtered = filtered
+                .into_iter()
+                .filter(|val| {
+                    match val["pretty"].as_str() {
+                        None => false,
+                        // source records have a space-delimited prefix that we want
+                        // to skip; by using split/last we handle it being optional.
+                        Some(actual) => actual.split(" ").last().unwrap_or("") == identifier,
+                    }
+                })
+                .collect();
+        }
+
+        Ok(PipelineValues::JsonRecords(JsonRecords {
+            by_file: vec![JsonRecordsByFile {
+                file: self.args.file.clone(),
+                records: filtered,
+            }],
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -1,0 +1,149 @@
+use std::cell::Cell;
+
+use async_trait::async_trait;
+use lol_html::{element, HtmlRewriter, Settings};
+use structopt::StructOpt;
+
+use super::interface::{JsonRecords, PipelineCommand, PipelineValues};
+use crate::{
+    abstract_server::{AbstractServer, Result},
+    cmd_pipeline::interface::{HtmlExcerpts, HtmlExcerptsByFile},
+};
+
+#[derive(Debug, StructOpt)]
+pub struct ShowHtml {}
+
+/// Output the HTML lines corresponding to the JSON records received via input.
+///
+/// There's also likely a use-case to process an HTML file as a root where we
+/// then filter lines based on "data-symbols".  It's not immediately clear if
+/// this command should also handle that or not.  There's also the question of
+/// whether symbol filtering would only excerpt the span associated with the
+/// symbol or would walk up to the enclosing line.  The answers should probably
+/// be driven by command-line use-cases; in particular, the experience of
+/// evolving a more targeted query.  Having to modify a command up-stream should
+/// be considered undesirable.
+pub struct ShowHtmlCommand {
+    pub args: ShowHtml,
+}
+
+#[async_trait]
+impl PipelineCommand for ShowHtmlCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let jr = match input {
+            PipelineValues::JsonRecords(jr) => jr,
+            _ => JsonRecords { by_file: vec![] },
+        };
+
+        let mut html_by_file = vec![];
+
+        for fr in jr.by_file {
+            // ## For each file!
+            let lines_to_show = fr.line_set();
+
+            // XXX Doing this as a single string received in a lump is fine for
+            // our testing use-case, but this may need to be reconsidered in
+            // production.  Or maybe production really wants the performance?
+            // Production certainly should have the RAM for our known worst
+            // case scenarios.
+            let html_str = server.fetch_html(&fr.file).await?;
+
+            let mut file_excerpts = vec![];
+
+            // ### HTML Extraction: What We Want
+            //
+            // We want the full line container which looks like:
+            // - div id="line-N" class="source-line-with-number" role="row"
+            //   - div role="cell"
+            //     - div class="cov-strip cov-uncovered cov-known"
+            //   - div role="cell"
+            //     - div class="blame-strip c2" data-blame="..."
+            //   - div role="cell" class="line-number" data-line-number="N"
+            //   - code role="cell" class="source-line"
+            //     - ex: span class="sync_comment"
+            //     - ex: span class="syn_def syn_type" data-symbols="..." data-i
+            //
+            // ### HTML Extraction Low Level Details
+            //
+            // Until https://github.com/cloudflare/lol-html/issues/40 or
+            // the spin-off https://github.com/cloudflare/lol-html/issues/78
+            // are implemented, lol_html doesn't explicitly provide a way to
+            // derive the value of an element.
+            //
+            // So we attempt a hack where we use a custom output sink that is
+            // kept aware of where we are in the file.  The good news is that
+            // since lol_html is oriented around minimal memory allocation, we
+            // can generally control when flushes happen.
+
+            let mut writing_line: u32 = 0;
+            let cur_line = Cell::new(0u32);
+            let want_cur_line = Cell::new(false);
+
+            let mut buf = vec![];
+
+            let mut rewrite = HtmlRewriter::new(
+                Settings {
+                    element_content_handlers: vec![element!(
+                        r#"div.source-line-with-number"#,
+                        |el| {
+                            if let Some(id_str) = el.get_attribute("id") {
+                                let id_parts: Vec<&str> = id_str.split("-").collect();
+                                if id_parts.len() == 2 && id_parts[0] == "line" {
+                                    let lno = id_parts[1].parse().unwrap_or(0);
+                                    cur_line.set(lno);
+                                    want_cur_line.set(lines_to_show.contains(&lno));
+                                }
+                            }
+
+                            Ok(())
+                        }
+                    )],
+                    ..Settings::default()
+                },
+                |c: &[u8]| {
+                    // We were actively writing and potentially have some
+                    // buffer.
+                    if writing_line > 0 {
+                        // We're done writing; flush!
+                        if cur_line.get() != writing_line {
+                            writing_line = 0;
+                            file_excerpts.push(String::from_utf8_lossy(&buf).to_string());
+                            buf.clear();
+                        }
+                        // We're still writing!
+                        else {
+                            // Write into the buffer and then leave, because we
+                            // don't need to consider switching into writing, as
+                            // we're still here.
+                            buf.extend_from_slice(c);
+                            return;
+                        }
+                    }
+                    // We either closed out writing or weren't writing.  But now
+                    // we need to see if we should be writing!
+                    if cur_line.get() > 0 && want_cur_line.get() {
+                        writing_line = cur_line.get();
+                        buf.extend_from_slice(c);
+                    }
+                    // Otherwise, this wasn't interesting.
+                },
+            );
+
+            rewrite.write(html_str.as_bytes()).unwrap();
+            rewrite.end().unwrap();
+
+            html_by_file.push(HtmlExcerptsByFile {
+                file: fr.file.clone(),
+                excerpts: file_excerpts,
+            });
+        }
+
+        Ok(PipelineValues::HtmlExcerpts(HtmlExcerpts {
+            by_file: html_by_file,
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -1,0 +1,86 @@
+use async_trait::async_trait;
+use clap::arg_enum;
+use serde_json::Value;
+use std::collections::HashSet;
+use structopt::StructOpt;
+
+pub use crate::abstract_server::{AbstractServer, Result};
+
+arg_enum! {
+  #[derive(Debug, PartialEq)]
+  pub enum RecordType {
+      Source,
+      Target,
+  }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct SymbolicQueryOpts {
+    /// Exact symbol match
+    #[structopt(short)]
+    pub symbol: Option<String>,
+
+    /// Exact identifier match
+    #[structopt(short)]
+    pub identifier: Option<String>,
+}
+
+/// The input and output of each pipeline segment
+pub enum PipelineValues {
+    JsonRecords(JsonRecords),
+    HtmlExcerpts(HtmlExcerpts),
+    Void,
+}
+
+/// JSON records are raw analysis records from a single file (for now)
+pub struct JsonRecordsByFile {
+    pub file: String,
+    pub records: Vec<Value>,
+}
+
+impl JsonRecordsByFile {
+    /// Return the set of lines covered by the records in this structure.
+    ///
+    /// A HashSet is returned for ease of consumption even though it would
+    /// almost certainly be more efficient to return a vec that the caller
+    /// caller can consume in concert with a parallel traversal of (ex) the
+    /// generated HTML for the given file.
+    pub fn line_set(&self) -> HashSet<u32> {
+        let mut line_set = HashSet::new();
+        for value in &self.records {
+            if let Some(loc) = value["loc"].as_str() {
+                let lno = loc.split(":").next().unwrap_or("0").parse().unwrap_or(0);
+                line_set.insert(lno);
+            }
+        }
+
+        line_set
+    }
+}
+
+pub struct JsonRecords {
+    pub by_file: Vec<JsonRecordsByFile>,
+}
+
+pub struct HtmlExcerptsByFile {
+    pub file: String,
+    pub excerpts: Vec<String>,
+}
+
+pub struct HtmlExcerpts {
+    pub by_file: Vec<HtmlExcerptsByFile>,
+}
+
+#[async_trait]
+pub trait PipelineCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues>;
+}
+
+pub struct ServerPipeline {
+    pub server: Box<dyn AbstractServer + Send + Sync>,
+    pub commands: Vec<Box<dyn PipelineCommand>>,
+}

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -1,0 +1,11 @@
+extern crate clap;
+extern crate structopt;
+
+pub mod builder;
+pub mod interface;
+pub mod parser;
+
+mod cmd_filter_analysis;
+mod cmd_show_html;
+
+pub use interface::{PipelineCommand, PipelineValues};

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -1,0 +1,51 @@
+use clap::arg_enum;
+use structopt::StructOpt;
+
+use super::cmd_filter_analysis::FilterAnalysis;
+use super::cmd_show_html::ShowHtml;
+
+arg_enum! {
+    #[derive(Debug, PartialEq)]
+    pub enum OutputFormat {
+        // Pretty-printed JSON.
+        Pretty,
+        // Un-pretty-printed JSON.
+        Concise,
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct ToolOpts {
+    /// URL of the server to query or the path to the root of the index tree if
+    /// using local data.
+    #[structopt(
+        long,
+        default_value = "https://searchfox.org/",
+        env = "SEARCHFOX_SERVER"
+    )]
+    pub server: String,
+
+    /// The name of the indexed tree to use.
+    #[structopt(long, default_value = "mozilla-central", env = "SEARCHFOX_TREE")]
+    pub tree: String,
+
+    #[structopt(long, short, possible_values = &OutputFormat::variants(), case_insensitive = true, default_value = "concise")]
+    pub output_format: OutputFormat,
+
+    #[structopt(subcommand)]
+    pub cmd: Command,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum Command {
+    Query(Query),
+    FilterAnalysis(FilterAnalysis),
+    ShowHtml(ShowHtml),
+    IdentifierLookup(IdentifierLookup),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Query {}
+
+#[derive(Debug, StructOpt)]
+pub struct IdentifierLookup {}

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -12,7 +12,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use git2::{Oid, Repository};
 
-#[derive(MallocSizeOf, RustcDecodable, RustcEncodable)]
+#[derive(Debug, MallocSizeOf, RustcDecodable, RustcEncodable)]
 pub struct TreeConfigPaths {
     pub index_path: String,
     pub files_path: String,

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -215,7 +215,7 @@ pub fn format_code(
                         None => continue,
                     };
 
-                    if jump.path == *path && jump.lineno == cur_line.into() {
+                    if jump.path == *path && jump.lineno == cur_line as u64 {
                         continue;
                     }
 

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -2,6 +2,7 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate log;
+extern crate clap;
 extern crate chrono;
 extern crate git2;
 extern crate linkify;
@@ -12,8 +13,12 @@ extern crate malloc_size_of_derive;
 extern crate jemalloc_sys;
 extern crate jemallocator;
 extern crate malloc_size_of;
+extern crate serde_json;
+extern crate structopt;
 
+pub mod abstract_server;
 pub mod file_format;
+pub mod cmd_pipeline;
 
 pub mod blame;
 pub mod config;


### PR DESCRIPTION
This implements "searchfox-tool" a new binary, as proposed in https://bugzilla.mozilla.org/show_bug.cgi?id=1707282 but does not yet do the "insta" snapshot testing or otherwise replace the check-helper.sh mechanism yet, but I think it's quite possibly ready to do so.

Given that this is already a sizable PR and the searchfox-tool thing is already a MVP and I won't be able to get to the testing stuff until the next weekend, I'm putting this up for review now.

## Example usages:

Here we see us filtering the contents of the (raw) analysis files to "source" (via record type) records that are a "def" (via kind) for a specific identifier "outerNS::Thing::Thing" via both local index from disk and localhost server:
```
> cargo run --bin searchfox-tool -- '--server http://localhost/ --tree tests filter-analysis big_cpp.cpp -k def -i outerNS::Thing::Thing -r source'
{"loc":"00147:2-7","nestingRange":"149:20-151:2","pretty":"function outerNS::Thing::Thing","source":1,"sym":"_ZN7outerNS5ThingC1Ei","syntax":"def,function"}

> cargo run --bin searchfox-tool -- '--server /home/vagrant/index/config.json --tree tests filter-analysis big_cpp.cpp -k def -i outerNS::Thing::Thing -r source'
{"loc":"00147:2-7","nestingRange":"149:20-151:2","pretty":"function outerNS::Thing::Thing","source":1,"sym":"_ZN7outerNS5ThingC1Ei","syntax":"def,function"}
```

Here we see the same commands, but now we pipe the output of the filtering to the "show-html" command which extracts the source lines for which we had records.
```
> cargo run --bin searchfox-tool -- '--server /home/vagrant/index/config.json --tree tests filter-analysis big_cpp.cpp -k def -i outerNS::Thing::Thing -r source | show-html'
<div role="row" id="line-147" class="source-line-with-number nesting-sticky-line">
  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
  <div role="cell"><div class="blame-strip"></div></div>
  <div role="cell" class="line-number" data-line-number="147"></div>
  <code role="cell" class="source-line">  <span class="syn_def" data-symbols="_ZN7outerNS5ThingC1Ei" data-i="23" >Thing</span>(<span class="syn_reserved" >int</span> <span data-symbols="V_328b2e25607c3527_812a493f256" >baseHP</span>)
</code>
</div>

> cargo run --bin searchfox-tool -- '--server http://localhost/ --tree tests filter-analysis big_cpp.cpp -k def -i outerNS::Thing::Thing -r source | show-html'
<div role="row" id="line-147" class="source-line-with-number nesting-sticky-line">
  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
  <div role="cell"><div class="blame-strip"></div></div>
  <div role="cell" class="line-number" data-line-number="147"></div>
  <code role="cell" class="source-line">  <span class="syn_def" data-symbols="_ZN7outerNS5ThingC1Ei" data-i="23" >Thing</span>(<span class="syn_reserved" >int</span> <span data-symbols="V_328b2e25607c3527_812a493f256" >baseHP</span>)
</code>
</div>
```


## General Operation

- `searchfox-tool.rs` is currently the only CLI interface, it takes the OS args and is assuming there is only a single argument now which contains a jq-style-ish query that's pipe-delimited.  (In other words, something that looks like a normal shell pipeline then gets quoted so that it has a single argument.)
- `cmd_pipeline/builder.rs`:
  - Takes the single argument and uses the `shell_words` crate to create a normal argument stream which then gets split on `|` and we feed the sub-slices to the structopt-built argument parser which understands a single command.  Each command is mapped into a pipeline command.  These exist as `cmd_pipeline/cmd_*.rs` of which there are 2 real ones right now and 2 stub ones.
  - It treats the first set of arguments as special, which is where we extract the global arguments from, specifically deciding what server to use.
  - There is a local-index and a remote-HTTP server option with all of the stuff living under `abstract_server`.  Both use async tokio.  We use tokio because it seems like we could potentially use some of this command pipeline in the future as part of web-server.rs, and in that case we want to be responsible async users.
- `searchfox-tool.rs` takes the pipeline and runs the commands in succession, feeding the output of the previous step to the input of the next step.  These steps in the above example are:
  - `cmd_pipeline/cmd_filter_analysis.rs`: Uses serde_json JSON-reps (our current use of `rustc_serialize::json` is not a modern best practice, so I figured I'd start the transition here to get some experience with it) and the structopt parameters to support various filtering.
  - `cmd_pipeline/cmd_show_html.rs`: Uses `lol_html` so that we can use a selector-based mechanism to pick out the lines of interest.  There isn't currently an excerpting mechanism so we use a hack so that we have a stateful OutputSink based on the lines we've seen.  Because of how the hack works and me forgetting about the edge-case until just now, we can't actually excerpt the last line of a file, but I'm willing to live with that for now...