### PR TITLE
Bug 1728376 - Show related symbols in search results with search upsell

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1612,7 +1612,8 @@ public:
         wasTemplate = true;
         D = D2->getTemplateInstantiationPattern();
       }
-      Kind = D2->isThisDeclarationADefinition() ? "def" : "decl";
+      // We treat pure virtual declarations as definitions.
+      Kind = (D2->isThisDeclarationADefinition() || D2->isPure()) ? "def" : "decl";
       PrettyKind = "function";
       PeekRange = getFunctionPeekRange(D2);
 
@@ -1740,7 +1741,7 @@ public:
       }
     }
     if (FunctionDecl *D2 = dyn_cast<FunctionDecl>(D)) {
-      if (D2->isThisDeclarationADefinition() &&
+      if ((D2->isThisDeclarationADefinition() || D2->isPure()) &&
           // a clause at the top should have generalized and set wasTemplate so
           // it shouldn't be the case that isTemplateInstantiation() is true.
           !D2->isTemplateInstantiation() &&

--- a/router/crossrefs.py
+++ b/router/crossrefs.py
@@ -68,9 +68,12 @@ def lookup_merging(tree_name, symbols):
         result = json.loads(data)
 
         for (k, v) in result.items():
-            if k == 'meta' or k == 'callees':
+            if k == 'callees':
                 continue
-            results[k] = results.get(k, []) + result[k]
+            # expand_keys now expects aggregated meta, so wrap the meta obj.
+            if k == 'meta':
+                v = [v]
+            results[k] = results.get(k, []) + v
 
     return results
 

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -339,6 +339,11 @@ tr.after-context-line + tr.before-context-line {
   color: royalblue;
 }
 
+.result-upsearch {
+  padding-left: 8px;
+  color: blue;
+}
+
 .section {
   text-align: right;
   font-size: 150%;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -262,6 +262,10 @@ function populateResults(data, full, jumpToSingle) {
     return "/" + Dxr.tree + "/source/" + path;
   }
 
+  function makeSearchUrl(q) {
+    return `/${Dxr.tree}/search?q=${encodeURIComponent(q)}`;
+  }
+
   function chooseIcon(path) {
     var suffix = path.lastIndexOf(".");
     if (suffix == -1) {
@@ -374,6 +378,11 @@ function populateResults(data, full, jumpToSingle) {
         " <span class='result-context'>// found in <code>" +
         inside +
         "</code></span>";
+    }
+
+    // Hacky attempt to provide a means of providing related searches.
+    if (line.upsearch) {
+      html += `<span class='result-upsearch'><a href="${makeSearchUrl(line.upsearch)}">Symbol Search This</a></span>`;
     }
 
     html += "</td>";

--- a/tests/tests/checks/inputs/cpp__big_cpp_cpp__structured_abstractart_beart__json
+++ b/tests/tests/checks/inputs/cpp__big_cpp_cpp__structured_abstractart_beart__json
@@ -1,0 +1,1 @@
+filter-analysis big_cpp.cpp -r structured -i outerNS::AbstractArt::beArt

--- a/tests/tests/checks/inputs/cpp__big_cpp_cpp__structured_practicalart_beart__json
+++ b/tests/tests/checks/inputs/cpp__big_cpp_cpp__structured_practicalart_beart__json
@@ -1,0 +1,1 @@
+filter-analysis big_cpp.cpp -r structured -i outerNS::PracticalArt::beArt

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
@@ -1,0 +1,6 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+
+---
+[]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
@@ -3,4 +3,19 @@ source: tests/test_check_insta.rs
 expression: "&json_results"
 
 ---
-[]
+[
+  {
+    "kind": "method",
+    "loc": "00424:15-20",
+    "overrides": [],
+    "parentsym": "T_outerNS::AbstractArt",
+    "pretty": "outerNS::AbstractArt::beArt",
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ],
+    "structured": 1,
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv"
+  }
+]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_practicalart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_practicalart_beart__json.snap
@@ -1,0 +1,26 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+
+---
+[
+  {
+    "kind": "method",
+    "loc": "00433:7-12",
+    "overrides": [
+      {
+        "pretty": "outerNS::AbstractArt::beArt",
+        "sym": "_ZN7outerNS11AbstractArt5beArtEv"
+      }
+    ],
+    "parentsym": "T_outerNS::PracticalArt",
+    "pretty": "outerNS::PracticalArt::beArt",
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ],
+    "structured": 1,
+    "sym": "_ZN7outerNS12PracticalArt5beArtEv"
+  }
+]

--- a/tests/tests/files/big_cpp.cpp
+++ b/tests/tests/files/big_cpp.cpp
@@ -412,6 +412,31 @@ class OuterCat : Thing {
   }
 };
 
+#define ART_HP 100
+
+class AbstractArt : public Thing {
+public:
+  AbstractArt()
+  : Thing(ART_HP) {}
+
+  // This pure virtual method needs to be treated like a definition for our
+  // structured record emission purposes.
+  virtual void beArt() = 0;
+};
+
+class PracticalArt : public AbstractArt {
+public:
+  PracticalArt()
+  : AbstractArt() {}
+
+  // This should properly see the beArt as something it's overriding.
+  void beArt() override {
+    // Apprecaite in value!
+    mHP++;
+  }
+};
+
+
 namespace innerNS {
 
 class InnerCat {


### PR DESCRIPTION
Here's a candidate fix for the regression in being able to see overridden
methods.