### PR TITLE
Bug 1738166 - Add a production-filter command to searchfox-tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,8 @@ check-test-repo:
 #
 # Depends on `cargo install cargo-insta`.
 review-test-repo:
+	/vagrant/infrastructure/web-server-setup.sh /vagrant/tests config.json ~/index ~
+	/vagrant/infrastructure/web-server-run.sh /vagrant/tests ~/index ~ WAIT
 	INSTA_FORCE_PASS=1 /vagrant/infrastructure/web-server-check.sh /vagrant/tests ~/index "http://localhost/"
 	cargo insta review --workspace-root=/vagrant/tests/
 

--- a/tests/tests/checks/inputs/cpp__big_cpp_cpp__include_big_header__prodhtml
+++ b/tests/tests/checks/inputs/cpp__big_cpp_cpp__include_big_header__prodhtml
@@ -1,0 +1,1 @@
+filter-analysis big_cpp.cpp -s FILE_big_header@2Eh | show-html | production-filter

--- a/tests/tests/checks/inputs/cpp__big_cpp_cpp__include_big_header__prodjson
+++ b/tests/tests/checks/inputs/cpp__big_cpp_cpp__include_big_header__prodjson
@@ -1,0 +1,1 @@
+filter-analysis big_cpp.cpp -s FILE_big_header@2Eh | production-filter

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__html.snap
@@ -4,6 +4,8 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-20" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="20"></div>
   <code role="cell" class="source-line"><span class="syn_reserved" >#include</span> <span class="syn_string" data-symbols="FILE_big_header@2Eh" data-i="0" >"big_header.h"</span>
 </code>

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__prodhtml.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__prodhtml.snap
@@ -1,0 +1,13 @@
+---
+source: tests/test_check_insta.rs
+expression: "&aggr_str"
+
+---
+<div role="row" id="line-NORM" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="NORM"></div>
+  <code role="cell" class="source-line"><span class="syn_reserved" >#include</span> <span class="syn_string" data-symbols="FILE_big_header@2Eh" data-i="NORM">"big_header.h"</span>
+</code>
+</div>
+

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__prodjson.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_cpp_cpp__include_big_header__prodjson.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+
+---
+[
+  {
+    "loc": "NORM:9-23",
+    "source": 1,
+    "syntax": "use,file",
+    "pretty": "file big_header.h",
+    "sym": "FILE_big_header@2Eh"
+  },
+  {
+    "loc": "NORM:9-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "big_header.h",
+    "sym": "FILE_big_header@2Eh"
+  }
+]

--- a/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@cpp__big_header__def_big_header__html.snap
@@ -4,6 +4,8 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-1" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="1"></div>
   <code role="cell" class="source-line"><span class="syn_comment" >// I am a header file.</span>
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__dependency__MyType__html.snap
@@ -4,6 +4,8 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-14" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="14"></div>
   <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span data-symbols="test_rust_dependency::<MyType>::do_foo" data-i="4" >do_foo</span>(<span class="syn_reserved" >self</span>) -> <span data-symbols="test_rust_dependency::MyType" data-i="5" >MyType</span> {
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__generated__GeneratedType__html.snap
@@ -4,6 +4,8 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-2" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="2"></div>
   <code role="cell" class="source-line"><span class="syn_reserved" >pub</span> <span class="syn_reserved" >struct</span> <span data-symbols="simple::build_time_generated::GeneratedType" data-i="0" >GeneratedType</span> {
 </code>

--- a/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__html.snap
+++ b/tests/tests/checks/snapshots/check_glob@rust__simple_rs__simple_Loader_new__html.snap
@@ -4,6 +4,8 @@ expression: "&aggr_str"
 
 ---
 <div role="row" id="line-37" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="37"></div>
   <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span data-symbols="simple::<Loader>::new" data-i="25" >new</span>(<span data-symbols="simple::<Loader>::new::deps_dir" data-i="26" >deps_dir</span>: PathBuf) -> <span class="syn_reserved" >Self</span> {
 </code>

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -1,4 +1,4 @@
-use crate::{cmd_pipeline::PipelineCommand, structopt::StructOpt};
+use crate::{cmd_pipeline::{PipelineCommand, cmd_prod_filter::ProductionFilterCommand}, structopt::StructOpt};
 use url::Url;
 
 use crate::{
@@ -76,6 +76,10 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
             }
 
             Command::IdentifierLookup(_il) => (),
+
+            Command::ProductionFilter(pf) => {
+                commands.push(Box::new(ProductionFilterCommand { args: pf }))
+            }
         }
     }
 

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -1,0 +1,120 @@
+use async_trait::async_trait;
+use lazy_static::lazy_static;
+use lol_html::{
+    element, html_content::ContentType, rewrite_str, RewriteStrSettings,
+};
+use regex::Regex;
+use serde_json::Value;
+use structopt::StructOpt;
+
+use super::interface::{
+    JsonRecords, JsonRecordsByFile, JsonValue, PipelineCommand, PipelineValues,
+};
+use crate::{
+    abstract_server::{AbstractServer, Result},
+    cmd_pipeline::interface::{HtmlExcerpts, HtmlExcerptsByFile},
+};
+
+#[derive(Debug, StructOpt)]
+pub struct ProductionFilter {}
+
+/// Normalize HTML or JSON records for production environment checks so that
+/// details like line numbers or `data-i` indexes that are subject to churn
+/// due to changes elsewhere in the file are normalized to "NORM".
+pub struct ProductionFilterCommand {
+    pub args: ProductionFilter,
+}
+
+/// Normalize JSON values by:
+/// - Converting "loc" properties from "LINE:COL-COL" to "NORML:COL-COL".
+fn norm_json_value(mut val: Value) -> Value {
+    lazy_static! {
+        // The column portion can potentially be singular I think so we just
+        // treat the half as its own group.
+        static ref RE: Regex = Regex::new(r"^(?P<line>\d+):(?P<cols>.+)$").unwrap();
+    }
+
+    if let Some(loc_ref) = val.pointer_mut("/loc") {
+        let existing_loc = loc_ref.as_str().unwrap();
+        *loc_ref = RE.replace_all(existing_loc, "NORM:$cols").into();
+    }
+
+    val
+}
+
+/// Normalize HTML values by:
+/// - Stripping .cov-strip elements.
+/// - Stripping .blame-strip elements.
+/// - Replacing line numbers with N
+/// - Replacing data-i values with "NORM".
+fn norm_html_value(s: String) -> String {
+    let element_content_handlers = vec![
+        element!(
+            r#"div.cell div.cov-strip, div.cell div.blame-strip"#,
+            |el| {
+                el.set_inner_content("", ContentType::Html);
+                Ok(())
+            }
+        ),
+        element!(r#"span[data-i]"#, |el| {
+            el.set_attribute("data-i", "NORM").unwrap();
+            Ok(())
+        }),
+        element!(r#"div.source-line-with-number"#, |el| {
+            el.set_attribute("id", "line-NORM").unwrap();
+            Ok(())
+        }),
+        element!(r#"div.line-number"#, |el| {
+            el.set_attribute("data-line-number", "NORM").unwrap();
+            Ok(())
+        }),
+    ];
+
+    rewrite_str(
+        &s,
+        RewriteStrSettings {
+            element_content_handlers,
+            ..RewriteStrSettings::default()
+        },
+    )
+    .unwrap()
+}
+
+#[async_trait]
+impl PipelineCommand for ProductionFilterCommand {
+    async fn execute(
+        &self,
+        _server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        Ok(match input {
+            PipelineValues::JsonRecords(jr) => PipelineValues::JsonRecords(JsonRecords {
+                by_file: jr
+                    .by_file
+                    .into_iter()
+                    .map(|jrbf| JsonRecordsByFile {
+                        file: jrbf.file,
+                        records: jrbf.records.into_iter().map(norm_json_value).collect(),
+                    })
+                    .collect(),
+            }),
+            PipelineValues::HtmlExcerpts(he) => PipelineValues::HtmlExcerpts(HtmlExcerpts {
+                by_file: he
+                    .by_file
+                    .into_iter()
+                    .map(|hebf| HtmlExcerptsByFile {
+                        file: hebf.file,
+                        excerpts: hebf.excerpts.into_iter().map(norm_html_value).collect(),
+                    })
+                    .collect(),
+            }),
+            // We don't currently handle a lone JsonValue but I guess it could
+            // just be the JsonRecords case that gets wrapped and then
+            // unwrapped?
+            PipelineValues::JsonValue(jv) => PipelineValues::JsonValue(JsonValue {
+                value: norm_json_value(jv.value),
+            }),
+            other => other,
+        })
+    }
+}

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -6,6 +6,7 @@ pub mod interface;
 pub mod parser;
 
 mod cmd_filter_analysis;
+mod cmd_prod_filter;
 mod cmd_query;
 mod cmd_show_html;
 

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -2,6 +2,7 @@ use clap::arg_enum;
 use structopt::StructOpt;
 
 use super::cmd_filter_analysis::FilterAnalysis;
+use super::cmd_prod_filter::ProductionFilter;
 use super::cmd_query::Query;
 use super::cmd_show_html::ShowHtml;
 
@@ -43,6 +44,7 @@ pub enum Command {
     FilterAnalysis(FilterAnalysis),
     ShowHtml(ShowHtml),
     IdentifierLookup(IdentifierLookup),
+    ProductionFilter(ProductionFilter),
 }
 
 #[derive(Debug, StructOpt)]

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -49,15 +49,6 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
             }
         }
 
-        // Regexp to help with stripping coverage and blame lines which are not
-        // expected to be stable in production for HTML lines.
-        //
-        // TODO: Make this something that doesn't impact the mozsearch test
-        // repository, since its coverage data is expected to always be canned.
-        let strip_stripper =
-            Regex::new(r#"(?m)^  <div role="cell"><div class="(?:cov|blame)-strip.+</div></div>\n"#)
-                .unwrap();
-
         for input_name in input_names {
             let input_path = format!("{}/inputs/{}", check_root, input_name);
             settings.set_input_file(&input_path);
@@ -83,11 +74,8 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         Ok(PipelineValues::HtmlExcerpts(he)) => {
                             let mut aggr_str = String::new();
                             for file_excerpts in he.by_file {
-                                //println!("HTML excerpts from: {}", file_excerpts.file);
                                 for str in file_excerpts.excerpts {
-                                    // Normalize out the blame/coverage lines.
-                                    // See the regexp def for more info.
-                                    aggr_str += &strip_stripper.replace_all(&str, "");
+                                    aggr_str += &str;
                                 }
                             }
                             insta::assert_snapshot!(&aggr_str);


### PR DESCRIPTION
The production-filter normalizes JSON and HTML data so that line numbers
and ANALYSIS_DATA indices are converted to "NORM" so that the normal
evolution of indexed production trees doesn't create needless false
positives for indexing failures.