### PR TITLE
Bug 1712578 - Use TMPDIR if defined over /tmp in shell scripts. a=bustage

### DIFF
--- a/scripts/crossref.sh
+++ b/scripts/crossref.sh
@@ -11,14 +11,14 @@ echo Root is $INDEX_ROOT
 
 # Find the files to cross-reference.
 cd $INDEX_ROOT/analysis
-find . -type f | cut -c 3- > /tmp/files
+find . -type f | cut -c 3- > ${TMPDIR:-/tmp}/files
 cd -
 
-$MOZSEARCH_PATH/tools/target/release/crossref $CONFIG_FILE $TREE_NAME /tmp/files
+$MOZSEARCH_PATH/tools/target/release/crossref $CONFIG_FILE $TREE_NAME ${TMPDIR:-/tmp}/files
 
 ID_FILE=$INDEX_ROOT/identifiers
-LC_ALL=C sort -f $ID_FILE > /tmp/ids
-mv /tmp/ids $ID_FILE
+LC_ALL=C sort -f $ID_FILE > ${TMPDIR:-/tmp}/ids
+mv ${TMPDIR:-/tmp}/ids $ID_FILE
 
 # Derive the per-file information.  We do this after the cross-referencing
 # because this might want to digest some cross-referenced info.

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -15,17 +15,17 @@ CONFIG_FILE=$(realpath $2)
 TREE_NAME=$3
 
 # parallel args:
-# --files: Place .par files in /tmp that document stdout/stderr for each run.
+# --files: Place .par files in ${TMPDIR:-/tmp} that document stdout/stderr for each run.
 # --joblog: Emit a joblog that can be used to `--resume` the previous job.  This
 # might be useful to attempt to reproduce failures without having to copy and
 # paste insanely long command lines.
 cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files | \
-    parallel --files --joblog /tmp/output.joblog --halt 2 -X --eta \
+    parallel --files --joblog ${TMPDIR:-/tmp}/output.joblog --halt 2 -X --eta \
 	     $MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME
 
 HG_ROOT=$(jq -r ".trees[\"${TREE_NAME}\"].hg_root" ${CONFIG_FILE})
-cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files > /tmp/dirs
-js $MOZSEARCH_PATH/scripts/output-dir.js $FILES_ROOT $INDEX_ROOT "$HG_ROOT" $MOZSEARCH_PATH $OBJDIR $TREE_NAME /tmp/dirs
+cat $INDEX_ROOT/repo-files $INDEX_ROOT/objdir-files > ${TMPDIR:-/tmp}/dirs
+js $MOZSEARCH_PATH/scripts/output-dir.js $FILES_ROOT $INDEX_ROOT "$HG_ROOT" $MOZSEARCH_PATH $OBJDIR $TREE_NAME ${TMPDIR:-/tmp}/dirs
 
 js $MOZSEARCH_PATH/scripts/output-template.js $FILES_ROOT $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME
 js $MOZSEARCH_PATH/scripts/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME


### PR DESCRIPTION
We have some logic that directly references /tmp that assumes it will have
bountiful storage available, but the reality is that it does not.  In
particular, `crossref.sh` was directly sorting the ~1.6G into the /tmp dir
which is very close to the amount of free space on our `/` EBS image.

This is not meant to be the end state fix for this, so I've just corrected
the shell scripts where it's trivial to evaluate an environment variable
and failover.  I have not touched the following other files under /scripts
that have the same problem but involve python/JS:
- output-dir.js
- idl-analyze.py
- idl-analyze.sh (because of the above)
- build-codesearch.py

The simplest solution in terms of avoiding using the wrong tmp dir would
be to just make sure that the /tmp dir is actually backed by the local
SSD, but that would ideally want to happen early in the machine boot
process to avoid /tmp already being in use when we actually get around to
creating the scratch drive.

Maybe that's okay though?  Otherwise we'll potentially want to enforce
some kind of invariant about TMPDIR being set and/or the indexing process
having a "tmp" directory in each index directory (which would make sense
for the purposes of having `mv` operating within the same filesystem).