### PR TITLE
Bug 1687016 - Bump cinnabar in provisioning scripts to current tip.

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -116,7 +116,7 @@ sudo pip3 install boto3 awscli
 if [ ! -d git-cinnabar ]; then
   # Need mercurial to prevent cinnabar from spewing warnings
   sudo apt-get install -y mercurial
-  CINNABAR_REVISION=6d21541cb23dbfe066de6cbd1c89f6da4e3d318a
+  CINNABAR_REVISION=1ffb93f88feadf2c376787a844efadf3fe6c519b
   git clone https://github.com/glandium/git-cinnabar
   pushd git-cinnabar
     git checkout $CINNABAR_REVISION

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -89,7 +89,7 @@ sudo pip3 install boto3 awscli
 if [ ! -d git-cinnabar ]; then
   # Need mercurial to prevent cinnabar from spewing warnings, and cinnabar requires python2.7
   sudo apt-get install -y mercurial python2.7
-  CINNABAR_REVISION=6d21541cb23dbfe066de6cbd1c89f6da4e3d318a
+  CINNABAR_REVISION=1ffb93f88feadf2c376787a844efadf3fe6c519b
   git clone https://github.com/glandium/git-cinnabar
   pushd git-cinnabar
     git checkout $CINNABAR_REVISION


### PR DESCRIPTION
We actually want this for 2 situations:
- Bug 1687016 - hg2git/git2hg hang fixes
- Bug 1716167 - to see if the cinnabar fsck becomes happier