### PR TITLE
Bug 1707282 - Correct expectations now that blame HTML is removed

### DIFF
--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__html.snap
@@ -4,7 +4,6 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-20" class="source-line-with-number">
-  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="20"></div>
   <code role="cell" class="source-line"><span class="syn_reserved" >#include</span> <span class="syn_string" data-symbols="FILE_big_header@2Eh" data-i="0" >"big_header.h"</span>
 </code>

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__html.snap
@@ -4,7 +4,6 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-1" class="source-line-with-number">
-  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="1"></div>
   <code role="cell" class="source-line"><span class="syn_comment" >// I am a header file.</span>
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__html.snap
@@ -4,7 +4,6 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-14" class="source-line-with-number">
-  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="14"></div>
   <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span data-symbols="test_rust_dependency::<MyType>::do_foo" data-i="4" >do_foo</span>(<span class="syn_reserved" >self</span>) -> <span data-symbols="test_rust_dependency::MyType" data-i="5" >MyType</span> {
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__html.snap
@@ -4,7 +4,6 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-2" class="source-line-with-number">
-  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="2"></div>
   <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="simple::build_time_generated::GeneratedType" data-i="0" >GeneratedType</span> {
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__html.snap
@@ -4,7 +4,6 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-37" class="source-line-with-number">
-  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="37"></div>
   <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span data-symbols="simple::<Loader>::new" data-i="25" >new</span>(<span data-symbols="simple::<Loader>::new::deps_dir" data-i="26" >deps_dir</span>: PathBuf) -> <span class="syn_reserved" >Self</span> {
 </code>


### PR DESCRIPTION
For the mozilla-central checks where blame is likely to change
unpredictably, I changed the test logic to normalize the blame lines
out of existence, but failed to update the "tests" repo.

This is the result of running `make review-test-repo` and accepting
the changes.