### PR TITLE
Bug 1683563 - Tweak diff similarity options

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -612,9 +612,9 @@ dependencies = [
 
 [[package]]
 name = "git2"
-version = "0.13.17"
+version = "0.13.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d250f5f82326884bd39c2853577e70a121775db76818ffa452ed1e80de12986"
+checksum = "d9831e983241f8c5591ed53f17d874833e2fa82cac2625f3888c50cbfe136cba"
 dependencies = [
  "bitflags",
  "libc",
@@ -966,9 +966,9 @@ checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.12.20+1.1.0"
+version = "0.12.21+1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2f09917e00b9ad194ae72072bb5ada2cca16d8171a43e91ddba2afbb02664b"
+checksum = "86271bacd72b2b9e854c3dcfb82efd538f15f870e4c11af66900effb462f6825"
 dependencies = [
  "cc",
  "libc",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -11,7 +11,7 @@ clap = "2"
 env_logger = "0.7.1"
 flate2 = { version = "1", features = ["tokio"] }
 getopts = "0.2.19"
-git2 = "0.13.17"
+git2 = "0.13.20"
 hyper = "0.10"
 ipdl_parser = { path = "./ipdl_parser" }
 jemalloc-sys = "0.3.2"

--- a/tools/malloc_size_of/Cargo.toml
+++ b/tools/malloc_size_of/Cargo.toml
@@ -11,4 +11,4 @@ path = "lib.rs"
 [features]
 
 [dependencies]
-git2 = "0.13.17"
+git2 = "0.13.20"

--- a/tools/src/bin/build-blame.rs
+++ b/tools/src/bin/build-blame.rs
@@ -558,7 +558,14 @@ fn compute_diff_data(
             )
             .unwrap();
         diff.find_similar(Some(
-            DiffFindOptions::new().copies(true).rename_limit(1000000),
+            DiffFindOptions::new()
+                .copies(true)
+                .copy_threshold(30)
+                .renames(true)
+                .rename_threshold(30)
+                .rename_limit(1000000)
+                .break_rewrites(true)
+                .break_rewrites_for_renames_only(true),
         ))
         .unwrap();
         for delta in diff.deltas() {


### PR DESCRIPTION
There isn't a new git2-rs release yet with the changes, so for now I'm just using the master branch head revision. Once there's a new release I'll update the Cargo.* files to use that instead.