### PR TITLE
Bug 1742820 - Dark mode: Use darker colors for highlights.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -121,8 +121,8 @@ table {
     --blame-light-gray: #595959;
     --blame-dark-gray: #393939;
 
-    --line-highlight-background: rgb(100, 100, 62);
-    --line-stuck-background: #646435;
+    --line-highlight-background: #3c3111;
+    --line-stuck-background: #221c09;
 
     --syntax-comment-color: GrayText;
     --syntax-symbol-highlight: #5d4d1d;


### PR DESCRIPTION
So that they contrast better with comments and so.