### PR TITLE
Bug 1716167 - Add a way to launch an indexer shell

### DIFF
--- a/infrastructure/aws/shell-setup.sh
+++ b/infrastructure/aws/shell-setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+if [ $# != 6 ]
+then
+    echo "usage: $0 <branch> <channel> <mozsearch-repo-url> <config-repo-url> <config-repo-path> <config-file-name>"
+    exit 1
+fi
+
+SCRIPT_PATH=$(readlink -f "$0")
+MOZSEARCH_PATH=$(dirname "$SCRIPT_PATH")/../..
+
+BRANCH=$1
+CHANNEL=$2
+MOZSEARCH_REPO_URL=$3
+CONFIG_REPO_URL=$4
+CONFIG_REPO_PATH=$(readlink -f $5)
+CONFIG_INPUT="$6"
+
+EC2_INSTANCE_ID=$(wget -q -O - http://instance-data/latest/meta-data/instance-id)
+
+echo "Branch is $BRANCH"
+echo "Channel is $CHANNEL"
+echo ""
+echo "For this shell we are NOT creating an EC2 volume, instead you get to use"
+echo "/mnt/index-scratch which is the local (fast) SSD.  This got setup in main.sh."
+echo
+echo "Running indexer setup, but stopping before we upload anything."
+
+$MOZSEARCH_PATH/infrastructure/indexer-setup.sh $CONFIG_REPO_PATH $CONFIG_INPUT /mnt/index-scratch
+
+echo "Setup complete, go crazy."

--- a/infrastructure/aws/trigger_blame_rebuild.py
+++ b/infrastructure/aws/trigger_blame_rebuild.py
@@ -1,78 +1,23 @@
 #!/usr/bin/env python3
 
-import boto3
-from datetime import datetime, timedelta
-import sys
-import os.path
+from trigger_common import TriggerCommandBase
 
 # Usage: trigger_blame_rebuild.py <mozsearch-repo> <config-repo> <config-input> <branch> <channel>
 #  e.g.: trigger_blame_rebuild.py https://github.com/mozsearch/mozsearch https://github.com/mozsearch/mozsearch-mozilla config1.json master release
 
-def trigger(mozsearch_repo, config_repo, config_input, branch, channel):
-    ec2 = boto3.resource('ec2')
-    client = boto3.client('ec2')
+class TriggerReblameCommand(TriggerCommandBase):
+    def __init__(self):
+        timeout_hours = 7 * 24 # upper bound on how long we expect the blame-rebuild to take
+        super().__init__('blame-builder', 'rebuild-blame.sh', timeout_hours)
 
-    running = ec2.instances.filter(Filters=[{'Name': 'tag-key', 'Values': ['blame-builder']},
-                                           {'Name': 'tag:channel', 'Values': [channel]},
-                                           {'Name': 'instance-state-name', 'Values': ['running']}])
-    for instance in running:
-        print("Terminating existing running blame-rebuilder %s for channel %s" % (instance.instance_id, channel))
-        instance.terminate()
-
-    timeout_hours = 7 * 24 # upper bound on how long we expect the blame-rebuild to take
-    user_data = '''#!/usr/bin/env bash
-
-cd ~ubuntu
-sudo -i -u ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
-sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh rebuild-blame.sh "{timeout_hours}" "{branch}" "{channel}" config "{config_input}"
-'''.format(branch=branch, channel=channel, mozsearch_repo=mozsearch_repo, config_repo=config_repo, config_input=config_input, timeout_hours=timeout_hours)
-
-    block_devices = []
-
-    images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-20.04']}])
-    image_id = images['Images'][0]['ImageId']
-
-    launch_spec = {
-        'ImageId': image_id,
-        'KeyName': 'Main Key Pair',
-        'SecurityGroups': ['indexer-secure'],
-        'UserData': user_data,
-        'InstanceType': 'm5d.2xlarge',
-        'BlockDeviceMappings': block_devices,
-        'IamInstanceProfile': {
-            'Name': 'indexer-role',
-        },
-        'TagSpecifications': [{
-            'ResourceType': 'instance',
-            'Tags': [{
-                'Key': 'blame-builder',
-                'Value': str(datetime.now())
-            }, {
-                'Key': 'channel',
-                'Value': channel,
-            }, {
-                'Key': 'branch',
-                'Value': branch,
-            }, {
-                'Key': 'mrepo',
-                'Value': mozsearch_repo,
-            }, {
-                'Key': 'crepo',
-                'Value': config_repo,
-            }, {
-                'Key': 'cfile',
-                'Value': config_input,
-            }],
-        }],
-    }
-    return client.run_instances(MinCount=1, MaxCount=1, **launch_spec)
-
+    def script_args_after_branch_and_channel(self, args):
+        return '''config "{config_input}"'''.format(
+            mozsearch_repo=args.mozsearch_repo,
+            config_repo=args.config_repo,
+            config_input=args.config_input
+        )
 
 if __name__ == '__main__':
-    mozsearch_repo = sys.argv[1]
-    config_repo = sys.argv[2]
-    config_input = sys.argv[3]
-    branch = sys.argv[4]
-    channel = sys.argv[5]
-
-    trigger(mozsearch_repo, config_repo, config_input, branch, channel)
+    cmd = TriggerReblameCommand()
+    cmd.parse_args()
+    cmd.trigger()

--- a/infrastructure/aws/trigger_common.py
+++ b/infrastructure/aws/trigger_common.py
@@ -1,0 +1,151 @@
+import boto3
+import argparse
+from datetime import datetime, timedelta
+import sys
+import os.path
+
+# Usage: trigger_indexer.py <mozsearch-repo> <config-repo> <config-input> <branch> <channel>
+
+class TriggerCommandBase:
+    '''
+    Helper class for launching indexers to extract out the commonality.  This
+    doesn't need to get particularly complex.
+
+    The general idea for now is:
+    - If you have a new high-level action that wants to trigger an indexer,
+      create a new script like `trigger_indexer.py` that's a thin wrapper
+      around this class/module.
+    - Place logic that can be used across all VM variants in here, or specialize
+      in the subclass as appropriate.
+    '''
+    def __init__(self, indexer_type, core_script, max_runtime_hours):
+        self.indexer_type = indexer_type
+        self.core_script = core_script
+        self.max_runtime_hours = max_runtime_hours
+
+        self.args = None
+
+    def make_parser(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('mozsearch_repo')
+        parser.add_argument('config_repo')
+        parser.add_argument('config_input')
+        parser.add_argument('branch')
+        parser.add_argument('channel')
+
+        parser.add_argument('--verbose', '-v', action='count', default=0)
+
+        parser.add_argument('--setenv', dest='env_vars', action='append', default=[])
+
+        return parser
+
+    def parse_args(self):
+        parser = self.make_parser()
+        self.args = parser.parse_args()
+
+    def script_args_after_branch_and_channel(self, args):
+        '''
+        This method allows subclasses to contribute arguments to their script.
+        Note that all scripts will be provided with the branch and channel as
+        their first two arguments because `main.sh` needs this information and
+        assumes those arguments exist.
+
+        This method's return value is interpolated directly into the bash shell
+        script built by `trigger` without any escaping.  This means arguments
+        should probably be quoted and escaped as appropriate.
+        '''
+        return ""
+
+    def build_extra_commands(self, args):
+        '''
+        Builds a single command-string, including newlines, that will be
+        inserted into the bash shell script built by `trigger`.
+        '''
+        cmds = []
+
+        for setenv in args.env_vars:
+            cmds.append('export ' + setenv)
+
+        return "\n".join(cmds)
+
+    def trigger(self):
+        if self.args is None:
+            raise Exception('Arguments were not parsed first!')
+        args=self.args
+        extra_args = self.script_args_after_branch_and_channel(args)
+
+        extra_commands = self.build_extra_commands(args)
+
+        ec2 = boto3.resource('ec2')
+        client = boto3.client('ec2')
+
+        running = ec2.instances.filter(Filters=[{'Name': 'tag-key', 'Values': [self.indexer_type]},
+                                            {'Name': 'tag:channel', 'Values': [args.channel]},
+                                            {'Name': 'instance-state-name', 'Values': ['running']}])
+        for instance in running:
+            print("Terminating existing running %s %s for channel %s" % (self.indexer_type, instance.instance_id, args.channel))
+            instance.terminate()
+
+
+        user_data = '''#!/usr/bin/env bash
+
+    cd ~ubuntu
+    {extra_commands}
+    sudo -i -u ubuntu ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
+    sudo -i -u ubuntu mozsearch/infrastructure/aws/main.sh {core_script} {max_runtime_hours} "{branch}" "{channel}" {extra_args}
+    '''.format(
+        core_script=self.core_script,
+        max_runtime_hours=self.max_runtime_hours,
+        branch=args.branch,
+        channel=args.channel,
+        mozsearch_repo=args.mozsearch_repo,
+        config_repo=args.config_repo,
+        extra_commands=extra_commands,
+        extra_args=extra_args
+        )
+
+        block_devices = []
+
+        images = client.describe_images(Filters=[{'Name': 'name', 'Values': ['indexer-20.04']}])
+        image_id = images['Images'][0]['ImageId']
+
+        launch_spec = {
+            'ImageId': image_id,
+            'KeyName': 'Main Key Pair',
+            'SecurityGroups': ['indexer-secure'],
+            'UserData': user_data,
+            'InstanceType': 'm5d.2xlarge',
+            'BlockDeviceMappings': block_devices,
+            'IamInstanceProfile': {
+                'Name': 'indexer-role',
+            },
+            'TagSpecifications': [{
+                'ResourceType': 'instance',
+                'Tags': [{
+                    'Key': self.indexer_type,
+                    'Value': str(datetime.now())
+                }, {
+                    'Key': 'channel',
+                    'Value': args.channel,
+                }, {
+                    'Key': 'branch',
+                    'Value': args.branch,
+                }, {
+                    'Key': 'mrepo',
+                    'Value': args.mozsearch_repo,
+                }, {
+                    'Key': 'crepo',
+                    'Value': args.config_repo,
+                }, {
+                    'Key': 'cfile',
+                    'Value': args.config_input,
+                }],
+            }],
+        }
+
+        if args.verbose > 0:
+            print('Launch Spec:')
+            print(repr(launch_spec))
+
+        return client.run_instances(MinCount=1, MaxCount=1, **launch_spec)
+

--- a/infrastructure/aws/trigger_shell.py
+++ b/infrastructure/aws/trigger_shell.py
@@ -5,9 +5,10 @@ from trigger_common import TriggerCommandBase
 # Usage: trigger_indexer.py <mozsearch-repo> <config-repo> <config-input> <branch> <channel>
 
 
-class TriggerIndexerCommand(TriggerCommandBase):
+class TriggerShellCommand(TriggerCommandBase):
     def __init__(self):
-        super().__init__('indexer', 'index.sh', 10)
+        max_hours = 6
+        super().__init__('shell', 'shell-setup.sh', max_hours)
 
     def script_args_after_branch_and_channel(self, args):
         return '''"{mozsearch_repo}" "{config_repo}" config "{config_input}"'''.format(
@@ -17,6 +18,6 @@ class TriggerIndexerCommand(TriggerCommandBase):
         )
 
 if __name__ == '__main__':
-    cmd = TriggerIndexerCommand()
+    cmd = TriggerShellCommand()
     cmd.parse_args()
     cmd.trigger()


### PR DESCRIPTION
This patch adds a new `trigger_shell.py` command and extracts the duplicated
logic that existed between `trigger_indexer.py` and `trigger_blame_rebuild.py`
up into `trigger_common.py` which now uses argparse as an argument parser.

The primary motivation of the cleanup because optional arguments like `setenv`
seem useful across all indexer types.  This would also be the case for things
like allowing a command-line to override.

As hinted above, we also add arguments for:
- `--setenv` intended to be used like
  `--setenv TRYPUSH_REV=<40-char-rev-hash>`.
  - This specific try use-case is potentially a candidate for a custom arugment
    type perhaps with extra smarts.