### PR TITLE
context-menu: Improve giant context menus / context menus towards the bottom of the page.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -494,10 +494,16 @@ tr.after-context-line + tr.before-context-line {
   padding: 0;
   border: 1px solid var(--page-border-color);
   border-radius: 6px;
-  border-top-left-radius: 0;
   list-style: none;
   z-index: 102;
   overflow: auto;
+  transition: opacity .2s ease;
+}
+.context-menu:not(.bottom) {
+  border-top-left-radius: 0;
+}
+.context-menu.bottom {
+  border-bottom-left-radius: 0;
 }
 .context-menu:focus {
   outline: none;

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -110,12 +110,38 @@ var ContextMenu = new (class ContextMenu {
 
     let viewportHeight = window.innerHeight;
     let spaceTowardsBottom = viewportHeight - event.clientY;
+    let spaceTowardsTop = viewportHeight - spaceTowardsBottom;
 
-    this.menu.style.left = x + "px";
+    // Position the menu towards the bottom, and if that overflows and there's
+    // more space to the top, flip it.
+    this.menu.classList.remove("bottom");
+    this.menu.style.bottom = "";
     this.menu.style.top = y + "px";
-    this.menu.style.maxHeight = spaceTowardsBottom + "px";
+    this.menu.style.left = x + "px";
+    this.menu.style.maxHeight = "none";
 
     this.menu.style.display = "";
+    this.menu.style.opacity = "0";
+
+    let rect = this.menu.getBoundingClientRect();
+    // If it overflows, either flip it or constrain its height.
+    if (rect.height > spaceTowardsBottom) {
+      if (spaceTowardsTop > spaceTowardsBottom) {
+        // Position it towards the top.
+        this.menu.classList.add("bottom");
+        this.menu.style.bottom = (viewportHeight - y) + "px";
+        this.menu.style.top = "";
+        if (rect.height > spaceTowardsTop) {
+          this.menu.style.maxHeight = spaceTowardsTop + "px";
+        }
+      } else {
+        // Constrain its height.
+        this.menu.style.maxHeight = spaceTowardsBottom + "px";
+      }
+    }
+
+    // Now the menu is correctly positioned, show it.
+    this.menu.style.opacity = "";
     this.menu.focus();
   }
 


### PR DESCRIPTION
This patch prevents context menus from overflowing the viewport by
making them scrollable, and also positioning them towards the top if you
click down enough the page.

This could be improved in the future, but seems like a trivial
improvement to me.