### PR TITLE
Dark mode

### DIFF
--- a/scripts/output.js
+++ b/scripts/output.js
@@ -65,7 +65,8 @@ function generate(content, opt)
   let output = `<!DOCTYPE html>
 <html lang="en-US">
 <head>
-  <meta charset="utf-8" />
+  <meta charset="utf-8">
+  <meta name="color-scheme" content="light dark">
   <link href="/static/icons/search.png" rel="shortcut icon">
   <title>${title}</title>
 

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -31,39 +31,41 @@
   border-radius: 2px;
   padding: 1px 3px;
   margin: 0 10px;
-  border: 1px solid #ddd;
+  border: 1px solid var(--page-border-color);
+  background-color: var(--button-background);
+  color: var(--button-color);
 }
 
 .panel .accel {
   /* simulate a keyboard key effect */
   font-family: monospace;
-  background: #f5f5f5;
-  box-shadow: 0 1px #999;
+  box-shadow: 0 1px rgba(0, 0, 0, .8);
 }
 
 .panel .copy {
-  height: 1em;
-  width: 1em;
-  padding: 3px;
+  height: 18px;
+  width: 18px;
+  padding: 1px;
   margin: 0 3px;
-  box-sizing: content-box;
   cursor: pointer;
   vertical-align: middle;
-  background-image: url(/static/icons/copy.svg);
-  background-position: center center;
-  background-color: #f5f5f5;
 }
 
 .panel .copy:hover {
-  background-color: white;
+  background-color: var(--button-hover-background);
 }
 
 .panel .copy:active {
-  background-color: #d5d5d5;
+  background-color: var(--button-active-background);
 }
 
-.panel .copy.copied {
-  background-image: url(/static/icons/tick.svg);
+.panel .copy svg {
+  fill: currentColor;
+}
+
+.panel .copy:not(.copied) .tick-icon,
+.panel .copy.copied .copy-icon {
+  display: none;
 }
 
 /* MimeType Icons */

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -28,9 +28,87 @@ table {
 }
 
 :root {
+  --page-background: #fff;
+  --page-foreground: #333;
+  --page-border-color: #333;
+
+  --button-color: var(--page-color);
+  --button-background: #f5f5f5;
+  --button-hover-background: white;
+  --button-active-background: #d5d5d5;
+
+  --search-box-background-image: linear-gradient(to bottom, #f8f8f8, #eaeaea);
+  --revision-text-color: #656565;
+
+  --panel-header-background: #333;
+  --panel-header-color: #fff;
+
+  --list-hover-background: #e0e0e0;
+  --list-hover-color: var(--page-foreground);
+
+  --table-header-color: #555;
+  --table-header-background: #f5f5f5;
+  --table-even-row-background: #f5f5f5;
+
+  --blame-popup-background: #404040;
+  --blame-popup-color: #fff;
+  --blame-light-gray: lightgray;
+  --blame-dark-gray: darkgray;
+
+  --line-highlight-background: rgb(255, 255, 204);
+  --line-stuck-background: #ffe;
+
+  --syntax-type-color: teal;
+  --syntax-comment-color: darkred;
+  --syntax-reserved-color: blue;
+  --syntax-string-color: green;
+  --syntax-regex-color: #6d7b8d;
+  --syntax-symbol-highlight: yellow;
+}
+
+@supports (color-scheme: dark) {
+@media (prefers-color-scheme: dark) {
+  :root {
+    --page-background: rgb(28, 27, 34);
+    --page-foreground: rgb(251, 251, 254);
+    --page-border-color: ThreeDLightShadow;
+
+    --search-box-background-image: linear-gradient(to bottom, #444, #333);
+    --revision-text-color: #ddd;
+
+    --button-background: rgb(43, 42, 51);
+    --button-hover-background: rgb(82, 82, 94);
+    --button-active-background: rgb(91, 91, 102);
+
+    --list-hover-background: var(--button-hover-background);
+
+    --table-header-color: var(--page-foreground);
+    --table-header-background: rgb(43, 42, 51);
+    --table-even-row-background: rgb(34, 37, 44);
+
+    --blame-light-gray: #595959;
+    --blame-dark-gray: #393939;
+
+    --line-highlight-background: rgb(100, 100, 62);
+    --line-stuck-background: #646435;
+
+    --syntax-comment-color: GrayText;
+    --syntax-symbol-highlight: #5d4d1d;
+    /* Shamelessly taken from source.chromium.org's dark theme */
+    --syntax-type-color: #79a9c4;
+    --syntax-reserved-color: #d8884b;
+    --syntax-string-color: #97c67b;
+    --syntax-regex-color: #b98eff;
+    color-scheme: dark;
+  }
+}
+}
+
+:root {
   font: 12px/1.5 Arial, Helvetica, sans-serif;
-  background-color: #fff;
-  color: #333;
+
+  background-color: var(--page-background);
+  color: var(--page-foreground);
 }
 
 body {
@@ -60,7 +138,8 @@ table#file {
   width: 100%;
 }
 table.folder-content thead tr:first-child {
-  color: #555;
+  color: var(--table-header-color);
+  background-color: var(--table-header-background);
   padding: 0.5em;
 }
 table th {
@@ -77,14 +156,14 @@ table th {
   padding-top: 0.2em;
   padding-bottom: 0.2em;
 }
-table.folder-content thead tr:first-child,
 table.folder-content tr:nth-child(even) {
-  background-color: #f5f5f5;
+  background-color: var(--table-even-row-background);
 }
 table.folder-content tbody tr:hover,
 table tbody tr:hover,
 .context-menu a:hover {
-  background-color: #e8e8e8;
+  background-color: var(--list-hover-background);
+  color: var(--list-hover-color);
 }
 table.folder-content td {
   padding: 0;
@@ -142,7 +221,7 @@ td#line-numbers {
   user-select: none;
 }
 .highlighted {
-  background: none repeat scroll content-box 0 0 rgb(255, 255, 204) !important;
+  background: none repeat scroll content-box 0 0 var(--line-highlight-background) !important;
 }
 .source-line {
   margin: 0;
@@ -153,10 +232,10 @@ td#line-numbers {
 }
 
 .source-line-with-number.stuck {
-  background-color: #ffe;
+  background-color: var(--line-stuck-background);
 }
 .source-line-with-number.last-stuck {
-  box-shadow: 0px 4px 8px #0002;
+  box-shadow: 0px 4px 8px rgba(0, 0, 0, .9);
 }
 
 .source-line a {
@@ -249,7 +328,7 @@ body {
   /* even with our "stuck" and "last-stuck" classes, it's important to have an
    opaque background color for these because those classes don't take effect
    immediately. */
-  background-color: white;
+  background-color: var(--page-background-color);
   top: calc(var(--nesting-level) * 12px * 1.3);
   z-index: calc(100 - var(--nesting-level));
 }
@@ -357,15 +436,19 @@ tr.after-context-line + tr.before-context-line {
   /* absolutely positioned within the containing block of the <body> relative
      to the click event */
   position: absolute;
-  background-color: #fff;
+  background-color: var(--page-background);
+  color: var(--page-color);
   margin: 0;
   padding: 0;
-  border: 1px solid #333;
+  border: 1px solid var(--page-border-color);
   border-radius: 6px;
   border-top-left-radius: 0;
   width: auto;
   list-style: none;
   z-index: 102;
+}
+.context-menu:focus {
+  outline: none;
 }
 .context-menu a {
   display: block;
@@ -431,9 +514,8 @@ tr.after-context-line + tr.before-context-line {
   position: fixed;
   top: 105px;
   right: 22px;
-  background-color: #fff;
-  border: 1px solid #e0e0e0;
-  border-right: 0;
+  background-color: var(--page-background);
+  border: 1px solid var(--page-border-color);
   min-width: 12rem;
   overflow-y: auto;
   overflow-x: hidden;
@@ -442,8 +524,8 @@ tr.after-context-line + tr.before-context-line {
 }
 #panel-toggle {
   display: inline-block;
-  background-color: #333;
-  color: #fff;
+  background-color: var(--panel-header-background);
+  color: var(--panel-header-color);
   margin: 0;
   padding: 0.5rem 0.2rem 0.5rem 0.7rem;
   border: 0;
@@ -486,15 +568,14 @@ tr.after-context-line + tr.before-context-line {
 }
 .panel section a {
   display: inline-block;
-  background-color: #fff;
   width: 100%;
 }
-.panel section a:hover {
-  background-color: #e0e0e0;
+.panel section a:is(:hover, :focus) {
+  background-color: var(--list-hover-background);
+  color: var(--list-hover-color);
   text-decoration: none;
 }
 .panel section a:focus {
-  background-color: #e0e0e0;
   text-decoration: underline;
 }
 
@@ -543,7 +624,7 @@ span[data-symbols]:hover {
   cursor: pointer;
 }
 span[data-symbols].hovered {
-  background-color: yellow;
+  background-color: var(--syntax-symbol-highlight);
 }
 
 /* Help screen */
@@ -602,10 +683,10 @@ span[data-symbols].hovered {
 /* blame zebra stripes: we alternate colors whenever the revision a line is from
    changes between lines. */
 .c1 {
-  background-color: lightgray;
+  background-color: var(--blame-light-gray);
 }
 .c2 {
-  background-color: darkgray;
+  background-color: var(--blame-dark-gray);
 }
 
 .blame-popup {
@@ -615,10 +696,10 @@ span[data-symbols].hovered {
   left: 0;
   width: 600px;
   padding: 10px;
-  background: #404040;
-  box-shadow: 3px 3px 3px grey;
+  background-color: var(--blame-popup-background);
+  color: var(--blame-popup-color);
+  box-shadow: 3px 3px 3px rgba(0, 0, 0, .5);
   border-radius: 3px;
-  color: white;
   text-align: left;
   z-index: 200;
   cursor: auto;
@@ -628,7 +709,7 @@ span[data-symbols].hovered {
   cursor: pointer;
 }
 .deemphasize {
-  color: #8c8c8c !important;
+  color: GrayText !important;
 }
 .minus-line {
   background-color: rgb(255, 204, 204);
@@ -673,11 +754,8 @@ input::placeholder {
   text-decoration: underline;
 }
 #search-box {
-  background-color: #f5f5f5;
-  background-image: linear-gradient(to bottom, #f8f8f8, #eaeaea);
-  border-bottom: 1px solid #6d6d6d;
-  border-top: 1px solid #f5f5f5;
-  color: #333;
+  background-image: var(--search-box-background-image);
+  border-bottom: 1px solid var(--page-border-color);
   padding: 0.8rem;
   width: 100%;
 }
@@ -697,7 +775,7 @@ input::placeholder {
 }
 #revision {
   padding-top: 0.2rem;
-  color: #656565;
+  color: var(--revision-text-color);
 }
 #revision a {
   text-decoration: underline;
@@ -853,29 +931,29 @@ input::placeholder {
   background-position: 0 0, 5px 5px;
 }
 
-.syn_type {
-  color: teal;
-}
-
 .syn_def {
   font-weight: 600;
 }
 
+.syn_type {
+  color: var(--syntax-type-color);
+}
+
 .syn_string {
-  color: green;
+  color: var(--syntax-string-color);
 }
 
 .syn_comment {
-  color: darkred;
+  color: var(--syntax-comment-color);
 }
 
 .syn_tag,
 .syn_reserved {
-  color: blue;
+  color: var(--syntax-reserved-color);
 }
 
 .syn_regex {
-  color: #6d7b8d;
+  color: var(--syntax-regex-color);
 }
 
 /* ## Code Coverage Styling ## */

--- a/static/icons/copy.svg
+++ b/static/icons/copy.svg
@@ -1,7 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-   Taken from mozilla-central@fc6d20cf008c2ca66d2c45439690d2ff067bf1b9/browser/extensions/screenshots/icons/copy.svg
-   -->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#3e3d40" d="M14.707 8.293l-3-3A1 1 0 0 0 11 5h-1V4a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 6 0H3a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3v3a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V9a1 1 0 0 0-.293-.707zM12.586 9H11V7.414zm-5-5H6V2.414zM6 7v2H3V2h2v2.5a.5.5 0 0 0 .5.5H8a2 2 0 0 0-2 2zm2 7V7h2v2.5a.5.5 0 0 0 .5.5H13v4z"/></svg>

--- a/static/icons/tick.svg
+++ b/static/icons/tick.svg
@@ -1,9 +1,0 @@
-<!-- This Source Code Form is subject to the terms of the Mozilla Public
-   - License, v. 2.0. If a copy of the MPL was not distributed with this
-   - file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-  Taken from https://searchfox.org/mozilla-central/rev/819be4899a92213abf121b449779ced662f2ce13/widget/nsNativeBasicTheme.cpp#226-230 with coordinates converted appropriately.
--->
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16">
-  <path fill="#3e3d40" d="M 2.857143 8.571428 L 6.285714 12.571428 L 7.428571 12.571428 L 13.714286 5.142857 L 13.428572 3.428571 L 12 3.428571 L 7.428571 9.142858 L 6.285714 9.428572 L 4 6.857143"/>
-</svg>

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -135,6 +135,7 @@ pub fn generate_header(opt: &Options, writer: &mut dyn Write) -> Result<(), &'st
 
     let mut head_seq = vec![
         F::S(r#"<meta charset="utf-8" />"#),
+        F::S(r#"<meta name="color-scheme" content="light dark">"#),
         F::S(r#"<link href="/static/icons/search.png" rel="shortcut icon">"#),
         F::T(format!("<title>{}</title>", opt.title)),
     ];
@@ -315,6 +316,28 @@ pub struct PanelSection {
     pub items: Vec<PanelItem>,
 }
 
+static COPY_ICONS: &str = r##"
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+   Taken from mozilla-central@fc6d20cf008c2ca66d2c45439690d2ff067bf1b9/browser/extensions/screenshots/icons/copy.svg
+   -->
+<svg viewbox="0 0 16 16" class="copy-icon">
+  <path d="M14.707 8.293l-3-3A1 1 0 0 0 11 5h-1V4a1 1 0 0 0-.293-.707l-3-3A1 1 0 0 0 6 0H3a2 2 0 0 0-2 2v7a2 2 0 0 0 2 2h3v3a2 2 0 0 0 2 2h5a2 2 0 0 0 2-2V9a1 1 0 0 0-.293-.707zM12.586 9H11V7.414zm-5-5H6V2.414zM6 7v2H3V2h2v2.5a.5.5 0 0 0 .5.5H8a2 2 0 0 0-2 2zm2 7V7h2v2.5a.5.5 0 0 0 .5.5H13v4z"/>
+</svg>
+
+<!-- This Source Code Form is subject to the terms of the Mozilla Public
+   - License, v. 2.0. If a copy of the MPL was not distributed with this
+   - file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+  Taken from https://searchfox.org/mozilla-central/rev/819be4899a92213abf121b449779ced662f2ce13/widget/nsNativeBasicTheme.cpp#226-230 with coordinates converted appropriately.
+-->
+<svg viewbox="0 0 16 16" class="tick-icon">
+  <path d="M 2.857143 8.571428 L 6.285714 12.571428 L 7.428571 12.571428 L 13.714286 5.142857 L 13.428572 3.428571 L 12 3.428571 L 7.428571 9.142858 L 6.285714 9.428572 L 4 6.857143"/>
+</svg>
+"##;
+
 /// Generate HTML for a panel containing the given sections and write it to the
 /// provided writer.  This is expected to be called once per document.
 pub fn generate_panel(
@@ -342,7 +365,10 @@ pub fn generate_panel(
                         String::new()
                     };
                     let copy = if item.copyable {
-                        format!(r#"<button class="icon copy" title="Copy to clipboard"></button>"#)
+                        format!(
+                            r#"<button class="icon copy" title="Copy to clipboard">{}</button>"#,
+                            COPY_ICONS
+                        )
                     } else {
                         String::new()
                     };


### PR DESCRIPTION
This is on top of #463.

Simpler, hopefully more palatable implementation of dark mode than #415.

The main trick that allows this to be so tiny is that we rely on the
browser's form controls (using color-scheme: dark).

The other main trick is including the copy SVG icons in the source
directly, so that we don't have to have multiple versions of them and
they can just use `fill: currentColor`.