### PR TITLE
Bug 1729178 - Enable serde_json preserve_order feature

### DIFF
--- a/tests/tests/checks/snapshots/check_glob@cpp__atom_list_h__structured_yo_atoms_foo_string_json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__atom_list_h__structured_yo_atoms_foo_string_json.snap
@@ -5,11 +5,11 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "field",
     "loc": "00004:0-7",
-    "parentsym": "T_YoAtoms",
-    "pretty": "YoAtoms::Foo_string",
     "structured": 1,
-    "sym": "F_<T_YoAtoms>_Foo_string"
+    "pretty": "YoAtoms::Foo_string",
+    "sym": "F_<T_YoAtoms>_Foo_string",
+    "kind": "field",
+    "parentsym": "T_YoAtoms"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__def_thing__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__def_thing__json.snap
@@ -6,18 +6,18 @@ expression: "&json_results"
 [
   {
     "loc": "00135:6-11",
-    "nestingRange": "135:12-164:0",
-    "pretty": "type outerNS::Thing",
     "source": 1,
-    "sym": "T_outerNS::Thing",
-    "syntax": "def,type"
+    "nestingRange": "135:12-164:0",
+    "syntax": "def,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing"
   },
   {
-    "kind": "def",
     "loc": "00135:6-11",
-    "peekRange": "135-135",
+    "target": 1,
+    "kind": "def",
     "pretty": "outerNS::Thing",
     "sym": "T_outerNS::Thing",
-    "target": 1
+    "peekRange": "135-135"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__json.snap
@@ -6,16 +6,16 @@ expression: "&json_results"
 [
   {
     "loc": "00020:9-23",
-    "pretty": "file big_header.h",
     "source": 1,
-    "sym": "FILE_big_header@2Eh",
-    "syntax": "use,file"
+    "syntax": "use,file",
+    "pretty": "file big_header.h",
+    "sym": "FILE_big_header@2Eh"
   },
   {
-    "kind": "use",
     "loc": "00020:9-23",
+    "target": 1,
+    "kind": "use",
     "pretty": "big_header.h",
-    "sym": "FILE_big_header@2Eh",
-    "target": 1
+    "sym": "FILE_big_header@2Eh"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_abstractart_beart__json.snap
@@ -5,17 +5,17 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "method",
     "loc": "00424:15-20",
-    "overrides": [],
-    "parentsym": "T_outerNS::AbstractArt",
+    "structured": 1,
     "pretty": "outerNS::AbstractArt::beArt",
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::AbstractArt",
+    "overrides": [],
     "props": [
       "instance",
       "virtual",
       "user"
-    ],
-    "structured": 1,
-    "sym": "_ZN7outerNS11AbstractArt5beArtEv"
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_globalcontext__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_globalcontext__json.snap
@@ -5,55 +5,55 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [],
-    "kind": "class",
     "loc": "00024:6-19",
+    "structured": 1,
+    "pretty": "GlobalContext",
+    "sym": "T_GlobalContext",
+    "kind": "class",
+    "sizeBytes": 1,
+    "supers": [],
     "methods": [
       {
         "pretty": "GlobalContext::decideBooleanTrait",
+        "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext18decideBooleanTraitEv"
+        ]
       },
       {
         "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+        "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv"
+        ]
       },
       {
         "pretty": "GlobalContext::decideCatBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv"
+        ]
       },
       {
         "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+        "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv"
+        ]
       },
       {
         "pretty": "GlobalContext::decideDogBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv"
+        ]
       }
     ],
-    "pretty": "GlobalContext",
-    "sizeBytes": 1,
-    "structured": 1,
-    "supers": [],
-    "sym": "T_GlobalContext"
+    "fields": []
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_human__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_human__json.snap
@@ -5,71 +5,71 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [],
-    "kind": "class",
     "loc": "00179:6-11",
-    "methods": [
-      {
-        "pretty": "outerNS::Human::Human",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS5HumanC1Ev"
-      },
-      {
-        "pretty": "outerNS::Human::operator=",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS5HumanaSERKS0_"
-      },
-      {
-        "pretty": "outerNS::Human::operator=",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS5HumanaSEOS0_"
-      },
-      {
-        "pretty": "outerNS::Human::~Human",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS5HumanD1Ev"
-      },
-      {
-        "pretty": "outerNS::Human::Human",
-        "props": [
-          "instance",
-          "defaulted",
-          "constexpr"
-        ],
-        "sym": "_ZN7outerNS5HumanC1ERKS0_"
-      },
-      {
-        "pretty": "outerNS::Human::Human",
-        "props": [
-          "instance",
-          "defaulted",
-          "constexpr"
-        ],
-        "sym": "_ZN7outerNS5HumanC1EOS0_"
-      }
-    ],
-    "pretty": "outerNS::Human",
-    "sizeBytes": 16,
     "structured": 1,
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "kind": "class",
+    "sizeBytes": 16,
     "supers": [
       {
         "pretty": "outerNS::Thing",
-        "props": [],
-        "sym": "T_outerNS::Thing"
+        "sym": "T_outerNS::Thing",
+        "props": []
       }
     ],
-    "sym": "T_outerNS::Human"
+    "methods": [
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1Ev",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::operator=",
+        "sym": "_ZN7outerNS5HumanaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::operator=",
+        "sym": "_ZN7outerNS5HumanaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::~Human",
+        "sym": "_ZN7outerNS5HumanD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1ERKS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1EOS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      }
+    ],
+    "fields": []
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_lessglobalcontext__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_lessglobalcontext__json.snap
@@ -5,23 +5,23 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [],
-    "kind": "class",
     "loc": "00075:8-25",
+    "structured": 1,
+    "pretty": "GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "kind": "class",
+    "sizeBytes": 1,
+    "supers": [],
     "methods": [
       {
         "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+        "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
         "props": [
           "static",
           "user"
-        ],
-        "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv"
+        ]
       }
     ],
-    "pretty": "GlobalContext::LessGlobalContext",
-    "sizeBytes": 1,
-    "structured": 1,
-    "supers": [],
-    "sym": "T_GlobalContext::LessGlobalContext"
+    "fields": []
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_lessglobalcontext_decidewhethertodecide__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_lessglobalcontext_decidewhethertodecide__json.snap
@@ -5,16 +5,16 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "method",
     "loc": "00087:4-25",
-    "overrides": [],
-    "parentsym": "T_GlobalContext::LessGlobalContext",
+    "structured": 1,
     "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext::LessGlobalContext",
+    "overrides": [],
     "props": [
       "static",
       "user"
-    ],
-    "structured": 1,
-    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv"
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_outercat__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_outercat__json.snap
@@ -5,124 +5,124 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [
-      {
-        "offsetBytes": 13,
-        "pretty": "outerNS::OuterCat::mIsFriendly",
-        "sizeBytes": 1,
-        "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
-        "type": "_Bool"
-      },
-      {
-        "offsetBytes": 14,
-        "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
-        "sizeBytes": 1,
-        "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
-        "type": "_Bool"
-      }
-    ],
-    "kind": "class",
     "loc": "00221:6-14",
-    "methods": [
-      {
-        "pretty": "outerNS::OuterCat::OuterCat",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCatC1Ebb"
-      },
-      {
-        "pretty": "outerNS::OuterCat::isFriendlyCat",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv"
-      },
-      {
-        "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv"
-      },
-      {
-        "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv"
-      },
-      {
-        "pretty": "outerNS::OuterCat::meet",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE"
-      },
-      {
-        "pretty": "outerNS::OuterCat::meet",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
-      },
-      {
-        "pretty": "outerNS::OuterCat::shred",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
-      },
-      {
-        "pretty": "outerNS::OuterCat::destroy",
-        "props": [
-          "instance",
-          "user"
-        ],
-        "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
-      },
-      {
-        "pretty": "outerNS::OuterCat::operator=",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS8OuterCataSERKS0_"
-      },
-      {
-        "pretty": "outerNS::OuterCat::operator=",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS8OuterCataSEOS0_"
-      },
-      {
-        "pretty": "outerNS::OuterCat::~OuterCat",
-        "props": [
-          "instance",
-          "defaulted"
-        ],
-        "sym": "_ZN7outerNS8OuterCatD1Ev"
-      }
-    ],
-    "pretty": "outerNS::OuterCat",
-    "sizeBytes": 16,
     "structured": 1,
+    "pretty": "outerNS::OuterCat",
+    "sym": "T_outerNS::OuterCat",
+    "kind": "class",
+    "sizeBytes": 16,
     "supers": [
       {
         "pretty": "outerNS::Thing",
-        "props": [],
-        "sym": "T_outerNS::Thing"
+        "sym": "T_outerNS::Thing",
+        "props": []
       }
     ],
-    "sym": "T_outerNS::OuterCat"
+    "methods": [
+      {
+        "pretty": "outerNS::OuterCat::OuterCat",
+        "sym": "_ZN7outerNS8OuterCatC1Ebb",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isFriendlyCat",
+        "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+        "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+        "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::meet",
+        "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::meet",
+        "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::shred",
+        "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::destroy",
+        "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::operator=",
+        "sym": "_ZN7outerNS8OuterCataSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::operator=",
+        "sym": "_ZN7outerNS8OuterCataSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::~OuterCat",
+        "sym": "_ZN7outerNS8OuterCatD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "pretty": "outerNS::OuterCat::mIsFriendly",
+        "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+        "type": "_Bool",
+        "offsetBytes": 13,
+        "sizeBytes": 1
+      },
+      {
+        "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+        "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+        "type": "_Bool",
+        "offsetBytes": 14,
+        "sizeBytes": 1
+      }
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_practicalart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_practicalart_beart__json.snap
@@ -5,22 +5,22 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "method",
     "loc": "00433:7-12",
+    "structured": 1,
+    "pretty": "outerNS::PracticalArt::beArt",
+    "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::PracticalArt",
     "overrides": [
       {
         "pretty": "outerNS::AbstractArt::beArt",
         "sym": "_ZN7outerNS11AbstractArt5beArtEv"
       }
     ],
-    "parentsym": "T_outerNS::PracticalArt",
-    "pretty": "outerNS::PracticalArt::beArt",
     "props": [
       "instance",
       "virtual",
       "user"
-    ],
-    "structured": 1,
-    "sym": "_ZN7outerNS12PracticalArt5beArtEv"
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_superhero__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_superhero__json.snap
@@ -5,80 +5,80 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [],
-    "kind": "class",
     "loc": "00188:6-15",
+    "structured": 1,
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "kind": "class",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Human",
+        "sym": "T_outerNS::Human",
+        "props": []
+      }
+    ],
     "methods": [
       {
         "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1Ev",
         "props": [
           "instance",
           "user"
-        ],
-        "sym": "_ZN7outerNS9SuperheroC1Ev"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::takeDamage",
+        "sym": "_ZN7outerNS9Superhero10takeDamageEi",
         "props": [
           "instance",
           "virtual",
           "user"
-        ],
-        "sym": "_ZN7outerNS9Superhero10takeDamageEi"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSERKS0_",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS9SuperheroaSERKS0_"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSEOS0_",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS9SuperheroaSEOS0_"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::~Superhero",
+        "sym": "_ZN7outerNS9SuperheroD1Ev",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS9SuperheroD1Ev"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1ERKS0_",
         "props": [
           "instance",
           "defaulted",
           "constexpr"
-        ],
-        "sym": "_ZN7outerNS9SuperheroC1ERKS0_"
+        ]
       },
       {
         "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1EOS0_",
         "props": [
           "instance",
           "defaulted",
           "constexpr"
-        ],
-        "sym": "_ZN7outerNS9SuperheroC1EOS0_"
+        ]
       }
     ],
-    "pretty": "outerNS::Superhero",
-    "sizeBytes": 16,
-    "structured": 1,
-    "supers": [
-      {
-        "pretty": "outerNS::Human",
-        "props": [],
-        "sym": "T_outerNS::Human"
-      }
-    ],
-    "sym": "T_outerNS::Superhero"
+    "fields": []
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_superhero_takedamage__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_superhero_takedamage__json.snap
@@ -5,22 +5,22 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "method",
     "loc": "00196:7-17",
+    "structured": 1,
+    "pretty": "outerNS::Superhero::takeDamage",
+    "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+    "kind": "method",
+    "parentsym": "T_outerNS::Superhero",
     "overrides": [
       {
         "pretty": "outerNS::Thing::takeDamage",
         "sym": "_ZN7outerNS5Thing10takeDamageEi"
       }
     ],
-    "parentsym": "T_outerNS::Superhero",
-    "pretty": "outerNS::Superhero::takeDamage",
     "props": [
       "instance",
       "virtual",
       "user"
-    ],
-    "structured": 1,
-    "sym": "_ZN7outerNS9Superhero10takeDamageEi"
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_thing__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_thing__json.snap
@@ -5,97 +5,97 @@ expression: "&json_results"
 ---
 [
   {
-    "fields": [
-      {
-        "offsetBytes": 8,
-        "pretty": "outerNS::Thing::mHP",
-        "sizeBytes": 4,
-        "sym": "F_<T_outerNS::Thing>_mHP",
-        "type": "int"
-      },
-      {
-        "offsetBytes": 12,
-        "pretty": "outerNS::Thing::mDefunct",
-        "sizeBytes": 1,
-        "sym": "F_<T_outerNS::Thing>_mDefunct",
-        "type": "_Bool"
-      }
-    ],
-    "kind": "class",
     "loc": "00135:6-11",
+    "structured": 1,
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "kind": "class",
+    "sizeBytes": 16,
+    "supers": [],
     "methods": [
       {
         "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1Ei",
         "props": [
           "instance",
           "user"
-        ],
-        "sym": "_ZN7outerNS5ThingC1Ei"
+        ]
       },
       {
         "pretty": "outerNS::Thing::ignore",
+        "sym": "_ZN7outerNS5Thing6ignoreEv",
         "props": [
           "instance",
           "user"
-        ],
-        "sym": "_ZN7outerNS5Thing6ignoreEv"
+        ]
       },
       {
         "pretty": "outerNS::Thing::takeDamage",
+        "sym": "_ZN7outerNS5Thing10takeDamageEi",
         "props": [
           "instance",
           "virtual",
           "user"
-        ],
-        "sym": "_ZN7outerNS5Thing10takeDamageEi"
+        ]
       },
       {
         "pretty": "outerNS::Thing::operator=",
+        "sym": "_ZN7outerNS5ThingaSERKS0_",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS5ThingaSERKS0_"
+        ]
       },
       {
         "pretty": "outerNS::Thing::operator=",
+        "sym": "_ZN7outerNS5ThingaSEOS0_",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS5ThingaSEOS0_"
+        ]
       },
       {
         "pretty": "outerNS::Thing::~Thing",
+        "sym": "_ZN7outerNS5ThingD1Ev",
         "props": [
           "instance",
           "defaulted"
-        ],
-        "sym": "_ZN7outerNS5ThingD1Ev"
+        ]
       },
       {
         "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1ERKS0_",
         "props": [
           "instance",
           "defaulted",
           "constexpr"
-        ],
-        "sym": "_ZN7outerNS5ThingC1ERKS0_"
+        ]
       },
       {
         "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1EOS0_",
         "props": [
           "instance",
           "defaulted",
           "constexpr"
-        ],
-        "sym": "_ZN7outerNS5ThingC1EOS0_"
+        ]
       }
     ],
-    "pretty": "outerNS::Thing",
-    "sizeBytes": 16,
-    "structured": 1,
-    "supers": [],
-    "sym": "T_outerNS::Thing"
+    "fields": [
+      {
+        "pretty": "outerNS::Thing::mHP",
+        "sym": "F_<T_outerNS::Thing>_mHP",
+        "type": "int",
+        "offsetBytes": 8,
+        "sizeBytes": 4
+      },
+      {
+        "pretty": "outerNS::Thing::mDefunct",
+        "sym": "F_<T_outerNS::Thing>_mDefunct",
+        "type": "_Bool",
+        "offsetBytes": 12,
+        "sizeBytes": 1
+      }
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_thing_takedamage__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__structured_thing_takedamage__json.snap
@@ -5,17 +5,17 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "method",
     "loc": "00156:15-25",
-    "overrides": [],
-    "parentsym": "T_outerNS::Thing",
+    "structured": 1,
     "pretty": "outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "overrides": [],
     "props": [
       "instance",
       "virtual",
       "user"
-    ],
-    "structured": 1,
-    "sym": "_ZN7outerNS5Thing10takeDamageEi"
+    ]
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__json.snap
@@ -6,16 +6,16 @@ expression: "&json_results"
 [
   {
     "loc": "00001:0",
-    "pretty": "file big_header.h",
     "source": 1,
-    "sym": "FILE_big_header@2Eh",
-    "syntax": "def,file"
+    "syntax": "def,file",
+    "pretty": "file big_header.h",
+    "sym": "FILE_big_header@2Eh"
   },
   {
-    "kind": "def",
     "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
     "pretty": "big_header.h",
-    "sym": "FILE_big_header@2Eh",
-    "target": 1
+    "sym": "FILE_big_header@2Eh"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00014:11-17",
+    "target": 1,
+    "kind": "def",
     "pretty": "test_rust_dependency::<MyType>::do_foo",
-    "sym": "test_rust_dependency::<MyType>::do_foo",
-    "target": 1
+    "sym": "test_rust_dependency::<MyType>::do_foo"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00002:11-24",
+    "target": 1,
+    "kind": "def",
     "pretty": "simple::build_time_generated::GeneratedType",
-    "sym": "simple::build_time_generated::GeneratedType",
-    "target": 1
+    "sym": "simple::build_time_generated::GeneratedType"
   }
 ]

--- a/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__json.snap
@@ -5,10 +5,10 @@ expression: "&json_results"
 ---
 [
   {
-    "kind": "def",
     "loc": "00037:11-14",
+    "target": 1,
+    "kind": "def",
     "pretty": "simple::<Loader>::new",
-    "sym": "simple::<Loader>::new",
-    "target": 1
+    "sym": "simple::<Loader>::new"
   }
 ]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -42,22 +42,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
-
-[[package]]
-name = "arrayvec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
-
-[[package]]
 name = "ascii-canvas"
-version = "2.0.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8eb72df928aafb99fe5d37b383f2fe25bd2a765e3e5f7c365916b6f2463a29"
+checksum = "8824ecca2e851cec16968d54a01dd372ef8f95b244fb84b84e70128be347c3c6"
 dependencies = [
  "term",
 ]
@@ -134,38 +122,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "blake2b_simd"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
-dependencies = [
- "arrayref",
- "arrayvec",
- "constant_time_eq",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array",
-]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
 name = "bstr"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,12 +135,6 @@ name = "bumpalo"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -248,7 +198,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -277,12 +227,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
-
-[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -308,15 +252,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.4"
+name = "crunchy"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feb231f0d4d6af81aed15928e58ecf5816aa62a2393e2c82f46973e92a9a278"
-dependencies = [
- "autocfg 1.0.1",
- "cfg-if 1.0.0",
- "lazy_static",
-]
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cssparser"
@@ -368,35 +307,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 
 [[package]]
-name = "digest"
-version = "0.8.1"
+name = "dirs-next"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "generic-array",
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
 ]
 
 [[package]]
-name = "dirs"
-version = "1.0.5"
+name = "dirs-sys-next"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fd78930633bd1c6e35c4b42b1df7b0cbc6bc191146e512bb3bedf243fcc3901"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
  "winapi 0.3.9",
-]
-
-[[package]]
-name = "docopt"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f3f119846c823f9eafcf953a8f6ffb6ed69bf6240883261a7f13b634579a51f"
-dependencies = [
- "lazy_static",
- "regex 1.5.4",
- "serde",
- "strsim 0.10.0",
 ]
 
 [[package]]
@@ -422,9 +350,9 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "ena"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8944dc8fa28ce4a38f778bd46bf7d923fe73eed5a439398507246c8e017e6f36"
+checksum = "d7402b94a93c24e742487327a7cd839dc9d36fec9de9fb25b09f2dae459f36c3"
 dependencies = [
  "log 0.4.14",
 ]
@@ -458,16 +386,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fixedbitset"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
+checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "flate2"
@@ -601,15 +523,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
-]
-
-[[package]]
 name = "getopts"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,24 +533,13 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
- "wasi 0.10.2+wasi-snapshot-preview1",
+ "wasi",
 ]
 
 [[package]]
@@ -906,6 +808,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69ddb889f9d0d08a67338271fa9b62996bc788c7796a5c18cf057420aaed5eaf"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,34 +879,32 @@ dependencies = [
 
 [[package]]
 name = "lalrpop"
-version = "0.18.1"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5e019883a6e9734d093f34216a3857160c6bc2a9a1ec196a177aaa737c74af"
+checksum = "b15174f1c529af5bf1283c3bc0058266b483a67156f79589fab2a25e23cf8988"
 dependencies = [
  "ascii-canvas",
  "atty",
  "bit-set",
  "diff",
- "docopt",
  "ena",
- "itertools 0.8.2",
+ "itertools 0.10.1",
  "lalrpop-util",
  "petgraph",
+ "pico-args",
  "regex 1.5.4",
  "regex-syntax 0.6.25",
- "serde",
- "serde_derive",
- "sha2",
  "string_cache",
  "term",
+ "tiny-keccak",
  "unicode-xid",
 ]
 
 [[package]]
 name = "lalrpop-util"
-version = "0.18.1"
+version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6e9bc1801eb54529fd6a020aaf9514e8193bb6b42d96d0fe7da99187efa93d"
+checksum = "d3e58cce361efcc90ba8a0a5f982c741ff86b603495bb15a998412e957dcd278"
 dependencies = [
  "regex 1.5.4",
 ]
@@ -1317,12 +1226,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
-
-[[package]]
 name = "openssl"
 version = "0.10.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1356,12 +1259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-
-[[package]]
 name = "percent-encoding"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,12 +1272,12 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "petgraph"
-version = "0.4.13"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
  "fixedbitset",
- "ordermap",
+ "indexmap",
 ]
 
 [[package]]
@@ -1389,7 +1286,7 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3da44b85f8e8dfaec21adae67f95d93244b2ecf6ad2a692320598dcc8e6dd18"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
 ]
 
 [[package]]
@@ -1399,7 +1296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.7.24",
 ]
 
 [[package]]
@@ -1408,7 +1305,7 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.7.24",
  "rand 0.6.5",
 ]
 
@@ -1418,8 +1315,23 @@ version = "0.7.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
 dependencies = [
- "siphasher",
+ "siphasher 0.2.3",
 ]
+
+[[package]]
+name = "phf_shared"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
+dependencies = [
+ "siphasher 0.3.7",
+]
+
+[[package]]
+name = "pico-args"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8bcd96cb740d03149cbad5518db9fd87126a10ab519c011893b1754134c468"
 
 [[package]]
 name = "pin-project"
@@ -1597,7 +1509,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
- "getrandom 0.2.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1682,12 +1594,6 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
-
-[[package]]
-name = "redox_syscall"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "742739e41cd49414de871ea5e549afb7e2a3ac77b589bcbebe8c82fab37147fc"
@@ -1697,13 +1603,12 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
+checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
 dependencies = [
- "getrandom 0.1.16",
- "redox_syscall 0.1.57",
- "rust-argon2",
+ "getrandom",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -1825,22 +1730,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-argon2"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
-dependencies = [
- "base64 0.13.0",
- "blake2b_simd",
- "constant_time_eq",
- "crossbeam-utils",
-]
-
-[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+
+[[package]]
+name = "rustversion"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
 
 [[package]]
 name = "ryu"
@@ -1941,6 +1840,7 @@ version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
+ "indexmap",
  "itoa",
  "ryu",
  "serde",
@@ -1981,18 +1881,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer",
- "digest",
- "fake-simd",
- "opaque-debug",
-]
-
-[[package]]
 name = "shell-words"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2009,6 +1897,12 @@ name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
+
+[[package]]
+name = "siphasher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "533494a8f9b724d33625ab53c6c4800f7cc445895924a8ef649222dcb76e938b"
 
 [[package]]
 name = "slab"
@@ -2043,49 +1937,21 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "string_cache"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89c058a82f9fd69b1becf8c274f412281038877c553182f1d02eb027045a2d67"
+checksum = "8ddb1139b5353f96e429e1a5e19fbaf663bddedaa06d1dbd49f82e352601209a"
 dependencies = [
  "lazy_static",
  "new_debug_unreachable",
- "phf_shared",
+ "phf_shared 0.8.0",
  "precomputed-hash",
- "serde",
- "string_cache_codegen",
- "string_cache_shared",
 ]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f45ed1b65bf9a4bf2f7b7dc59212d1926e9eaf00fa998988e420fd124467c6"
-dependencies = [
- "phf_generator",
- "phf_shared",
- "proc-macro2",
- "quote",
- "string_cache_shared",
-]
-
-[[package]]
-name = "string_cache_shared"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 
 [[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "structopt"
@@ -2143,19 +2009,19 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.8",
+ "redox_syscall",
  "remove_dir_all",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "term"
-version = "0.5.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd106a334b7657c10b7c540a0106114feadeb4dc314513e97df481d5d966f42"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
- "byteorder",
- "dirs",
+ "dirs-next",
+ "rustversion",
  "winapi 0.3.9",
 ]
 
@@ -2230,6 +2096,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -2391,12 +2266,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 
 [[package]]
-name = "typenum"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
-
-[[package]]
 name = "ucd-util"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2526,12 +2395,6 @@ dependencies = [
  "log 0.4.14",
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,7 +34,7 @@ rls-analysis = "0.18.1"
 rls-data = "0.19.1"
 rustc-serialize = "0.3.18"
 shell-words = "1.0.0"
-serde_json = "1.0.64"
+serde_json = { version = "1.0.64", features = ["preserve_order"] }
 structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 url = "2.2.2"


### PR DESCRIPTION
By default serde-json re-orders objects alphabetically because it uses a
BTreeMap under the hood.  By enabling "preserve_order" an IndexMap is
used instead which maintains the ordering.

This commit enables preserve_order because router.py emits an explicitly
ordered object dictionary and so we need that order reflected in testing.

This results in changes to all the test snapshots, so this commit only
makes this change and commits those changes.

This will have a corresponding change in mozsearch-mozilla very shortly.