### PR TITLE
Bug 1720037 - Run the update step when provisioning to cache crates.

### DIFF
--- a/infrastructure/aws/indexer-provision.sh
+++ b/infrastructure/aws/indexer-provision.sh
@@ -7,6 +7,36 @@ set -o pipefail # Check all commands in a pipeline
 # We want the NVME tools, that's how EBS gets mounted now on "nitro" instances.
 sudo apt-get install -y nvme-cli
 
+date
+
+# Size up our root partition to 12G
+#
+# To this end we need to know the volume id in order to issue an EBS resizing
+# command.  Note that the select constraint here is intended more as a check
+# that our assumption about partition sizes hasn't changed, as when provisioning
+# there should only be this single EBS mount.
+ROOT_VOL_ID=$(sudo nvme list -o json | jq --raw-output '.Devices[] | select(.PhysicalSize < 9000000000) | .SerialNumber | sub("^vol"; "vol-")')
+AWS_REGION=us-west-2
+# The size is in gigs.
+aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 12
+# Re: hardcoded devices: The devices should currently be stable.
+#
+# We use an until loop because it can take some time for the change to
+# propagate to this VM.  The error will look like:
+#   "NOCHANGE: partition 1 is size 16775135. it cannot be grown"
+# And success will look like:
+#   "CHANGED: partition=1 start=2048 old: size=16775135 end=16777183 new: size=25163743 end=25165791"
+#
+# The 5 is arbitrary in both cases.
+sleep 5
+until sudo growpart /dev/nvme0n1 1
+do
+  sleep 5
+done
+sudo resize2fs /dev/nvme0n1p1
+
+date
+
 cat > cloudwatch.cfg <<"THEEND"
 [general]
 state_file = /var/awslogs/state/agent-state

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -42,6 +42,14 @@ launch_spec = {
     'UserData': user_data,
     'InstanceType': 'c5d.2xlarge',
     'BlockDeviceMappings': [],
+    # In order to be able to automatically have the `aws` command work so that
+    # we can resize our root partition, we need to assign an IAM role.
+    #
+    # This also could potentially let the provisioning process checkpoint itself
+    # into a new AMI.
+    'IamInstanceProfile': {
+        'Name': 'indexer-role',
+    },
     'TagSpecifications': [{
         'ResourceType': 'instance',
         'Tags': [{

--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -8,3 +8,30 @@ set -o pipefail # Check all commands in a pipeline
 sudo apt-get install -y nvme-cli
 
 date
+
+# Size up our root partition to 12G
+#
+# To this end we need to know the volume id in order to issue an EBS resizing
+# command.  Note that the select constraint here is intended more as a check
+# that our assumption about partition sizes hasn't changed, as when provisioning
+# there should only be this single EBS mount.
+ROOT_VOL_ID=$(sudo nvme list -o json | jq --raw-output '.Devices[] | select(.PhysicalSize < 9000000000) | .SerialNumber | sub("^vol"; "vol-")')
+AWS_REGION=us-west-2
+# The size is in gigs.
+aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 12
+# Re: hardcoded devices: The devices should currently be stable.
+#
+# We use an until loop because it can take some time for the change to
+# propagate to this VM.  The error will look like:
+#   "NOCHANGE: partition 1 is size 16775135. it cannot be grown"
+# And success will look like:
+#   "CHANGED: partition=1 start=2048 old: size=16775135 end=16777183 new: size=25163743 end=25165791"
+#
+# The 5 is arbitrary in both cases.
+sleep 5
+until sudo growpart /dev/nvme0n1 1
+do
+  sleep 5
+done
+sudo resize2fs /dev/nvme0n1p1
+

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -22,6 +22,7 @@ set -o pipefail # Check all commands in a pipeline
 # Update Rust (make sure we have the latest version).
 # We need rust nightly to use the save-analysis, and firefox requires recent
 # versions of Rust.
+#
 # Before we do the update, we remove some components that we don't need and
 # that are sometimes missing. If they are missing, `rustup update` will try
 # to use a previous nightly instead that does have the components, which means
@@ -29,9 +30,16 @@ set -o pipefail # Check all commands in a pipeline
 # usualy fine, but in cases where we hit ICEs that have been fixed upstream,
 # we want the very latest rustc to get the fix. Removing these components also
 # reduces download time during `rustup update`.
-rustup component remove clippy
-rustup component remove rustfmt
-rustup component remove rust-docs
+#
+# Note that these commands are not idempotent, so we need to `|| true` for cases
+# where they've already been removed by a prior invocation of this script.
+# (Originally this script would only ever be run on the indexers and web-servers
+# at most once because the script would not be run during provisioning and each
+# VM's root partition would be discarded after running.  Now we run this script
+# as part of provisioning for side-effects.)
+rustup component remove clippy || true
+rustup component remove rustfmt || true
+rustup component remove rust-docs || true
 rustup update
 
 # Install SpiderMonkey.

--- a/infrastructure/web-server-update.sh
+++ b/infrastructure/web-server-update.sh
@@ -21,9 +21,9 @@ set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
 # See comments in indexer-update.sh
-rustup component remove clippy
-rustup component remove rustfmt
-rustup component remove rust-docs
+rustup component remove clippy || true
+rustup component remove rustfmt || true
+rustup component remove rust-docs || true
 rustup update
 
 pushd mozsearch/tools


### PR DESCRIPTION
The following changes are made:
- Provisioning is given an IAM role so that the `aws` command can use it.
  No role = no way to run `aws` without manually providing credentials.
  - It's the same IAM role we use for indexers!
- Indexer and web server AWS provisioning resizes their root partition up
  to 12 gigs from 8.  This depends on the IAM role to work.
- The indexer and web server scripts run their update scripts for side
  effect of caching crates but also validating the installs.
  - This happens in the core non-AWS scripts primarily so that we notice
    any mistakes in changes to the provisioning process sooner when
    rebuilding the VM locally.
- The update scripts and their helper scripts have been updated to handle
  being run multiple times, once at provisioning, and once at spawning.
  - `vagrant up` was very helpful in testing this since it runs both
    indexer and web-server provisioning, which is not quite the same
    thing that happens on the servers (because they're different scripts!)
    but helped uncover the problem.
  - I've added a second invocation of the update scripts as part of the
    provisioning to provide that fidelity during provisioning, noting
    that there is some awkwardness about how the update process is
    explicitly checking out the tip of the repo which makes it hard to
    fully test things until they're landed on the tip.
    - This could be addressed by having provisioning use its own branch
      called "provisioning" or something like that, with changes to
      provisioning first staged there and then only moved to the main
      branch afterwards.  But that assumes some other automation would
      be in place.  That's too much for a manual process right now.