### PR TITLE
Bug 1721037 - channel-tool should not get mad at channel-less provisioners

### DIFF
--- a/infrastructure/aws/channel-tool.py
+++ b/infrastructure/aws/channel-tool.py
@@ -160,7 +160,7 @@ class ChannelHelper:
                 'target_groups': [],
             }
 
-            channel = get_channel(tags['channel'])
+            channel = get_channel(tags.get('channel', 'None'))
             channel['instances'].append(irep)
 
         # The sub-domains live as "resource record sets" under the


### PR DESCRIPTION
The provisioners currently don't get marked with channel tags which made the
channel-tool.py script sad.  This makes it treat them as having a channel of
"None" which will bring joy to everyone as they assume the `None` value is
being coerced into be a `"None"` string when in fact it's just the exact
string value I chose... mainly due to VSCode automagically wrapping things in
paired quotes when you type the first quote.