### PR TITLE
Bug 1727453 - Migrate to serde_json

### DIFF
--- a/tests/tests/checks/inputs/merge__big_cpp
+++ b/tests/tests/checks/inputs/merge__big_cpp
@@ -1,1 +1,1 @@
-merge-analyses big_cpp.cpp -p foo-plat
+merge-analyses big_cpp.cpp big_cpp.cpp -p foo-plat -p bar-plat

--- a/tests/tests/checks/inputs/merge__big_cpp
+++ b/tests/tests/checks/inputs/merge__big_cpp
@@ -1,0 +1,1 @@
+merge-analyses big_cpp.cpp -p foo-plat

--- a/tests/tests/checks/snapshots/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/check_glob@merge__big_cpp.snap
@@ -1,0 +1,3653 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "big_cpp.cpp",
+    "sym": "FILE_big_cpp@2Ecpp"
+  },
+  {
+    "loc": "00020:9-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "big_header.h",
+    "sym": "FILE_big_header@2Eh"
+  },
+  {
+    "loc": "00021:9-50",
+    "target": 1,
+    "kind": "use",
+    "pretty": "subdir/header@with,many^strange~chars.h",
+    "sym": "FILE_subdir/header@40with@2Cmany@5Estrange@7Echars@2Eh"
+  },
+  {
+    "loc": "00022:9-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "atom_magic.h",
+    "sym": "FILE_atom_magic@2Eh"
+  },
+  {
+    "loc": "00024:6-19",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext",
+    "sym": "T_GlobalContext",
+    "peekRange": "24-24"
+  },
+  {
+    "loc": "00027:14-32",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "27-27"
+  },
+  {
+    "loc": "00028:15-19",
+    "target": 1,
+    "kind": "use",
+    "pretty": "rand",
+    "sym": "rand",
+    "context": "GlobalContext::decideBooleanTrait",
+    "contextsym": "_ZN13GlobalContext18decideBooleanTraitEv"
+  },
+  {
+    "loc": "00034:24-32",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RAND_MAX",
+    "sym": "M_85a652bdd3e78849"
+  },
+  {
+    "loc": "00063:14-47",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "63-63"
+  },
+  {
+    "loc": "00064:11-29",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "context": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "contextsym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv"
+  },
+  {
+    "loc": "00067:14-35",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::decideCatBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "67-67"
+  },
+  {
+    "loc": "00068:11-44",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+    "context": "GlobalContext::decideCatBooleanTrait",
+    "contextsym": "_ZN13GlobalContext21decideCatBooleanTraitEv"
+  },
+  {
+    "loc": "00071:14-42",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "71-71"
+  },
+  {
+    "loc": "00072:11-29",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "context": "GlobalContext::decideBestFriendBooleanTrait",
+    "contextsym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv"
+  },
+  {
+    "loc": "00075:8-25",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "75-75"
+  },
+  {
+    "loc": "00087:4-25",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "context": "GlobalContext::LessGlobalContext",
+    "contextsym": "T_GlobalContext::LessGlobalContext",
+    "peekRange": "77-87"
+  },
+  {
+    "loc": "00122:14-35",
+    "target": 1,
+    "kind": "def",
+    "pretty": "GlobalContext::decideDogBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+    "context": "GlobalContext",
+    "contextsym": "T_GlobalContext",
+    "peekRange": "112-122"
+  },
+  {
+    "loc": "00123:27-48",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "context": "GlobalContext::decideDogBooleanTrait",
+    "contextsym": "_ZN13GlobalContext21decideDogBooleanTraitEv"
+  },
+  {
+    "loc": "00123:8-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "context": "GlobalContext::decideDogBooleanTrait",
+    "contextsym": "_ZN13GlobalContext21decideDogBooleanTraitEv"
+  },
+  {
+    "loc": "00124:13-41",
+    "target": 1,
+    "kind": "use",
+    "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "context": "GlobalContext::decideDogBooleanTrait",
+    "contextsym": "_ZN13GlobalContext21decideDogBooleanTraitEv"
+  },
+  {
+    "loc": "00131:10-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS",
+    "sym": "NS_outerNS"
+  },
+  {
+    "loc": "00133:8-16",
+    "target": 1,
+    "kind": "def",
+    "pretty": "HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00135:6-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "peekRange": "135-135"
+  },
+  {
+    "loc": "00141:6-9",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing",
+    "peekRange": "137-141"
+  },
+  {
+    "loc": "00145:7-15",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing",
+    "peekRange": "143-145"
+  },
+  {
+    "loc": "00148:2-7",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing",
+    "peekRange": "148-148"
+  },
+  {
+    "loc": "00149:4-7",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00150:4-12",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00154:7-13",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing",
+    "peekRange": "154-154"
+  },
+  {
+    "loc": "00156:15-25",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "context": "outerNS::Thing",
+    "contextsym": "T_outerNS::Thing",
+    "peekRange": "156-156"
+  },
+  {
+    "loc": "00157:4-7",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "context": "outerNS::Thing::takeDamage",
+    "contextsym": "_ZN7outerNS5Thing10takeDamageEi"
+  },
+  {
+    "loc": "00160:6-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "context": "outerNS::Thing::takeDamage",
+    "contextsym": "_ZN7outerNS5Thing10takeDamageEi"
+  },
+  {
+    "loc": "00166:12-18",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "peekRange": "166-166"
+  },
+  {
+    "loc": "00166:5-10",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::Thing::ignore",
+    "contextsym": "_ZN7outerNS5Thing6ignoreEv"
+  },
+  {
+    "loc": "00179:20-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::Human",
+    "contextsym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00179:6-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "peekRange": "179-179"
+  },
+  {
+    "loc": "00182:2-7",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
+    "context": "outerNS::Human",
+    "contextsym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00183:10-18",
+    "target": 1,
+    "kind": "use",
+    "pretty": "HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00183:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::Human::Human",
+    "contextsym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00183:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "context": "outerNS::Human::Human",
+    "contextsym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00188:25-30",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "context": "outerNS::Superhero",
+    "contextsym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00188:6-15",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "peekRange": "188-188"
+  },
+  {
+    "loc": "00191:2-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev",
+    "context": "outerNS::Superhero",
+    "contextsym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00192:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "context": "outerNS::Superhero::Superhero",
+    "contextsym": "_ZN7outerNS9SuperheroC1Ev"
+  },
+  {
+    "loc": "00192:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
+    "context": "outerNS::Superhero::Superhero",
+    "contextsym": "_ZN7outerNS9SuperheroC1Ev"
+  },
+  {
+    "loc": "00196:7-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Superhero::takeDamage",
+    "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+    "context": "outerNS::Superhero",
+    "contextsym": "T_outerNS::Superhero",
+    "peekRange": "196-196"
+  },
+  {
+    "loc": "00205:21-26",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::Couch",
+    "contextsym": "T_outerNS::Couch"
+  },
+  {
+    "loc": "00205:6-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "peekRange": "205-205"
+  },
+  {
+    "loc": "00208:2-7",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::Couch::Couch",
+    "sym": "_ZN7outerNS5CouchC1Ei",
+    "context": "outerNS::Couch",
+    "contextsym": "T_outerNS::Couch",
+    "peekRange": "208-208"
+  },
+  {
+    "loc": "00209:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00209:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00210:14-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00210:4-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00211:20-29",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00211:31-37",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00211:4-19",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector",
+    "sym": "T_WhatsYourVector",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00213:10-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00213:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00214:20-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00214:27-45",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00214:4-19",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector",
+    "sym": "T_WhatsYourVector",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00216:11-51",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
+    "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00217:23-63",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
+    "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
+    "context": "outerNS::Couch::Couch",
+    "contextsym": "_ZN7outerNS5CouchC1Ei"
+  },
+  {
+    "loc": "00221:17-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat"
+  },
+  {
+    "loc": "00221:6-14",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat",
+    "sym": "T_outerNS::OuterCat",
+    "peekRange": "221-221"
+  },
+  {
+    "loc": "00235:7-18",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "223-235"
+  },
+  {
+    "loc": "00236:7-28",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "236-236"
+  },
+  {
+    "loc": "00248:2-10",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::OuterCat",
+    "sym": "_ZN7outerNS8OuterCatC1Ebb",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "239-254"
+  },
+  {
+    "loc": "00258:14-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00258:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::OuterCat::OuterCat",
+    "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
+  },
+  {
+    "loc": "00258:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "context": "outerNS::OuterCat::OuterCat",
+    "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
+  },
+  {
+    "loc": "00259:4-15",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat"
+  },
+  {
+    "loc": "00263:4-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat"
+  },
+  {
+    "loc": "00311:7-20",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "301-311"
+  },
+  {
+    "loc": "00312:11-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "context": "outerNS::OuterCat::isFriendlyCat",
+    "contextsym": "_ZN7outerNS8OuterCat13isFriendlyCatEv"
+  },
+  {
+    "loc": "00315:7-27",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "315-315"
+  },
+  {
+    "loc": "00327:11-32",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "context": "outerNS::OuterCat::isSecretlyUnfriendly",
+    "contextsym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv"
+  },
+  {
+    "loc": "00330:7-38",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "330-330"
+  },
+  {
+    "loc": "00331:8-28",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "context": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "contextsym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv"
+  },
+  {
+    "loc": "00335:11-24",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "context": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "contextsym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv"
+  },
+  {
+    "loc": "00340:12-17",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE"
+  },
+  {
+    "loc": "00340:7-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "340-340"
+  },
+  {
+    "loc": "00341:10-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE"
+  },
+  {
+    "loc": "00351:12-17",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00351:7-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "344-351"
+  },
+  {
+    "loc": "00352:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00354:9-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00362:6-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00363:15-46",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00383:6-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "context": "outerNS::OuterCat::meet",
+    "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+  },
+  {
+    "loc": "00390:13-18",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::OuterCat::shred",
+    "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+  },
+  {
+    "loc": "00390:7-12",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "387-390"
+  },
+  {
+    "loc": "00391:10-20",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "context": "outerNS::OuterCat::shred",
+    "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+  },
+  {
+    "loc": "00397:15-20",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00397:7-14",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "context": "outerNS::OuterCat",
+    "contextsym": "T_outerNS::OuterCat",
+    "peekRange": "394-397"
+  },
+  {
+    "loc": "00399:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00402:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00405:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00408:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00411:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "context": "outerNS::OuterCat::destroy",
+    "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+  },
+  {
+    "loc": "00415:8-14",
+    "target": 1,
+    "kind": "def",
+    "pretty": "ART_HP",
+    "sym": "M_6b997b2064ef3d77"
+  },
+  {
+    "loc": "00417:27-32",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::AbstractArt",
+    "contextsym": "T_outerNS::AbstractArt"
+  },
+  {
+    "loc": "00417:6-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "peekRange": "417-417"
+  },
+  {
+    "loc": "00419:2-13",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev",
+    "context": "outerNS::AbstractArt",
+    "contextsym": "T_outerNS::AbstractArt"
+  },
+  {
+    "loc": "00420:10-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ART_HP",
+    "sym": "M_6b997b2064ef3d77"
+  },
+  {
+    "loc": "00420:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "context": "outerNS::AbstractArt::AbstractArt",
+    "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+  },
+  {
+    "loc": "00420:4-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "context": "outerNS::AbstractArt::AbstractArt",
+    "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+  },
+  {
+    "loc": "00424:15-20",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::AbstractArt::beArt",
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+    "context": "outerNS::AbstractArt",
+    "contextsym": "T_outerNS::AbstractArt",
+    "peekRange": "422-424"
+  },
+  {
+    "loc": "00427:28-39",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "context": "outerNS::PracticalArt",
+    "contextsym": "T_outerNS::PracticalArt"
+  },
+  {
+    "loc": "00427:6-18",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::PracticalArt",
+    "sym": "T_outerNS::PracticalArt",
+    "peekRange": "427-427"
+  },
+  {
+    "loc": "00429:2-14",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::PracticalArt::PracticalArt",
+    "sym": "_ZN7outerNS12PracticalArtC1Ev",
+    "context": "outerNS::PracticalArt",
+    "contextsym": "T_outerNS::PracticalArt"
+  },
+  {
+    "loc": "00430:4-15",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "context": "outerNS::PracticalArt::PracticalArt",
+    "contextsym": "_ZN7outerNS12PracticalArtC1Ev"
+  },
+  {
+    "loc": "00430:4-15",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev",
+    "context": "outerNS::PracticalArt::PracticalArt",
+    "contextsym": "_ZN7outerNS12PracticalArtC1Ev"
+  },
+  {
+    "loc": "00433:7-12",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::PracticalArt::beArt",
+    "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+    "context": "outerNS::PracticalArt",
+    "contextsym": "T_outerNS::PracticalArt",
+    "peekRange": "432-433"
+  },
+  {
+    "loc": "00435:4-7",
+    "target": 1,
+    "kind": "use",
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "context": "outerNS::PracticalArt::beArt",
+    "contextsym": "_ZN7outerNS12PracticalArt5beArtEv"
+  },
+  {
+    "loc": "00440:10-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::innerNS",
+    "sym": "NS_outerNS::innerNS"
+  },
+  {
+    "loc": "00442:6-14",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::innerNS::InnerCat",
+    "sym": "T_outerNS::innerNS::InnerCat",
+    "peekRange": "442-442"
+  },
+  {
+    "loc": "00448:6-13",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::innerNS::AnonCat",
+    "sym": "T_outerNS::innerNS::AnonCat",
+    "peekRange": "448-448"
+  },
+  {
+    "loc": "00460:6-21",
+    "target": 1,
+    "kind": "def",
+    "pretty": "outerNS::innerNS::NondebugAnonCat",
+    "sym": "T_outerNS::innerNS::NondebugAnonCat",
+    "peekRange": "460-460"
+  },
+  {
+    "loc": "00473:5-33",
+    "target": 1,
+    "kind": "def",
+    "pretty": "i_was_declared_in_the_header",
+    "sym": "i_was_declared_in_the_header",
+    "peekRange": "473-473"
+  },
+  {
+    "loc": "00001:0",
+    "source": 1,
+    "syntax": "def,file",
+    "pretty": "file big_cpp.cpp",
+    "sym": "FILE_big_cpp@2Ecpp"
+  },
+  {
+    "loc": "00020:9-23",
+    "source": 1,
+    "syntax": "use,file",
+    "pretty": "file big_header.h",
+    "sym": "FILE_big_header@2Eh"
+  },
+  {
+    "loc": "00021:9-50",
+    "source": 1,
+    "syntax": "use,file",
+    "pretty": "file subdir/header@with,many^strange~chars.h",
+    "sym": "FILE_subdir/header@40with@2Cmany@5Estrange@7Echars@2Eh"
+  },
+  {
+    "loc": "00022:9-23",
+    "source": 1,
+    "syntax": "use,file",
+    "pretty": "file atom_magic.h",
+    "sym": "FILE_atom_magic@2Eh"
+  },
+  {
+    "loc": "00024:6-19",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type GlobalContext",
+    "sym": "T_GlobalContext",
+    "nestingRange": "24:20-129:0"
+  },
+  {
+    "loc": "00027:14-32",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "nestingRange": "27:35-61:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00028:8-12",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable rval",
+    "sym": "V_6d0df62064ef3d77_a959d9c71",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00028:15-19",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function rand",
+    "sym": "rand",
+    "type": "int (void) throw()"
+  },
+  {
+    "loc": "00034:8-21",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable midpointValue",
+    "sym": "V_33c4072064ef3d77_644177abb24920da",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00034:24-32",
+    "source": 1,
+    "syntax": "use,macro",
+    "pretty": "macro RAND_MAX",
+    "sym": "M_85a652bdd3e78849"
+  },
+  {
+    "loc": "00036:8-12",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable rval",
+    "sym": "V_6d0df62064ef3d77_a959d9c71",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00036:15-28",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable midpointValue",
+    "sym": "V_33c4072064ef3d77_644177abb24920da",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00063:14-47",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+    "nestingRange": "63:50-65:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00064:11-29",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00067:14-35",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::decideCatBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+    "nestingRange": "67:38-69:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00068:11-44",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00071:14-42",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "nestingRange": "71:45-73:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00072:11-29",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00075:8-25",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "nestingRange": "75:26-110:2"
+  },
+  {
+    "loc": "00087:4-25",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "nestingRange": "87:28-99:4",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00122:14-35",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function GlobalContext::decideDogBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+    "nestingRange": "122:38-128:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00123:8-25",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "type": "class GlobalContext::LessGlobalContext",
+    "typesym": "T_GlobalContext::LessGlobalContext"
+  },
+  {
+    "loc": "00123:27-48",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00124:13-41",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00131:10-17",
+    "source": 1,
+    "syntax": "def,namespace",
+    "pretty": "namespace outerNS",
+    "sym": "NS_outerNS",
+    "nestingRange": "131:19-470:0"
+  },
+  {
+    "loc": "00133:8-16",
+    "source": 1,
+    "syntax": "def,macro",
+    "pretty": "macro HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00135:6-11",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "nestingRange": "135:12-164:0"
+  },
+  {
+    "loc": "00141:6-9",
+    "source": 1,
+    "syntax": "def,field",
+    "pretty": "field outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "type": "int"
+  },
+  {
+    "loc": "00145:7-15",
+    "source": 1,
+    "syntax": "def,field",
+    "pretty": "field outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00148:2-7",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "nestingRange": "150:20-152:2",
+    "type": "void (int)"
+  },
+  {
+    "loc": "00148:12-18",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable baseHP",
+    "sym": "V_48443e25607c3527_812a493f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00149:4-7",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "type": "int"
+  },
+  {
+    "loc": "00149:8-14",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable baseHP",
+    "sym": "V_48443e25607c3527_812a493f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00150:4-12",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00154:7-13",
+    "source": 1,
+    "syntax": "decl,function",
+    "pretty": "function outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00156:15-25",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "nestingRange": "156:38-163:2",
+    "type": "void (int)"
+  },
+  {
+    "loc": "00156:30-36",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable damage",
+    "sym": "V_38444f25607c3527_42c9b38f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00157:4-7",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "type": "int"
+  },
+  {
+    "loc": "00157:11-17",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable damage",
+    "sym": "V_38444f25607c3527_42c9b38f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00159:8-14",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable damage",
+    "sym": "V_38444f25607c3527_42c9b38f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00160:6-14",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00161:6-12",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable damage",
+    "sym": "V_38444f25607c3527_42c9b38f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00166:5-10",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00166:12-18",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "nestingRange": "166:21-177:0",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00179:6-11",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "nestingRange": "179:26-186:0"
+  },
+  {
+    "loc": "00179:20-25",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00182:2-7",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
+    "nestingRange": "183:20-185:2",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00183:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00183:4-9",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00183:10-18",
+    "source": 1,
+    "syntax": "use,macro",
+    "pretty": "macro HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00188:6-15",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "nestingRange": "188:31-203:0"
+  },
+  {
+    "loc": "00188:25-30",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00191:2-11",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev",
+    "nestingRange": "192:12-194:2",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00192:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00192:4-9",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00196:7-17",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Superhero::takeDamage",
+    "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+    "nestingRange": "196:39-202:2",
+    "type": "void (int)"
+  },
+  {
+    "loc": "00196:22-28",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable damage",
+    "sym": "V_866ac335607c3527_42c9b38f256",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00205:6-11",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "nestingRange": "205:27-219:0"
+  },
+  {
+    "loc": "00205:21-26",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00208:2-7",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::Couch::Couch",
+    "sym": "_ZN7outerNS5CouchC1Ei",
+    "nestingRange": "209:20-218:2",
+    "type": "void (int)"
+  },
+  {
+    "loc": "00208:12-19",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couchHP",
+    "sym": "V_12b00f45607c3527_f4afee3d1b0d",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00209:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00209:4-9",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00209:11-18",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couchHP",
+    "sym": "V_12b00f45607c3527_f4afee3d1b0d",
+    "no_crossref": 1,
+    "type": "int"
+  },
+  {
+    "loc": "00210:4-13",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "type": "class outerNS::Superhero",
+    "typesym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00210:14-22",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev"
+  },
+  {
+    "loc": "00210:14-22",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable superBob",
+    "sym": "V_c90cdf45607c3527_74bc848dc87ea1",
+    "no_crossref": 1,
+    "type": "class outerNS::Superhero",
+    "typesym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00211:4-19",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type WhatsYourVector",
+    "sym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00211:20-29",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "type": "class outerNS::Superhero",
+    "typesym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00211:31-37",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable victor",
+    "sym": "V_c3d4ef45607c3527_c9114c22356",
+    "no_crossref": 1,
+    "type": "WhatsYourVector<class outerNS::Superhero>",
+    "typesym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00211:31-37",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_"
+  },
+  {
+    "loc": "00211:39-47",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable superBob",
+    "sym": "V_c90cdf45607c3527_74bc848dc87ea1",
+    "no_crossref": 1,
+    "type": "class outerNS::Superhero",
+    "typesym": "T_outerNS::Superhero"
+  },
+  {
+    "loc": "00213:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00213:10-13",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable bob",
+    "sym": "V_bb56ff45607c3527_872688b",
+    "no_crossref": 1,
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00213:10-13",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00214:4-19",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type WhatsYourVector",
+    "sym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00214:20-25",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00214:27-45",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable goodReferenceRight",
+    "sym": "V_442fff45607c3527_bbca21f4b95005a5",
+    "no_crossref": 1,
+    "type": "WhatsYourVector<class outerNS::Human>",
+    "typesym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00214:27-45",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_"
+  },
+  {
+    "loc": "00214:47-50",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable bob",
+    "sym": "V_bb56ff45607c3527_872688b",
+    "no_crossref": 1,
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00216:4-10",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable victor",
+    "sym": "V_c3d4ef45607c3527_c9114c22356",
+    "no_crossref": 1,
+    "type": "WhatsYourVector<class outerNS::Superhero>",
+    "typesym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00216:11-51",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
+    "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
+    "type": "WhatsYourVector_impl<class outerNS::Superhero, class CoolAlloc>::elem_type"
+  },
+  {
+    "loc": "00217:4-22",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable goodReferenceRight",
+    "sym": "V_442fff45607c3527_bbca21f4b95005a5",
+    "no_crossref": 1,
+    "type": "WhatsYourVector<class outerNS::Human>",
+    "typesym": "T_WhatsYourVector"
+  },
+  {
+    "loc": "00217:23-63",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
+    "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
+    "type": "WhatsYourVector_impl<class outerNS::Human, class CoolAlloc>::elem_type"
+  },
+  {
+    "loc": "00221:6-14",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::OuterCat",
+    "sym": "T_outerNS::OuterCat",
+    "nestingRange": "221:23-413:0"
+  },
+  {
+    "loc": "00221:17-22",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00235:7-18",
+    "source": 1,
+    "syntax": "def,field",
+    "pretty": "field outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00236:7-28",
+    "source": 1,
+    "syntax": "def,field",
+    "pretty": "field outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00248:2-10",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::OuterCat",
+    "sym": "_ZN7outerNS8OuterCatC1Ebb",
+    "nestingRange": "263:48-297:2",
+    "type": "void (_Bool, _Bool)"
+  },
+  {
+    "loc": "00248:16-26",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable beFriendly",
+    "sym": "V_92d68355607c3527_925a094997a10727",
+    "no_crossref": 1,
+    "type": "_Bool"
+  },
+  {
+    "loc": "00254:9-29",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable beSecretlyUnfriendly",
+    "sym": "V_8f59592064ef3d77_75b6f44f1cbf596d",
+    "no_crossref": 1,
+    "type": "_Bool"
+  },
+  {
+    "loc": "00258:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00258:4-9",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00258:14-22",
+    "source": 1,
+    "syntax": "use,macro",
+    "pretty": "macro HUMAN_HP",
+    "sym": "M_3706282064ef3d77"
+  },
+  {
+    "loc": "00259:4-15",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00259:16-26",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable beFriendly",
+    "sym": "V_92d68355607c3527_925a094997a10727",
+    "no_crossref": 1,
+    "type": "_Bool"
+  },
+  {
+    "loc": "00263:4-25",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00263:26-46",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable beSecretlyUnfriendly",
+    "sym": "V_8f59592064ef3d77_75b6f44f1cbf596d",
+    "no_crossref": 1,
+    "type": "_Bool"
+  },
+  {
+    "loc": "00311:7-20",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "nestingRange": "311:23-313:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00312:11-22",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00315:7-27",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "nestingRange": "315:30-328:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00327:11-32",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00330:7-38",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "nestingRange": "330:41-336:2",
+    "type": "_Bool (void)"
+  },
+  {
+    "loc": "00331:8-28",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00335:11-24",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00340:7-11",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+    "nestingRange": "340:26-342:2",
+    "type": "void (class outerNS::Human &)"
+  },
+  {
+    "loc": "00340:12-17",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "type": "class outerNS::Human",
+    "typesym": "T_outerNS::Human"
+  },
+  {
+    "loc": "00340:19-24",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable human",
+    "sym": "V_5c239875607c3527_e79fa9f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Human &"
+  },
+  {
+    "loc": "00341:4-9",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable human",
+    "sym": "V_5c239875607c3527_e79fa9f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Human &"
+  },
+  {
+    "loc": "00341:10-16",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "type": "void"
+  },
+  {
+    "loc": "00351:7-11",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+    "nestingRange": "351:26-385:2",
+    "type": "void (class outerNS::Couch &)"
+  },
+  {
+    "loc": "00351:12-17",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "type": "class outerNS::Couch",
+    "typesym": "T_outerNS::Couch"
+  },
+  {
+    "loc": "00351:19-24",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couch",
+    "sym": "V_7a7db975607c3527_7f65d3f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Couch &"
+  },
+  {
+    "loc": "00352:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00352:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couch",
+    "sym": "V_7a7db975607c3527_7f65d3f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Couch &"
+  },
+  {
+    "loc": "00354:9-22",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00362:6-13",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00362:14-19",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couch",
+    "sym": "V_7a7db975607c3527_7f65d3f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Couch &"
+  },
+  {
+    "loc": "00363:15-46",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "type": "_Bool"
+  },
+  {
+    "loc": "00383:6-13",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00383:14-19",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable couch",
+    "sym": "V_7a7db975607c3527_7f65d3f013",
+    "no_crossref": 1,
+    "type": "class outerNS::Couch &"
+  },
+  {
+    "loc": "00390:7-12",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "nestingRange": "390:27-392:2",
+    "type": "void (class outerNS::Thing &)"
+  },
+  {
+    "loc": "00390:13-18",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00390:20-25",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_26da3e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00391:4-9",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_26da3e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00391:10-20",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "type": "void"
+  },
+  {
+    "loc": "00397:7-14",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "nestingRange": "397:29-412:2",
+    "type": "void (class outerNS::Thing &)"
+  },
+  {
+    "loc": "00397:15-20",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00397:22-27",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00399:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00399:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00402:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00402:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00405:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00405:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00408:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00408:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00411:4-9",
+    "source": 1,
+    "syntax": "use,function",
+    "pretty": "function outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "type": "void"
+  },
+  {
+    "loc": "00411:10-15",
+    "source": 1,
+    "syntax": "",
+    "pretty": "variable thing",
+    "sym": "V_b0487e75607c3527_f3fec60113",
+    "no_crossref": 1,
+    "type": "class outerNS::Thing &"
+  },
+  {
+    "loc": "00415:8-14",
+    "source": 1,
+    "syntax": "def,macro",
+    "pretty": "macro ART_HP",
+    "sym": "M_6b997b2064ef3d77"
+  },
+  {
+    "loc": "00417:6-17",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "nestingRange": "417:33-425:0"
+  },
+  {
+    "loc": "00417:27-32",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00419:2-13",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev",
+    "nestingRange": "420:18-420:19",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00420:4-9",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "type": "class outerNS::Thing",
+    "typesym": "T_outerNS::Thing"
+  },
+  {
+    "loc": "00420:4-9",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00420:10-16",
+    "source": 1,
+    "syntax": "use,macro",
+    "pretty": "macro ART_HP",
+    "sym": "M_6b997b2064ef3d77"
+  },
+  {
+    "loc": "00424:15-20",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::AbstractArt::beArt",
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00427:6-18",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::PracticalArt",
+    "sym": "T_outerNS::PracticalArt",
+    "nestingRange": "427:40-437:0"
+  },
+  {
+    "loc": "00427:28-39",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "type": "class outerNS::AbstractArt",
+    "typesym": "T_outerNS::AbstractArt"
+  },
+  {
+    "loc": "00429:2-14",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::PracticalArt::PracticalArt",
+    "sym": "_ZN7outerNS12PracticalArtC1Ev",
+    "nestingRange": "430:18-430:19",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00430:4-15",
+    "source": 1,
+    "syntax": "use,type",
+    "pretty": "type outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "type": "class outerNS::AbstractArt",
+    "typesym": "T_outerNS::AbstractArt"
+  },
+  {
+    "loc": "00430:4-15",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev"
+  },
+  {
+    "loc": "00433:7-12",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function outerNS::PracticalArt::beArt",
+    "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+    "nestingRange": "433:24-436:2",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00435:4-7",
+    "source": 1,
+    "syntax": "use,field",
+    "pretty": "field outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "type": "int"
+  },
+  {
+    "loc": "00440:10-17",
+    "source": 1,
+    "syntax": "def,namespace",
+    "pretty": "namespace outerNS::innerNS",
+    "sym": "NS_outerNS::innerNS",
+    "nestingRange": "440:19-468:0"
+  },
+  {
+    "loc": "00442:6-14",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::innerNS::InnerCat",
+    "sym": "T_outerNS::innerNS::InnerCat",
+    "nestingRange": "442:15-444:0"
+  },
+  {
+    "loc": "00448:6-13",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::innerNS::AnonCat",
+    "sym": "T_outerNS::innerNS::AnonCat",
+    "nestingRange": "448:14-450:0"
+  },
+  {
+    "loc": "00460:6-21",
+    "source": 1,
+    "syntax": "def,type",
+    "pretty": "type outerNS::innerNS::NondebugAnonCat",
+    "sym": "T_outerNS::innerNS::NondebugAnonCat",
+    "nestingRange": "460:22-462:0"
+  },
+  {
+    "loc": "00473:5-33",
+    "source": 1,
+    "syntax": "def,function",
+    "pretty": "function i_was_declared_in_the_header",
+    "sym": "i_was_declared_in_the_header",
+    "nestingRange": "473:36-477:0",
+    "type": "void (void)"
+  },
+  {
+    "loc": "00473:5-33",
+    "structured": 1,
+    "pretty": "i_was_declared_in_the_header",
+    "sym": "i_was_declared_in_the_header",
+    "kind": "function",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00442:6-14",
+    "structured": 1,
+    "pretty": "outerNS::innerNS::InnerCat",
+    "sym": "T_outerNS::innerNS::InnerCat",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00311:7-20",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00156:15-25",
+    "structured": 1,
+    "pretty": "outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00067:14-35",
+    "structured": 1,
+    "pretty": "GlobalContext::decideCatBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00188:6-15",
+    "structured": 1,
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Human",
+        "sym": "T_outerNS::Human",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1Ev",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::takeDamage",
+        "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+        "props": [
+          "instance",
+          "virtual",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::~Superhero",
+        "sym": "_ZN7outerNS9SuperheroD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1ERKS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      },
+      {
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1EOS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00179:6-11",
+    "structured": 1,
+    "pretty": "outerNS::Human",
+    "sym": "T_outerNS::Human",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1Ev",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::operator=",
+        "sym": "_ZN7outerNS5HumanaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::operator=",
+        "sym": "_ZN7outerNS5HumanaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::~Human",
+        "sym": "_ZN7outerNS5HumanD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1ERKS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      },
+      {
+        "pretty": "outerNS::Human::Human",
+        "sym": "_ZN7outerNS5HumanC1EOS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00340:7-11",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00235:7-18",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "kind": "field",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00148:2-7",
+    "structured": 1,
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00330:7-38",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00424:15-20",
+    "structured": 1,
+    "pretty": "outerNS::AbstractArt::beArt",
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::AbstractArt",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00221:6-14",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat",
+    "sym": "T_outerNS::OuterCat",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::OuterCat::OuterCat",
+        "sym": "_ZN7outerNS8OuterCatC1Ebb",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isFriendlyCat",
+        "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+        "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+        "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::meet",
+        "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::meet",
+        "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::shred",
+        "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::destroy",
+        "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::operator=",
+        "sym": "_ZN7outerNS8OuterCataSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::operator=",
+        "sym": "_ZN7outerNS8OuterCataSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::OuterCat::~OuterCat",
+        "sym": "_ZN7outerNS8OuterCatD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "pretty": "outerNS::OuterCat::mIsFriendly",
+        "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+        "type": "_Bool",
+        "typesym": "",
+        "offsetBytes": 13,
+        "bitPositions": null,
+        "sizeBytes": 1
+      },
+      {
+        "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+        "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+        "type": "_Bool",
+        "typesym": "",
+        "offsetBytes": 14,
+        "bitPositions": null,
+        "sizeBytes": 1
+      }
+    ],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00427:6-18",
+    "structured": 1,
+    "pretty": "outerNS::PracticalArt",
+    "sym": "T_outerNS::PracticalArt",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::AbstractArt",
+        "sym": "T_outerNS::AbstractArt",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::PracticalArt::PracticalArt",
+        "sym": "_ZN7outerNS12PracticalArtC1Ev",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::PracticalArt::beArt",
+        "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+        "props": [
+          "instance",
+          "virtual",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::PracticalArt::operator=",
+        "sym": "_ZN7outerNS12PracticalArtaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::PracticalArt::operator=",
+        "sym": "_ZN7outerNS12PracticalArtaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::PracticalArt::~PracticalArt",
+        "sym": "_ZN7outerNS12PracticalArtD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00248:2-10",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::OuterCat",
+    "sym": "_ZN7outerNS8OuterCatC1Ebb",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00208:2-7",
+    "structured": 1,
+    "pretty": "outerNS::Couch::Couch",
+    "sym": "_ZN7outerNS5CouchC1Ei",
+    "kind": "method",
+    "parentsym": "T_outerNS::Couch",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00417:6-17",
+    "structured": 1,
+    "pretty": "outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1Ev",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::beArt",
+        "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+        "props": [
+          "instance",
+          "virtual",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::operator=",
+        "sym": "_ZN7outerNS11AbstractArtaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::operator=",
+        "sym": "_ZN7outerNS11AbstractArtaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::~AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1ERKS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      },
+      {
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1EOS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00135:6-11",
+    "structured": 1,
+    "pretty": "outerNS::Thing",
+    "sym": "T_outerNS::Thing",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [],
+    "methods": [
+      {
+        "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1Ei",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::ignore",
+        "sym": "_ZN7outerNS5Thing6ignoreEv",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::takeDamage",
+        "sym": "_ZN7outerNS5Thing10takeDamageEi",
+        "props": [
+          "instance",
+          "virtual",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::operator=",
+        "sym": "_ZN7outerNS5ThingaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::operator=",
+        "sym": "_ZN7outerNS5ThingaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::~Thing",
+        "sym": "_ZN7outerNS5ThingD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1ERKS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      },
+      {
+        "pretty": "outerNS::Thing::Thing",
+        "sym": "_ZN7outerNS5ThingC1EOS0_",
+        "props": [
+          "instance",
+          "defaulted",
+          "constexpr"
+        ]
+      }
+    ],
+    "fields": [
+      {
+        "pretty": "outerNS::Thing::mHP",
+        "sym": "F_<T_outerNS::Thing>_mHP",
+        "type": "int",
+        "typesym": "",
+        "offsetBytes": 8,
+        "bitPositions": null,
+        "sizeBytes": 4
+      },
+      {
+        "pretty": "outerNS::Thing::mDefunct",
+        "sym": "F_<T_outerNS::Thing>_mDefunct",
+        "type": "_Bool",
+        "typesym": "",
+        "offsetBytes": 12,
+        "bitPositions": null,
+        "sizeBytes": 1
+      }
+    ],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00419:2-13",
+    "structured": 1,
+    "pretty": "outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev",
+    "kind": "method",
+    "parentsym": "T_outerNS::AbstractArt",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00351:7-11",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00448:6-13",
+    "structured": 1,
+    "pretty": "outerNS::innerNS::AnonCat",
+    "sym": "T_outerNS::innerNS::AnonCat",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00390:7-12",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00315:7-27",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00429:2-14",
+    "structured": 1,
+    "pretty": "outerNS::PracticalArt::PracticalArt",
+    "sym": "_ZN7outerNS12PracticalArtC1Ev",
+    "kind": "method",
+    "parentsym": "T_outerNS::PracticalArt",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00205:6-11",
+    "structured": 1,
+    "pretty": "outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::Couch::Couch",
+        "sym": "_ZN7outerNS5CouchC1Ei",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::operator=",
+        "sym": "_ZN7outerNS5CouchaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::operator=",
+        "sym": "_ZN7outerNS5CouchaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::~Couch",
+        "sym": "_ZN7outerNS5CouchD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00063:14-47",
+    "structured": 1,
+    "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+    "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00182:2-7",
+    "structured": 1,
+    "pretty": "outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
+    "kind": "method",
+    "parentsym": "T_outerNS::Human",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00433:7-12",
+    "structured": 1,
+    "pretty": "outerNS::PracticalArt::beArt",
+    "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::PracticalArt",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [
+      {
+        "pretty": "outerNS::AbstractArt::beArt",
+        "sym": "_ZN7outerNS11AbstractArt5beArtEv"
+      }
+    ],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00027:14-32",
+    "structured": 1,
+    "pretty": "GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00071:14-42",
+    "structured": 1,
+    "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00024:6-19",
+    "structured": 1,
+    "pretty": "GlobalContext",
+    "sym": "T_GlobalContext",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [
+      {
+        "pretty": "GlobalContext::decideBooleanTrait",
+        "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+        "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideCatBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+        "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideDogBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00122:14-35",
+    "structured": 1,
+    "pretty": "GlobalContext::decideDogBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00397:7-14",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::destroy",
+    "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00145:7-15",
+    "structured": 1,
+    "pretty": "outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "kind": "field",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00236:7-28",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "kind": "field",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00191:2-11",
+    "structured": 1,
+    "pretty": "outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev",
+    "kind": "method",
+    "parentsym": "T_outerNS::Superhero",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00196:7-17",
+    "structured": 1,
+    "pretty": "outerNS::Superhero::takeDamage",
+    "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+    "kind": "method",
+    "parentsym": "T_outerNS::Superhero",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [
+      {
+        "pretty": "outerNS::Thing::takeDamage",
+        "sym": "_ZN7outerNS5Thing10takeDamageEi"
+      }
+    ],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00087:4-25",
+    "structured": 1,
+    "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext::LessGlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00166:12-18",
+    "structured": 1,
+    "pretty": "outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00075:8-25",
+    "structured": 1,
+    "pretty": "GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [
+      {
+        "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+        "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00460:6-21",
+    "structured": 1,
+    "pretty": "outerNS::innerNS::NondebugAnonCat",
+    "sym": "T_outerNS::innerNS::NondebugAnonCat",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00141:6-9",
+    "structured": 1,
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "kind": "field",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  }
+]

--- a/tests/tests/checks/snapshots/check_glob@query__big_cpp__abstractart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__big_cpp__abstractart__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 417,
             "bounds": [
               6,
               17
             ],
+            "line": "class AbstractArt : public Thing {",
             "context": "",
             "contextsym": "",
-            "line": "class AbstractArt : public Thing {",
-            "lno": 417,
-            "peekLines": "class AbstractArt : public Thing {\n"
+            "peekRange": "417-417"
           }
         ]
       }
@@ -28,15 +28,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 135,
             "bounds": [
               6,
               17
             ],
+            "line": "class Thing {",
             "context": "",
             "contextsym": "",
-            "line": "class Thing {",
-            "lno": 135,
-            "peekLines": "class Thing {\n",
+            "peekRange": "135-135",
             "upsearch": "symbol:T_outerNS::Thing"
           }
         ]
@@ -47,15 +47,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 427,
             "bounds": [
               6,
               17
             ],
+            "line": "class PracticalArt : public AbstractArt {",
             "context": "",
             "contextsym": "",
-            "line": "class PracticalArt : public AbstractArt {",
-            "lno": 427,
-            "peekLines": "class PracticalArt : public AbstractArt {\n",
+            "peekRange": "427-427",
             "upsearch": "symbol:T_outerNS::PracticalArt"
           }
         ]
@@ -66,14 +66,14 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 430,
             "bounds": [
               2,
               13
             ],
-            "context": "outerNS::PracticalArt::PracticalArt",
-            "contextsym": "_ZN7outerNS12PracticalArtC1Ev",
             "line": ": AbstractArt() {}",
-            "lno": 430
+            "context": "outerNS::PracticalArt::PracticalArt",
+            "contextsym": "_ZN7outerNS12PracticalArtC1Ev"
           }
         ]
       }

--- a/tests/tests/checks/snapshots/check_glob@query__big_cpp__abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__big_cpp__abstractart_beart__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 424,
             "bounds": [
               13,
               18
             ],
+            "line": "virtual void beArt() = 0;",
             "context": "outerNS::AbstractArt",
             "contextsym": "T_outerNS::AbstractArt",
-            "line": "virtual void beArt() = 0;",
-            "lno": 424,
-            "peekLines": "// This pure virtual method needs to be treated like a definition for our\n// structured record emission purposes.\nvirtual void beArt() = 0;\n"
+            "peekRange": "422-424"
           }
         ]
       }
@@ -28,15 +28,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 433,
             "bounds": [
               5,
               10
             ],
+            "line": "void beArt() override {",
             "context": "outerNS::PracticalArt",
             "contextsym": "T_outerNS::PracticalArt",
-            "line": "void beArt() override {",
-            "lno": 433,
-            "peekLines": "// This should properly see the beArt as something it's overriding.\nvoid beArt() override {\n",
+            "peekRange": "432-433",
             "upsearch": "symbol:_ZN7outerNS12PracticalArt5beArtEv"
           }
         ]

--- a/tests/tests/checks/snapshots/check_glob@query__big_cpp__human__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__big_cpp__human__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 179,
             "bounds": [
               6,
               11
             ],
+            "line": "class Human: public Thing {",
             "context": "",
             "contextsym": "",
-            "line": "class Human: public Thing {",
-            "lno": 179,
-            "peekLines": "class Human: public Thing {\n"
+            "peekRange": "179-179"
           }
         ]
       }
@@ -28,15 +28,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 135,
             "bounds": [
               6,
               11
             ],
+            "line": "class Thing {",
             "context": "",
             "contextsym": "",
-            "line": "class Thing {",
-            "lno": 135,
-            "peekLines": "class Thing {\n",
+            "peekRange": "135-135",
             "upsearch": "symbol:T_outerNS::Thing"
           }
         ]
@@ -47,15 +47,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 188,
             "bounds": [
               6,
               11
             ],
+            "line": "class Superhero : public Human {",
             "context": "",
             "contextsym": "",
-            "line": "class Superhero : public Human {",
-            "lno": 188,
-            "peekLines": "class Superhero : public Human {\n",
+            "peekRange": "188-188",
             "upsearch": "symbol:T_outerNS::Superhero"
           }
         ]
@@ -66,44 +66,44 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 192,
             "bounds": [
               2,
               7
             ],
-            "context": "outerNS::Superhero::Superhero",
-            "contextsym": "_ZN7outerNS9SuperheroC1Ev",
             "line": ": Human() {",
-            "lno": 192
+            "context": "outerNS::Superhero::Superhero",
+            "contextsym": "_ZN7outerNS9SuperheroC1Ev"
           },
           {
+            "lno": 213,
             "bounds": [
               0,
               5
             ],
-            "context": "outerNS::Couch::Couch",
-            "contextsym": "_ZN7outerNS5CouchC1Ei",
             "line": "Human bob;",
-            "lno": 213
+            "context": "outerNS::Couch::Couch",
+            "contextsym": "_ZN7outerNS5CouchC1Ei"
           },
           {
+            "lno": 214,
             "bounds": [
               16,
               21
             ],
-            "context": "outerNS::Couch::Couch",
-            "contextsym": "_ZN7outerNS5CouchC1Ei",
             "line": "WhatsYourVector<Human> goodReferenceRight(&bob);",
-            "lno": 214
+            "context": "outerNS::Couch::Couch",
+            "contextsym": "_ZN7outerNS5CouchC1Ei"
           },
           {
+            "lno": 340,
             "bounds": [
               10,
               15
             ],
-            "context": "outerNS::OuterCat::meet",
-            "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
             "line": "void meet(Human &human) {",
-            "lno": 340
+            "context": "outerNS::OuterCat::meet",
+            "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE"
           }
         ]
       }

--- a/tests/tests/checks/snapshots/check_glob@query__big_cpp__practicalart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__big_cpp__practicalart__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 427,
             "bounds": [
               6,
               18
             ],
+            "line": "class PracticalArt : public AbstractArt {",
             "context": "",
             "contextsym": "",
-            "line": "class PracticalArt : public AbstractArt {",
-            "lno": 427,
-            "peekLines": "class PracticalArt : public AbstractArt {\n"
+            "peekRange": "427-427"
           }
         ]
       }
@@ -28,15 +28,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 417,
             "bounds": [
               6,
               18
             ],
+            "line": "class AbstractArt : public Thing {",
             "context": "",
             "contextsym": "",
-            "line": "class AbstractArt : public Thing {",
-            "lno": 417,
-            "peekLines": "class AbstractArt : public Thing {\n",
+            "peekRange": "417-417",
             "upsearch": "symbol:T_outerNS::AbstractArt"
           }
         ]

--- a/tests/tests/checks/snapshots/check_glob@query__big_cpp__practicalart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__big_cpp__practicalart_beart__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 433,
             "bounds": [
               5,
               10
             ],
+            "line": "void beArt() override {",
             "context": "outerNS::PracticalArt",
             "contextsym": "T_outerNS::PracticalArt",
-            "line": "void beArt() override {",
-            "lno": 433,
-            "peekLines": "// This should properly see the beArt as something it's overriding.\nvoid beArt() override {\n"
+            "peekRange": "432-433"
           }
         ]
       }
@@ -28,15 +28,15 @@ expression: "&jv.value"
         "path": "big_cpp.cpp",
         "lines": [
           {
+            "lno": 424,
             "bounds": [
               13,
               18
             ],
+            "line": "virtual void beArt() = 0;",
             "context": "outerNS::AbstractArt",
             "contextsym": "T_outerNS::AbstractArt",
-            "line": "virtual void beArt() = 0;",
-            "lno": 424,
-            "peekLines": "// This pure virtual method needs to be treated like a definition for our\n// structured record emission purposes.\nvirtual void beArt() = 0;\n",
+            "peekRange": "422-424",
             "upsearch": "symbol:_ZN7outerNS11AbstractArt5beArtEv"
           }
         ]

--- a/tests/tests/checks/snapshots/check_glob@query__overs_cpp__doublePure__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__overs_cpp__doublePure__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 9,
             "bounds": [
               13,
               23
             ],
+            "line": "virtual void doublePure() = 0;",
             "context": "DoubleBase",
             "contextsym": "T_DoubleBase",
-            "line": "virtual void doublePure() = 0;",
-            "lno": 9,
-            "peekLines": "virtual void doublePure() = 0;\n"
+            "peekRange": "9-9"
           }
         ]
       }
@@ -28,27 +28,27 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 15,
             "bounds": [
               5,
               15
             ],
+            "line": "void doublePure() override {",
             "context": "DoubleSubOne",
             "contextsym": "T_DoubleSubOne",
-            "line": "void doublePure() override {",
-            "lno": 15,
-            "peekLines": "void doublePure() override {\n",
+            "peekRange": "15-15",
             "upsearch": "symbol:_ZN12DoubleSubOne10doublePureEv"
           },
           {
+            "lno": 23,
             "bounds": [
               5,
               15
             ],
+            "line": "void doublePure() override {",
             "context": "DoubleSubTwo",
             "contextsym": "T_DoubleSubTwo",
-            "line": "void doublePure() override {",
-            "lno": 23,
-            "peekLines": "void doublePure() override {\n",
+            "peekRange": "23-23",
             "upsearch": "symbol:_ZN12DoubleSubTwo10doublePureEv"
           }
         ]
@@ -59,24 +59,24 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 64,
             "bounds": [
               8,
               18
             ],
-            "context": "generateDoubleUses",
-            "contextsym": "_Z18generateDoubleUsesv",
             "line": "subOne->doublePure();",
-            "lno": 64
+            "context": "generateDoubleUses",
+            "contextsym": "_Z18generateDoubleUsesv"
           },
           {
+            "lno": 65,
             "bounds": [
               8,
               18
             ],
-            "context": "generateDoubleUses",
-            "contextsym": "_Z18generateDoubleUsesv",
             "line": "subTwo->doublePure();",
-            "lno": 65
+            "context": "generateDoubleUses",
+            "contextsym": "_Z18generateDoubleUsesv"
           }
         ]
       }

--- a/tests/tests/checks/snapshots/check_glob@query__overs_cpp__triplePure__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@query__overs_cpp__triplePure__json.snap
@@ -10,15 +10,15 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 31,
             "bounds": [
               13,
               23
             ],
+            "line": "virtual void triplePure() = 0;",
             "context": "TripleBase",
             "contextsym": "T_TripleBase",
-            "line": "virtual void triplePure() = 0;",
-            "lno": 31,
-            "peekLines": "virtual void triplePure() = 0;\n"
+            "peekRange": "31-31"
           }
         ]
       }
@@ -28,39 +28,39 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 37,
             "bounds": [
               5,
               15
             ],
+            "line": "void triplePure() override {",
             "context": "TripleSubOne",
             "contextsym": "T_TripleSubOne",
-            "line": "void triplePure() override {",
-            "lno": 37,
-            "peekLines": "void triplePure() override {\n",
+            "peekRange": "37-37",
             "upsearch": "symbol:_ZN12TripleSubOne10triplePureEv"
           },
           {
+            "lno": 45,
             "bounds": [
               5,
               15
             ],
+            "line": "void triplePure() override {",
             "context": "TripleSubTwo",
             "contextsym": "T_TripleSubTwo",
-            "line": "void triplePure() override {",
-            "lno": 45,
-            "peekLines": "void triplePure() override {\n",
+            "peekRange": "45-45",
             "upsearch": "symbol:_ZN12TripleSubTwo10triplePureEv"
           },
           {
+            "lno": 53,
             "bounds": [
               5,
               15
             ],
+            "line": "void triplePure() override {",
             "context": "TripleSubThree",
             "contextsym": "T_TripleSubThree",
-            "line": "void triplePure() override {",
-            "lno": 53,
-            "peekLines": "void triplePure() override {\n",
+            "peekRange": "53-53",
             "upsearch": "symbol:_ZN14TripleSubThree10triplePureEv"
           }
         ]
@@ -71,34 +71,34 @@ expression: "&jv.value"
         "path": "overs.cpp",
         "lines": [
           {
+            "lno": 79,
             "bounds": [
               8,
               18
             ],
-            "context": "generateTripleUses",
-            "contextsym": "_Z18generateTripleUsesv",
             "line": "subOne->triplePure();",
-            "lno": 79
+            "context": "generateTripleUses",
+            "contextsym": "_Z18generateTripleUsesv"
           },
           {
+            "lno": 80,
             "bounds": [
               8,
               18
             ],
-            "context": "generateTripleUses",
-            "contextsym": "_Z18generateTripleUsesv",
             "line": "subTwo->triplePure();",
-            "lno": 80
+            "context": "generateTripleUses",
+            "contextsym": "_Z18generateTripleUsesv"
           },
           {
+            "lno": 81,
             "bounds": [
               10,
               20
             ],
-            "context": "generateTripleUses",
-            "contextsym": "_Z18generateTripleUsesv",
             "line": "subThree->triplePure();",
-            "lno": 81
+            "context": "generateTripleUses",
+            "contextsym": "_Z18generateTripleUsesv"
           }
         ]
       }

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -62,6 +62,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-stream"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171374e7e3b2504e0e5236e3b59260560f9fe94bfe9ac39ba5e4e929c5590625"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648ed8c8d2ce5409ccd57453d9d1b214b342a0d69376a6feda1fd6cae3299308"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,9 +516,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.15"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0402f765d8a89a26043b889b26ce3c4679d268fa6bb22cd7c6aad98340e179d1"
+checksum = "88d1c26957f23603395cd326b0ffe64124b818f4449552f960d815cfba83a53d"
 
 [[package]]
 name = "futures-sink"
@@ -2201,9 +2222,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "588b2d10a336da58d877567cd8fb8a14b463e2104910f8132cd054b4b96e29ee"
 dependencies = [
  "autocfg 1.0.1",
  "bytes 1.0.1",
@@ -2213,6 +2234,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -2248,6 +2270,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2265,11 +2298,13 @@ dependencies = [
 name = "tools"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "async-trait",
  "chrono",
  "clap",
  "env_logger",
  "flate2",
+ "futures-core",
  "getopts",
  "git2",
  "hyper 0.10.16",
@@ -2297,6 +2332,7 @@ dependencies = [
  "shell-words",
  "structopt",
  "tokio",
+ "tokio-stream",
  "url 2.2.2",
  "ustr",
 ]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -15,6 +15,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
+name = "ahash"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check 0.9.3",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,7 +283,7 @@ dependencies = [
  "proc-macro2",
  "procedural-masquerade",
  "quote",
- "smallvec",
+ "smallvec 0.6.14",
  "syn",
 ]
 
@@ -595,7 +606,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 dependencies = [
- "ahash",
+ "ahash 0.4.7",
 ]
 
 [[package]]
@@ -765,6 +776,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,9 +949,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.94"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18794a8ad5b29321f790b55d93dfba91e125cb1a9edbd4f8e3150acc771c1a5e"
+checksum = "7b2f96d100e1cf1929e7719b7edb3b90ab5298072638fccd77be9ce942ecdfce"
 
 [[package]]
 name = "libgit2-sys"
@@ -986,6 +1006,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "982160d2fa2fa89ca7efec4bbcd3ced2103fddd51934f12eb00501980dd0c501"
 dependencies = [
  "memchr 1.0.2",
+]
+
+[[package]]
+name = "lock_api"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712a4d093c9976e24e7dbca41db895dabcbac38eb5f4045393d17a95bdfb1109"
+dependencies = [
+ "scopeguard",
 ]
 
 [[package]]
@@ -1221,9 +1250,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.7.2"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "openssl"
@@ -1256,6 +1285,31 @@ dependencies = [
  "libc",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+dependencies = [
+ "cfg-if 1.0.0",
+ "instant",
+ "libc",
+ "redox_syscall",
+ "smallvec 1.7.0",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1773,6 +1827,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
 name = "security-framework"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1810,24 +1870,24 @@ dependencies = [
  "phf_codegen",
  "precomputed-hash",
  "servo_arc",
- "smallvec",
+ "smallvec 0.6.14",
  "thin-slice",
 ]
 
 [[package]]
 name = "serde"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7505abeacaec74ae4778d9d9328fe5a5d04253220a85c4ee022239fc996d03"
+checksum = "f12d06de37cf59146fbdecab66aa99f9fe4f78722e3607577a5375d66bd0c913"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.126"
+version = "1.0.130"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "963a7dbc9895aeac7ac90e74f34a5d5261828f79df35cbed41e10189d3804d43"
+checksum = "d7bc1a1ab1961464eae040d96713baa5a724a8152c1222492465b54322ec508b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1836,14 +1896,25 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.64"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
+checksum = "a7f9e390c27c3c0ce8bc5d725f6e4d30a29d26659494aa4b17535f7522c5c950"
 dependencies = [
  "indexmap",
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98d0516900518c29efa217c298fa1f4e6c6ffc85ae29fd7f4ee48f176e1a9ed5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1918,6 +1989,12 @@ checksum = "b97fcaeba89edba30f044a10c6a3cc39df9c3f17d7cd829dd1446cab35f890e0"
 dependencies = [
  "maybe-uninit",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "socket2"
@@ -2214,11 +2291,14 @@ dependencies = [
  "rls-analysis",
  "rls-data",
  "rustc-serialize",
+ "serde",
  "serde_json",
+ "serde_repr",
  "shell-words",
  "structopt",
  "tokio",
  "url 2.2.2",
+ "ustr",
 ]
 
 [[package]]
@@ -2337,6 +2417,19 @@ dependencies = [
  "idna 0.2.3",
  "matches",
  "percent-encoding 2.1.0",
+]
+
+[[package]]
+name = "ustr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbd539d8973e229b9d04f15d36e6a8f8d8f85f946b366f06bb001aaed3fa9dd9"
+dependencies = [
+ "ahash 0.7.6",
+ "byteorder",
+ "lazy_static",
+ "parking_lot",
+ "serde",
 ]
 
 [[package]]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -34,10 +34,15 @@ rls-analysis = "0.18.1"
 rls-data = "0.19.1"
 rustc-serialize = "0.3.18"
 shell-words = "1.0.0"
-serde_json = { version = "1.0.64", features = ["preserve_order"] }
+# Note that the "rc" feature as documented at https://serde.rs/feature-flags.html
+# does not make any effort to do interning
+serde = { version = "1.0.130", features = ["derive", "rc", "std"] }
+serde_json = { version = "1.0.67", features = ["preserve_order"] }
+serde_repr = "0.1"
 structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 url = "2.2.2"
+ustr = { version = "0.8.1", features = ["serialization"] }
 
 # Build release mode with line number info for easier debugging when
 # we hit panics in production

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -5,11 +5,13 @@ authors = ["Bill McCloskey <billm@mozilla.com>"]
 edition = "2018"
 
 [dependencies]
+async-stream = "0.3.2"
 async-trait = "0.1.50"
 chrono = "0.2"
 clap = "2"
 env_logger = "0.7.1"
 flate2 = { version = "1", features = ["tokio"] }
+futures-core = "0.3.17"
 getopts = "0.2.19"
 git2 = "0.13.20"
 hyper = "0.10"
@@ -41,6 +43,7 @@ serde_json = { version = "1.0.67", features = ["preserve_order"] }
 serde_repr = "0.1"
 structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
+tokio-stream = "0.1.8"
 url = "2.2.2"
 ustr = { version = "0.8.1", features = ["serialization"] }
 

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -46,6 +46,7 @@ async fn read_gzipped_ndjson_from_file(path: &str) -> Result<Vec<Value>> {
         .collect()
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct LocalIndex {
     // We only hold onto the TreeConfigPaths portion of the config because the

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -66,6 +66,10 @@ struct LocalIndex {
 
 #[async_trait]
 impl AbstractServer for LocalIndex {
+    fn translate_analysis_path(&self, sf_path: &str) -> Result<String> {
+        Ok(format!("{}/analysis/{}.gz", self.config_paths.index_path, sf_path))
+    }
+
     async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
         let full_path = format!("{}/analysis/{}.gz", self.config_paths.index_path, sf_path);
         let values = read_gzipped_ndjson_from_file(&full_path).await?;

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -25,6 +25,7 @@ impl From<ParseError> for ServerError {
     }
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct RemoteServer {
     server_base_url: Url,

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -84,6 +84,11 @@ async fn get_json(url: Url) -> Result<reqwest::Response> {
 
 #[async_trait]
 impl AbstractServer for RemoteServer {
+    fn translate_analysis_path(&self, _sf_path: &str) -> Result<String> {
+        // Remote servers don't have local filesystem paths.
+        Err(ServerError::Unsupported)
+    }
+
     async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
         let url = self.raw_analysis_base_url.join(sf_path)?;
         let raw_str = get(url).await?.text().await?;

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -1,4 +1,5 @@
 use async_trait::async_trait;
+use futures_core::stream::BoxStream;
 use serde_json::Value;
 
 pub type Result<T> = std::result::Result<T, ServerError>;
@@ -96,7 +97,7 @@ pub enum ServerError {
 ///
 #[async_trait]
 pub trait AbstractServer {
-    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<Vec<Value>>;
+    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>>;
 
     async fn fetch_html(&self, sf_path: &str) -> Result<String>;
 

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -97,6 +97,10 @@ pub enum ServerError {
 ///
 #[async_trait]
 pub trait AbstractServer {
+    /// Convert a searchfox tree-local path into an absolute analysis path on
+    /// disk.  This fundamentally only works for local indices.
+    fn translate_analysis_path(&self, sf_path: &str) -> Result<String>;
+
     async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>>;
 
     async fn fetch_html(&self, sf_path: &str) -> Result<String>;

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -83,11 +83,9 @@ pub enum ServerError {
 ///
 /// Currently existing analysis-file processing and other logic:
 /// - Uses synchronous I/O
-/// - Uses rustc_serialize::json
 ///
 /// In the end, it likely would make sense for the analysis mechanism to:
 /// - Support async I/O
-/// - Use serde_json
 /// - Use async streams via https://docs.rs/tokio-stream/0.1.5/tokio_stream/
 ///   on a per-record or per-line granularity, quite possibly using our analysis
 ///   types for analysis records instead of untyped JSON.

--- a/tools/src/bin/merge-analyses.rs
+++ b/tools/src/bin/merge-analyses.rs
@@ -12,33 +12,16 @@
 //! Note that as this code uses the analysis.rs code for parsing and printing,
 //! the emitted output should always be in a consistent/normalized format.
 
-use std::collections::hash_map::DefaultHasher;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::env;
-use std::hash::Hash;
-use std::hash::Hasher;
+use std::io::stdout;
 
 extern crate regex;
 use regex::Regex;
-use serde_json::to_value;
-use serde_json::{from_value, json, to_string, Value};
-use tools::file_format::analysis::AnalysisUnion;
 
 extern crate env_logger;
 
 extern crate tools;
-use tools::file_format::analysis::{
-    read_analyses, AnalysisSource, AnalysisStructured, Location, WithLocation,
-};
-
-#[derive(Debug)]
-pub struct HashedStructured {
-    pub platforms: Vec<usize>,
-    pub loc: Location,
-    pub data: AnalysisStructured,
-}
+use tools::file_format::merger::merge_files;
 
 fn main() {
     env_logger::init();
@@ -67,168 +50,5 @@ fn main() {
         })
         .collect();
 
-    let mut unique_targets = HashSet::new();
-    // Maps from symbol name to a HashMap<u64 hash, HashedStructured>
-    let mut structured_syms = BTreeMap::new();
-
-    let src_data = read_analyses(&args, &mut |obj: Value, loc: &Location, i_file: usize| {
-        if let Ok(unified) = from_value(obj) {
-            match unified {
-                AnalysisUnion::Source(src) => {
-                    // return source objects for so that they come out of `read_analyses` for
-                    // additional processing below.
-                    return Some(src);
-                }
-                AnalysisUnion::Target(tgt) => {
-                    // for target objects, just print them back out, but use the `unique_targets`
-                    // hashset to deduplicate them.
-                    let target_str = to_string(&WithLocation {
-                        data: tgt,
-                        loc: loc.clone(),
-                    })
-                    .unwrap();
-                    if !unique_targets.contains(&target_str) {
-                        println!("{}", target_str);
-                        unique_targets.insert(target_str);
-                    }
-                }
-                AnalysisUnion::Structured(structured) => {
-                    // Structured objects may have different data for different platforms.  We
-                    // detect this by building a map for each symbol from the hash of the string
-                    // representation of their JSON encoding to the AnalysisStructured
-                    // representation.  If, after processing the files we find there was a single
-                    // hash, then we emit that record as we originally found it.  However, if there
-                    // were multiple hashes, we pick the last.
-                    //
-                    // We used to have AnalysisStructured be hashable, but the `extra` Map was
-                    // not currently hashable due to https://github.com/serde-rs/json/issues/747
-                    // and in reality we just want to hash the JSON string, but it's already
-                    // been parsed into a Value, which is why we're not using the string.
-                    let variants = structured_syms
-                        .entry(structured.sym.clone())
-                        .or_insert(HashMap::new());
-                    let json_str = to_string(&structured).unwrap();
-                    let mut hasher = DefaultHasher::new();
-                    json_str.hash(&mut hasher);
-                    let hash_key = hasher.finish();
-                    let hs = variants.entry(hash_key).or_insert(HashedStructured {
-                        platforms: vec![],
-                        loc: loc.clone(),
-                        data: structured,
-                    });
-                    hs.platforms.push(i_file);
-                }
-            }
-        }
-        None
-    });
-
-    // For each bucket of source data at a given location, sort the source data by
-    // the `pretty` field. This allows us to walk through the bucket and operate
-    // with the assumption that entries with the same (location, pretty) tuple are
-    // adjacent. If we do run into such entries we merge them to union the tokens
-    // in the `syntax` and `sym` fields.
-    for mut loc_data in src_data {
-        loc_data.data.sort_by(|s1, s2| s1.pretty.cmp(&s2.pretty));
-        let mut last_entry: Option<AnalysisSource> = None;
-        for analysis_entry in std::mem::replace(&mut loc_data.data, Vec::new()) {
-            match last_entry {
-                Some(mut e) => {
-                    if e.pretty == analysis_entry.pretty {
-                        // the (loc, pretty) tuple on `analysis_entry` matches that
-                        // on `last_entry` so we merge them
-                        e.merge(analysis_entry);
-                        last_entry = Some(e);
-                    } else {
-                        loc_data.data.push(e);
-                        last_entry = Some(analysis_entry);
-                    }
-                }
-                None => {
-                    last_entry = Some(analysis_entry);
-                }
-            }
-        }
-        if let Some(e) = last_entry {
-            loc_data.data.push(e);
-        }
-        print!("{}", to_string(&loc_data).unwrap());
-    }
-
-    for (_id, mut hmap) in structured_syms {
-        if hmap.len() == 1 {
-            // There was only one variant of the structured info, so we can just use it as-is.
-            let (_hash, hs) = hmap.drain().next().unwrap();
-            println!(
-                "{}",
-                to_string(&WithLocation {
-                    loc: hs.loc,
-                    data: hs.data
-                })
-                .unwrap()
-            );
-        } else {
-            // There are multiple variants, so we want to:
-            // 1. Pick one of the variants as the canonical variant.  For now our heuristic is to
-            //    pick the highest platform index.  This is because the platform list is currently
-            //    accomplished via wildcard that puts "android-armv7" first and that's a 32-bit
-            //    platform, and we'd rather our defaults be 64-bit.
-            // 2. Using the `extras` field, populate a `platforms` value in
-            //    the canonical variant as well a `variants` field.  This should
-            //    allow round-tripping while also avoiding us actually doing
-            //    anything with this surplus-ish info which we expect to only be
-            //    consumed by front-end JS UI at this time for the purposes of
-            //    showing differing memory layouts across platforms.
-            //
-            // Prior to the conversion to serde_json, the `extras` field was a
-            // JSON-string `payload` field and we just did a lot of sketchy
-            // gluing together of raw JSON string fragments.
-
-            // Do a pass to pick the best hash.
-            let mut best_hash = 0;
-            let mut best_plat = 0;
-            for (hash, hs) in hmap.iter() {
-                let local_plat = hs.platforms.iter().max().unwrap();
-                if local_plat >= &best_plat {
-                    best_plat = *local_plat;
-                    best_hash = *hash;
-                }
-            }
-
-            let mut hs = hmap.remove(&best_hash).unwrap();
-            hs.data.extra.insert(
-                "platforms".to_string(),
-                json!(hs
-                    .platforms
-                    .iter()
-                    .map(|x| platforms[*x].clone())
-                    .collect::<Vec<String>>()),
-            );
-            hs.data.extra.insert(
-                "variants".to_string(),
-                hmap.into_values()
-                    .map(|mut variant| {
-                        variant.data.extra.insert(
-                            "platforms".to_string(),
-                            json!(variant
-                                .platforms
-                                .iter()
-                                .map(|x| platforms[*x].clone())
-                                .collect::<Vec<String>>()),
-                        );
-                        to_value(&variant.data).unwrap()
-                    })
-                    .collect(),
-            );
-
-            println!(
-                "{}",
-                to_string(&WithLocation {
-                    loc: hs.loc,
-                    data: hs.data
-                })
-                .unwrap()
-            );
-        }
-    }
+    merge_files(&args, &platforms, &mut stdout());
 }

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -10,14 +10,14 @@ extern crate tools;
 use crate::data::GlobalCrateId;
 use crate::data::{DefKind, ImplKind};
 use rls_analysis::{AnalysisHost, AnalysisLoader, SearchDirectory};
+use serde_json::to_string;
+use ustr::ustr;
 use std::collections::{BTreeSet, HashMap};
 use std::fs::{self, File};
 use std::io;
 use std::io::{BufRead, BufReader, Read, Seek};
 use std::path::{Path, PathBuf};
-use tools::file_format::analysis::{
-    AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location, SourceRange, WithLocation,
-};
+use tools::file_format::analysis::{AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location, SourceRange, SourceTag, TargetTag, WithLocation};
 
 /// A global definition id in a crate.
 ///
@@ -379,11 +379,12 @@ fn visit_common(
     let sanitized = sanitize_symbol(qualname);
     let target_data = WithLocation {
         data: AnalysisTarget {
+            target: TargetTag::Target,
             kind,
-            pretty: sanitized.clone(),
-            sym: sanitized.clone(),
-            context: String::from(context.unwrap_or("")),
-            contextsym: String::from(context.unwrap_or("")),
+            pretty: ustr(&sanitized),
+            sym: ustr(&sanitized),
+            context: ustr(context.unwrap_or("")),
+            contextsym: ustr(context.unwrap_or("")),
             peek_range: LineRange {
                 start_lineno: 0,
                 end_lineno: 0,
@@ -391,7 +392,7 @@ fn visit_common(
         },
         loc: loc.clone(),
     };
-    out_data.insert(format!("{}", target_data));
+    out_data.insert(to_string(&target_data).unwrap());
 
     let nesting_range = match nesting {
         Some(span) => SourceRange {
@@ -412,9 +413,10 @@ fn visit_common(
 
     let source_data = WithLocation {
         data: AnalysisSource {
+            source: SourceTag::Source,
             syntax: vec![],
-            pretty: pretty.to_string(),
-            sym: vec![sanitized],
+            pretty: ustr(&pretty),
+            sym: vec![ustr(&sanitized)],
             no_crossref: false,
             nesting_range,
             // TODO: Expose type information for fields/etc.
@@ -423,7 +425,7 @@ fn visit_common(
         },
         loc,
     };
-    out_data.insert(format!("{}", source_data));
+    out_data.insert(to_string(&source_data).unwrap());
 }
 
 /// Normalizes a searchfox user-visible relative file path to be an absolute

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::cmd_filter_analysis::FilterAnalysisCommand;
+use super::{cmd_filter_analysis::FilterAnalysisCommand, cmd_merge_analyses::MergeAnalysesCommand};
 use super::cmd_query::QueryCommand;
 use super::cmd_show_html::ShowHtmlCommand;
 
@@ -63,22 +63,27 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
         }
 
         match opts.cmd {
-            Command::Query(q) => {
-                commands.push(Box::new(QueryCommand { args: q }))
-            }
-
             Command::FilterAnalysis(fa) => {
                 commands.push(Box::new(FilterAnalysisCommand { args: fa }));
             }
 
-            Command::ShowHtml(sh) => {
-                commands.push(Box::new(ShowHtmlCommand { args: sh }));
-            }
-
             Command::IdentifierLookup(_il) => (),
+
+            Command::MergeAnalyses(ma) => {
+                commands.push(Box::new(MergeAnalysesCommand{ args: ma }))
+            }
 
             Command::ProductionFilter(pf) => {
                 commands.push(Box::new(ProductionFilterCommand { args: pf }))
+            }
+
+            Command::Query(q) => {
+                commands.push(Box::new(QueryCommand { args: q }))
+            }
+
+
+            Command::ShowHtml(sh) => {
+                commands.push(Box::new(ShowHtmlCommand { args: sh }));
             }
         }
     }

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -1,0 +1,62 @@
+use async_trait::async_trait;
+use serde_json::{from_str, Value};
+use structopt::StructOpt;
+
+use super::interface::{
+    JsonRecords, PipelineCommand, PipelineValues,
+};
+use crate::{
+    abstract_server::{AbstractServer, Result, ServerError},
+    cmd_pipeline::interface::JsonRecordsByFile,
+    file_format::merger::merge_files,
+};
+
+#[derive(Debug, StructOpt)]
+pub struct MergeAnalyses {
+    /// Tree-relative analysis file paths
+    files: Vec<String>,
+
+    /// The list of platforms to claim the files came from.
+    #[structopt(long, short)]
+    platforms: Vec<String>,
+}
+
+/// Command brought into existence to test the analysis-merging logic of
+/// `merge-analyses.rs`.
+pub struct MergeAnalysesCommand {
+    pub args: MergeAnalyses,
+}
+
+#[async_trait]
+impl PipelineCommand for MergeAnalysesCommand {
+    ///
+    ///
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        _input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let abs_paths: Result<Vec<String>> = self
+            .args
+            .files
+            .iter()
+            .map(|f| server.translate_analysis_path(f))
+            .collect();
+
+        let mut merged_output = Vec::new();
+        merge_files(&abs_paths?, &self.args.platforms, &mut merged_output);
+
+        let values: Result<Vec<Value>> = std::str::from_utf8(merged_output.as_slice())
+            .unwrap()
+            .lines()
+            .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+            .collect();
+
+        Ok(PipelineValues::JsonRecords(JsonRecords {
+            by_file: vec![JsonRecordsByFile {
+                file: self.args.files.iter().next().unwrap().clone(),
+                records: values?,
+            }],
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use lazy_static::lazy_static;
 use lol_html::{
-    element, html_content::ContentType, rewrite_str, RewriteStrSettings,
+    element, rewrite_str, RewriteStrSettings,
 };
 use regex::Regex;
 use serde_json::Value;

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -6,6 +6,7 @@ pub mod interface;
 pub mod parser;
 
 mod cmd_filter_analysis;
+mod cmd_merge_analyses;
 mod cmd_prod_filter;
 mod cmd_query;
 mod cmd_show_html;

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -2,6 +2,7 @@ use clap::arg_enum;
 use structopt::StructOpt;
 
 use super::cmd_filter_analysis::FilterAnalysis;
+use super::cmd_merge_analyses::MergeAnalyses;
 use super::cmd_prod_filter::ProductionFilter;
 use super::cmd_query::Query;
 use super::cmd_show_html::ShowHtml;
@@ -40,11 +41,12 @@ pub struct ToolOpts {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
-    Query(Query),
     FilterAnalysis(FilterAnalysis),
-    ShowHtml(ShowHtml),
     IdentifierLookup(IdentifierLookup),
+    MergeAnalyses(MergeAnalyses),
     ProductionFilter(ProductionFilter),
+    Query(Query),
+    ShowHtml(ShowHtml),
 }
 
 #[derive(Debug, StructOpt)]

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -11,7 +11,7 @@ use serde_json::{from_str, from_value, Map, Value};
 use serde_repr::*;
 use ustr::{ustr, Ustr, UstrMap};
 
-#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, PartialOrd, Ord, Debug)]
 pub struct Location {
     pub lineno: u32,
     pub col_start: u32,

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -520,6 +520,10 @@ pub fn read_analysis<T>(
 /// transformed via the provided `filter`, resulting in either AnalysisSource records being
 /// returned (if `read_source` is provided) or AnalysisTarget (if `read_target`) and other record
 /// types being ignored.
+///
+/// Note that the filter function is invoked as records are read in, which means
+/// that the sort order seen by the filter function is the order the file
+/// already had.  It's only the return value that's sorted and grouped.
 pub fn read_analyses<T>(
     filenames: &[String],
     filter: &mut dyn FnMut(Value, &Location, usize) -> Option<T>,

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -6,7 +6,8 @@ use std::io::BufRead;
 use std::process::Command;
 use std::str;
 
-use rustc_serialize::json;
+use serde::{Deserialize, Serialize};
+use serde_json::{to_string};
 
 use crate::config;
 
@@ -26,7 +27,7 @@ pub struct IdentMap {
     mmap: Option<Mmap>,
 }
 
-#[derive(RustcDecodable, RustcEncodable)]
+#[derive(Serialize, Deserialize)]
 pub struct IdentResult {
     pub id: String,
     pub symbol: String,
@@ -191,6 +192,6 @@ impl IdentMap {
         max_results: usize,
     ) -> String {
         let results = self.lookup(needle, complete, fold_case, max_results);
-        json::encode(&results).unwrap()
+        to_string(&results).unwrap()
     }
 }

--- a/tools/src/file_format/merger.rs
+++ b/tools/src/file_format/merger.rs
@@ -1,0 +1,200 @@
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::collections::HashSet;
+use std::hash::Hash;
+use std::hash::Hasher;
+
+extern crate regex;
+use serde_json::to_value;
+use serde_json::{from_value, json, to_string, Value};
+
+use super::analysis::AnalysisUnion;
+use super::analysis::{
+    read_analyses, AnalysisSource, AnalysisStructured, Location, WithLocation,
+};
+
+#[derive(Debug)]
+pub struct HashedStructured {
+    pub platforms: Vec<usize>,
+    pub loc: Location,
+    pub data: AnalysisStructured,
+}
+
+/// Given a list of files and a matching parallel list of platform identifiers,
+/// merge the records and write them to the provided writer.
+///
+/// This logic was extracted out from `merge-analyses.rs` for the purpose of
+/// being able to test its logic through the introduction of `cmd_merge_ananlyses`.
+///
+/// The logic could almost certainly be further unified into the `cmd_pipeline`
+/// data model, with callers potentially altered to use searchfox-tool and
+/// eliminate the standalone merge-analyses.rs binary.  But there's no urgency.
+pub fn merge_files<W: std::io::Write>(filenames: &[String],  platforms: &Vec<String>, mut writer: W) {
+  let mut unique_targets = HashSet::new();
+  // Maps from symbol name to a HashMap<u64 hash, HashedStructured>
+  let mut structured_syms = BTreeMap::new();
+
+  let src_data = read_analyses(filenames, &mut |obj: Value, loc: &Location, i_file: usize| {
+      if let Ok(unified) = from_value(obj) {
+          match unified {
+              AnalysisUnion::Source(src) => {
+                  // return source objects so that they come out of `read_analyses` for
+                  // additional processing below.
+                  return Some(src);
+              }
+              AnalysisUnion::Target(tgt) => {
+                  // for target objects, just print them back out, but use the `unique_targets`
+                  // hashset to deduplicate them.
+                  let target_str = to_string(&WithLocation {
+                      data: tgt,
+                      loc: loc.clone(),
+                  })
+                  .unwrap();
+                  if !unique_targets.contains(&target_str) {
+                      writeln!(writer, "{}", target_str).unwrap();
+                      unique_targets.insert(target_str);
+                  }
+              }
+              AnalysisUnion::Structured(structured) => {
+                  // Structured objects may have different data for different platforms.  We
+                  // detect this by building a map for each symbol from the hash of the string
+                  // representation of their JSON encoding to the AnalysisStructured
+                  // representation.  If, after processing the files we find there was a single
+                  // hash, then we emit that record as we originally found it.  However, if there
+                  // were multiple hashes, we pick the last.
+                  //
+                  // We used to have AnalysisStructured be hashable, but the `extra` Map was
+                  // not currently hashable due to https://github.com/serde-rs/json/issues/747
+                  // and in reality we just want to hash the JSON string, but it's already
+                  // been parsed into a Value, which is why we're not using the string.
+                  let variants = structured_syms
+                      .entry(structured.sym.clone())
+                      .or_insert(HashMap::new());
+                  let json_str = to_string(&structured).unwrap();
+                  let mut hasher = DefaultHasher::new();
+                  json_str.hash(&mut hasher);
+                  let hash_key = hasher.finish();
+                  let hs = variants.entry(hash_key).or_insert(HashedStructured {
+                      platforms: vec![],
+                      loc: loc.clone(),
+                      data: structured,
+                  });
+                  hs.platforms.push(i_file);
+              }
+          }
+      }
+      None
+  });
+
+  // For each bucket of source data at a given location, sort the source data by
+  // the `pretty` field. This allows us to walk through the bucket and operate
+  // with the assumption that entries with the same (location, pretty) tuple are
+  // adjacent. If we do run into such entries we merge them to union the tokens
+  // in the `syntax` and `sym` fields.
+  for mut loc_data in src_data {
+      loc_data.data.sort_by(|s1, s2| s1.pretty.cmp(&s2.pretty));
+      let mut last_entry: Option<AnalysisSource> = None;
+      for analysis_entry in std::mem::replace(&mut loc_data.data, Vec::new()) {
+          match last_entry {
+              Some(mut e) => {
+                  if e.pretty == analysis_entry.pretty {
+                      // the (loc, pretty) tuple on `analysis_entry` matches that
+                      // on `last_entry` so we merge them
+                      e.merge(analysis_entry);
+                      last_entry = Some(e);
+                  } else {
+                      loc_data.data.push(e);
+                      last_entry = Some(analysis_entry);
+                  }
+              }
+              None => {
+                  last_entry = Some(analysis_entry);
+              }
+          }
+      }
+      if let Some(e) = last_entry {
+          loc_data.data.push(e);
+      }
+      writeln!(writer, "{}", to_string(&loc_data).unwrap()).unwrap();
+  }
+
+  for (_id, mut hmap) in structured_syms {
+      if hmap.len() == 1 {
+          // There was only one variant of the structured info, so we can just use it as-is.
+          let (_hash, hs) = hmap.drain().next().unwrap();
+          writeln!(
+              writer,
+              "{}",
+              to_string(&WithLocation {
+                  loc: hs.loc,
+                  data: hs.data
+              })
+              .unwrap()
+          ).unwrap();
+      } else {
+          // There are multiple variants, so we want to:
+          // 1. Pick one of the variants as the canonical variant.  For now our heuristic is to
+          //    pick the highest platform index.  This is because the platform list is currently
+          //    accomplished via wildcard that puts "android-armv7" first and that's a 32-bit
+          //    platform, and we'd rather our defaults be 64-bit.
+          // 2. Using the `extras` field, populate a `platforms` value in
+          //    the canonical variant as well a `variants` field.  This should
+          //    allow round-tripping while also avoiding us actually doing
+          //    anything with this surplus-ish info which we expect to only be
+          //    consumed by front-end JS UI at this time for the purposes of
+          //    showing differing memory layouts across platforms.
+          //
+          // Prior to the conversion to serde_json, the `extras` field was a
+          // JSON-string `payload` field and we just did a lot of sketchy
+          // gluing together of raw JSON string fragments.
+
+          // Do a pass to pick the best hash.
+          let mut best_hash = 0;
+          let mut best_plat = 0;
+          for (hash, hs) in hmap.iter() {
+              let local_plat = hs.platforms.iter().max().unwrap();
+              if local_plat >= &best_plat {
+                  best_plat = *local_plat;
+                  best_hash = *hash;
+              }
+          }
+
+          let mut hs = hmap.remove(&best_hash).unwrap();
+          hs.data.extra.insert(
+              "platforms".to_string(),
+              json!(hs
+                  .platforms
+                  .iter()
+                  .map(|x| platforms[*x].clone())
+                  .collect::<Vec<String>>()),
+          );
+          hs.data.extra.insert(
+              "variants".to_string(),
+              hmap.into_values()
+                  .map(|mut variant| {
+                      variant.data.extra.insert(
+                          "platforms".to_string(),
+                          json!(variant
+                              .platforms
+                              .iter()
+                              .map(|x| platforms[*x].clone())
+                              .collect::<Vec<String>>()),
+                      );
+                      to_value(&variant.data).unwrap()
+                  })
+                  .collect(),
+          );
+
+          writeln!(
+              writer,
+              "{}",
+              to_string(&WithLocation {
+                  loc: hs.loc,
+                  data: hs.data
+              })
+              .unwrap()
+          ).unwrap();
+      }
+  }
+}

--- a/tools/src/file_format/merger.rs
+++ b/tools/src/file_format/merger.rs
@@ -116,7 +116,12 @@ pub fn merge_files<W: std::io::Write>(filenames: &[String],  platforms: &Vec<Str
       if let Some(e) = last_entry {
           loc_data.data.push(e);
       }
-      writeln!(writer, "{}", to_string(&loc_data).unwrap()).unwrap();
+      // We can't convert WithLocation<Vec<T>> directly to JSON; we need to
+      // spread the loc to each individual piece of data.
+      let loc = loc_data.loc;
+      for datum in loc_data.data {
+        writeln!(writer, "{}", to_string(&WithLocation { loc, data: datum }).unwrap()).unwrap();
+      }
   }
 
   for (_id, mut hmap) in structured_syms {

--- a/tools/src/file_format/mod.rs
+++ b/tools/src/file_format/mod.rs
@@ -1,2 +1,3 @@
 pub mod analysis;
 pub mod identifiers;
+pub mod merger;

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -9,12 +9,12 @@ extern crate git2;
 extern crate itertools;
 extern crate linkify;
 extern crate regex;
-extern crate rustc_serialize;
 #[macro_use]
 extern crate malloc_size_of_derive;
 extern crate jemalloc_sys;
 extern crate jemallocator;
 extern crate malloc_size_of;
+extern crate serde;
 extern crate serde_json;
 extern crate structopt;
 

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -1,4 +1,3 @@
-use regex::Regex;
 use tokio::fs::{read_dir, read_to_string};
 use tools::{abstract_server::ServerError, cmd_pipeline::{build_pipeline, PipelineValues}};
 


### PR DESCRIPTION
This is a migration to serde_json from rustc_serialize and undertakes
some related cleanups/refactorings when doing so.  It can be handy to
read / consult the following sources of information for context:
- https://docs.serde.rs/serde_json/ at the top-level has a great intro
  to `json!` and related helpers.
- https://serde.rs/ while notionally about serde proper has many
  specifics relating to serde_json.  The "attributes" and "examples"
  documentation is exceedingly relevant.

The following things are going on in this patch:
- Mechanical translations from the rustc_serialize wrappers to just
  using `json!`.  In some cases I've also gotten rid of intermediary
  maps because `json!` has really great ergonomics.
  - There are probably places we could use `json!` more.  In some
    cases I punted because I didn't see a way to conditionally omit
    some key/value pairs trivially, but presumably those could just
    be optionally mutated onto the result after.
- Migration to using serde's Serialize and Deserialize directly, for
  everything.
  - Initially I was going to be more conservative, potentially only
    using Serialize, but this ended up seeming foolish and also more
    confusing when implementing (de)serialization helpers.
  - Previously we were manually converting from rustc_serialize's
    parsed JSON value rep, and then we implemented `fmt::Display`
    traits for output.  serde's automation shines at everything we
    were doing here through annotations and helpers.
  - Got rid of additional representation structs that could instead
    be represented by a single struct.  In particular, crossref was
    using reference-counted types that required a lot of labor in the
    code.
  - Searchfox's use of `"source": 1` and `"target": 1` in the JSON to
    convey the type of record that was being used gets a little bit of
    a hack.
    - serde has a nice documentation page on enum representations at
      https://serde.rs/enum-representations.html and one might note
      that what searchfox has been doing doesn't really fit into any
      (other than "untagged").  Adjacently tagged sorta seems like it
      might work if we flattened the adjacent payloads, but our use of
      the `read_` functions as filters that themselves expect to see
      the tags made that a little weird.  If we always used an enum
      type instead of the distinct types, this could be moot, but that
      also potentially runs into `WithLocation` issues.  (I maintained
      existing `WithLocation` behaviour through use of `flatten`,
      although maybe that should be rethought at some point.)
      - I did consider changing the reps we use, but that would be a
        logistical hassle to update all the m-c and c-c branches.
    - We use a single-valued enum for each type which theoretically
      doesn't use storage space but does need to be listed when
      instantiating the struct.
- Switched to using the `Ustr` https://github.com/anderslanglands/ustr
  automagically reference-counted string type directly in our types
  where appropriate.
  - I did a moderately extensive survey and settled on Ustr primarily
    because it already had serde integration and seemed mature in
    terms of continued updates as well as having benchmarks.
  - The primary caveat to ustr is that all interned strings are
    permanently interned and never freed, so long-lived processes that
    potentially see a lot of strings need to be sure not to use Ustr
    for strings that will never be seen again.  To this end I tried to
    be responsible in my choices and at the transition layer, but it's
    conceivable we could see ramifications.
  - It does feel like this has really helped simplify the crossref.rs
    logic and so while I'm not wedded to Ustr, I'd like to stick with
    something with similar ergonomics.
- `peekLines`, a multi-line string, in the crossref output has been
  changed back to its source data of `peekRange` because we never ended
  up using `peekLines` in production and I think it likely makes sense
  to switch to using lol_html to instead filter the statically
  generated HTML instead.  Should that not be sufficiently performant,
  we'd switch to having direct source file offsets with any necessary
  state to put the tokenizer in the right state.
  - "fancy" branch prototyping seemed to show that the lack of syntax
    highlighting was a real problem.
  - Part of why this never got used was I was trying to convert us to
    using offsets, but ended up in a hyper.rs-upgrade nightmare
    situation back during the original searchfox work week when :billm
    handed off searchfox.
- `AnalysisStructured` got less hacky!  Previously we only extracted a
  few fields and re-emitted the rest as a JSON string `payload` which
  we would then glue together again when formatting it for output.  Now
  we use serde's ability to `flatten` all the extra values that don't
  have direct struct fields into its value rep.
  - I didn't feel great about the original `payload` mechanism, but it
    seemed least bad versus the heavy-seeming rustc_serialize Value
    reps.  (Heavy both in terms of memory usage and in terms of hassle
    to work with them.)
  - Given the conversion to using the more structured serde rep, it no
    longer made any sense to try and keep this up and likely would have
    been a total nightmare.
  - Many of `AnalysisStructured`'s fields are now mapped directly into
    rust structs.  Serde makes this easy and this is consistent with my
    conclusions from the "pretty" branch that for performance we need
    to be doing any fancy stuff in the back-end where it can be
    (partially) pre-computed and/or cached (with cached values possibly
    begetting pre-cached values in future indexer runs, making them
    pre-computed).  The JS single-page-app thing was not fast enough to
    be considered Searchfox brand searchfoxing!
- I added allow-dead-code as appropriate.