### PR TITLE
Bug 1728294 - Use the nightly+release rust build configuration for te…

### DIFF
--- a/scripts/check-index.sh
+++ b/scripts/check-index.sh
@@ -25,14 +25,14 @@ then
       SEARCHFOX_SERVER=${CONFIG_FILE} \
       SEARCHFOX_TREE=${TREE_NAME} \
       CHECK_ROOT=${CONFIG_REPO}/${TREE_NAME}/checks \
-      cargo test --manifest-path ${MOZSEARCH_PATH}/tools/Cargo.toml test_check_glob
+      cargo +nightly test --release --manifest-path ${MOZSEARCH_PATH}/tools/Cargo.toml test_check_glob
   fi
   if [[ $CHECK_SERVER_URL ]]; then
     RUST_BACKTRACE=1 \
       SEARCHFOX_SERVER="$CHECK_SERVER_URL" \
       SEARCHFOX_TREE=${TREE_NAME} \
       CHECK_ROOT=${CONFIG_REPO}/${TREE_NAME}/checks \
-      cargo test --manifest-path ${MOZSEARCH_PATH}/tools/Cargo.toml test_check_glob
+      cargo +nightly test --release --manifest-path ${MOZSEARCH_PATH}/tools/Cargo.toml test_check_glob
   fi
   #$CONFIG_REPO/$TREE_NAME/check "$MOZSEARCH_PATH/scripts/check-helper.sh" "$CHECK_DISK" "$CHECK_SERVER_URL"
 fi


### PR DESCRIPTION
…sting

This avoids rebuilding all the rust code in a new configuration,
since it's already built in the nightly+release configuration for
other stuff.