### PR TITLE
Bug 1641372 - router.py python3 drift fixes

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -626,8 +626,8 @@ class Handler(six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler):
         are just a specialized sorch.
         '''
         j = get_json_sorch_results(tree_name, query)
-        if 'json' in self.headers.getheader('Accept', ''):
-                self.generate(j, 'application/json')
+        if 'json' in self.headers.get('Accept', ''):
+                self.generateJson(j)
         else:
             j = j.replace("</", "<\\/").replace("<script", "<\\script").replace("<!", "<\\!")
             template = os.path.join(index_path(tree_name), 'templates/sorch.html')
@@ -652,13 +652,13 @@ class Handler(six.moves.SimpleHTTPServer.SimpleHTTPRequestHandler):
                 self.generateWithTemplate({'{{BODY}}': j, '{{TITLE}}': 'Search'}, template)
         elif len(path_elts) >= 2 and path_elts[1] == 'sorch':
             tree_name = path_elts[0]
-            query = urlparse.parse_qs(url.query)
+            query = six.moves.urllib.parse.parse_qs(url.query)
             self._wrap_sorch_results(tree_name, query)
         # "symbol" is a variant on "define", but whereas "define" creates a
         # redirect, "symbol" is equivalent to source with "q=symbol:ORIGINAL_Q"
         elif len(path_elts) >= 2 and path_elts[1] == 'symbol':
             tree_name = path_elts[0]
-            orig_query = urlparse.parse_qs(url.query)
+            orig_query = six.moves.urllib.parse.parse_qs(url.query)
             symbol = orig_query['q'][0]
             new_query = { 'q': [ 'symbol:' + symbol ]}
             self._wrap_sorch_results(tree_name, new_query)


### PR DESCRIPTION
The fancy branch UI work all built on the "sorch" search endpoint which broke
with the change to python3 but I didn't notice it when rebasing because the
intent was not to surface any of the fancy UI and so it didn't get tested
(and there currently is not test coverage for router.py).

These changes are to account for changes to urlparse that were made by six
and the minor method change introducing `generateJson`.

With these fixes it should now be possible to run (outside of the VM) on a
machine with the VM running the following and see something almost useful:

```
curl -H "Accept: application/json" 'http://localhost:16995/tests/sorch?q=superhero&path=' | jq .
```