### PR TITLE
Crossref ext

### DIFF
--- a/docs/crossref.md
+++ b/docs/crossref.md
@@ -6,8 +6,12 @@ to another. This is the job of the cross-referencer (located in
 `tools/src/bin/crossref.rs`). It reads in target records from every
 analysis file and records them in a hashtable. The hashtable maps the
 symbol name to every target record with that symbol. Finally, the
-hashtable is written to a file `${index}/${tree_name}/crossref`. The
-general structure is:
+hashtable is written to a pair of files `${index}/${tree_name}/crossref` and
+`${index}/${tree_name}/crossref-extra`.  The `-extra` variant stores data
+payloads that are large enough that they impact our ability to perform a
+memory-mapped binary search of `crossref` file.
+
+The general structure of hit records is:
 
 ```
 {<kind>: [{"path": <file-path>, "lines": [{"lno": <lineno>, "line": <text-of-line>}, ...]}, ...]}
@@ -20,12 +24,28 @@ The `<text-of-line>` contains the text of the given line, with leading and
 trailing spaces stripped.  An example entry in this file looks like:
 
 ```
-_ZN19nsISupportsPRUint647SetDataEm
-{"Declarations":[{"lines":[{"line":"NS_IMETHOD SetData(uint64_t aData) = 0;","lno":830},{"line":"NS_IMETHOD SetData(uint64_t aData) override; \\","lno":842}],"path":"__GENERATED__/dist/include/nsISupportsPrimitives.h"}],"Definitions":[{"lines":[{"line":"nsSupportsPRUint64::SetData(uint64_t aData)","lno":371}],"path":"xpcom/ds/nsSupportsPrimitives.cpp"}],"IDL":[{"lines":[{"line":"attribute uint64_t data;","lno":129}],"path":"xpcom/ds/nsISupportsPrimitives.idl"}],"Uses":[{"lines":[{"line":"wrapper->SetData(mWindowID);","lno":72}],"path":"dom/audiochannel/AudioChannelService.cpp"},{"lines":[{"line":"wrapper->SetData(mID);","lno":8925}],"path":"dom/base/nsGlobalWindow.cpp"},{"lines":[{"line":"ret->SetData(gBrowserTabsRemoteStatus);","lno":1004}],"path":"toolkit/xre/nsAppRunner.cpp"}]}
+!_ZN19nsISupportsPRUint647SetDataEm
+:{"Declarations":[{"lines":[{"line":"NS_IMETHOD SetData(uint64_t aData) = 0;","lno":830},{"line":"NS_IMETHOD SetData(uint64_t aData) override; \\","lno":842}],"path":"__GENERATED__/dist/include/nsISupportsPrimitives.h"}],"Definitions":[{"lines":[{"line":"nsSupportsPRUint64::SetData(uint64_t aData)","lno":371}],"path":"xpcom/ds/nsSupportsPrimitives.cpp"}],"IDL":[{"lines":[{"line":"attribute uint64_t data;","lno":129}],"path":"xpcom/ds/nsISupportsPrimitives.idl"}],"Uses":[{"lines":[{"line":"wrapper->SetData(mWindowID);","lno":72}],"path":"dom/audiochannel/AudioChannelService.cpp"},{"lines":[{"line":"wrapper->SetData(mID);","lno":8925}],"path":"dom/base/nsGlobalWindow.cpp"},{"lines":[{"line":"ret->SetData(gBrowserTabsRemoteStatus);","lno":1004}],"path":"toolkit/xre/nsAppRunner.cpp"}]}
 ```
 
+The file is sorted.
+
 The first line is the symbol name and the second line is a JSON object
-describing all the target records for that symbol.  The file is sorted.
+describing all the target records for that symbol.  Each line begins with an
+indicator character that identifies the type of line.
+
+More details from https://bugzilla.mozilla.org/show_bug.cgi?id=1702916:
+- `crossref` continues to be newline-delimited.
+- Each line in `crossref` gets a prefix indicating what's on the line:
+  - `!`: An Identifier follows.
+  - `:`: Inline-stored JSON for the preceding line's identifier (which must be an identifier).
+  - `@`: Externally-stored JSON in `crossref-extra`.  The entirety of the line (eliding the trailing newline) should be `@${offsetOfJsonOpeningCurlyBrace.toString(16)} ${lengthIncludingNewline.toString(16)}`.  The offset and length (including newline) are represented in hexadecimal (without preceding `0x`) and separated by a space.  The choice of hex is for information density purposes while still being human readable.  Because I'll be augmenting `searchfox-tool` to directly perform any lookups people would otherwise use UNIX tools for, I think this should be fine.
+- Although it seems like this would support having comment lines, we won't support
+  these, at least not initially, as it would complicate the bisection logic which
+  benefits from being able to depend on things being written in pairs.
+- `crossref-extra` also ends up looking like `crossref` for the sake of ease of debugging.  It's newline delimited and will include (useless) `!Identifier` lines preceding each long JSON line.  The JSON lines also get `:` prefixed onto them even though the offsets in `crossref` will not include the leading `:`.
+  - The rationale here is that it seems nice if someone wants to build a naive script / grep command invocation that they can just point it at both files and they'll get a result without having to deal with the offset indirection by requiring the second line to start with `:` and ignore the `@` second lines.
+- The initial arbitrary line length cutoff will be 3k based on the statistics I gathered from comment 0 and because if we assume 4k page sizes that means in any 4k page we should then still be able to find an identifier (although the binary search will likely be naive about page alignment issues which means it would probably be happier with a constant that's less than 2k).  I'm sure one could write a nice shell script to brute force some practical legwork.  Or we could vary the constant randomly every day and gather the performance characteristics, etc. etc.  I'm not super concerned, I just want rust-based lookups.
 
 ### Identifiers file
 

--- a/router/crossrefs.py
+++ b/router/crossrefs.py
@@ -1,3 +1,6 @@
+# Functions for working with the `crossref` and `crossref-extra` cross-reference
+# files documented in `crossref.md`.
+
 from __future__ import absolute_import
 import json
 import sys
@@ -14,37 +17,151 @@ def load(config):
         log('Loading %s', repo_name)
         index_path = config['trees'][repo_name]['index_path']
 
-        mm = None
+        inline_mm = None
         with open(os.path.join(index_path, 'crossref')) as f:
             try:
-                mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+                inline_mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
             except ValueError as e:
                 log('Failed to mmap crossref file for %s: %s', repo_name, str(e))
                 pass
 
-        crossrefs = {}
-        if mm:
-            key = None
-            pos = 0
-            while True:
-                line = mm.readline()
-                linelen = len(line)
-                if linelen == 0:
-                    break
+        extra_mm = None
+        with open(os.path.join(index_path, 'crossref-extra')) as f:
+            try:
+                extra_mm = mmap.mmap(f.fileno(), 0, prot=mmap.PROT_READ)
+            except ValueError as e:
+                log('Failed to mmap crossref file for %s: %s', repo_name, str(e))
+                pass
 
-                # Crossrefs file is written by Rust in utf-8
-                line = line.decode('utf-8').strip()
-                if key == None:
-                    pos += linelen
-                    key = line
-                else:
-                    value = line
-                    s = "{},{}".format(pos, pos + linelen)
-                    crossrefs[key] = s
-                    key = None
-                    pos += linelen
+        repo_data[repo_name] = (inline_mm, extra_mm)
 
-        repo_data[repo_name] = (mm, crossrefs)
+NEWLINE = ord('\n')
+ID_START = ord('!')
+INLINE_STORED = ord(':')
+EXTERNALLY_STORED = ord('@')
+
+def get_id_line(mm, pos):
+    '''
+    Given a memory map and a position, expand from `pos` to find the identifier
+    line (`!` prefixed) that covers the position.  Returns (the identifier,
+    the offset of the `!` from the start of the identifier line, the offset of
+    the newline ending the identifier line).
+
+    `pos` is either inside an identifier line or a payload line that follows an
+    identifier line, so we always walk backwards until we find an identifier.
+    We should never need to walk forward (to find the start of the identifier
+    line) because the result of any comparison should always tell the bisection
+    to bisect in the positive direction (because the file is sorted), which
+    should then find the subsequent record (if that's the one we're looking
+    for, etc.).
+    '''
+    # We could the trailing newline as part of the record, so back up a char.
+    if mm[pos] == NEWLINE:
+        pos -= 1
+
+    start = end = pos
+
+    # Scan backwards until we hit the start of the file (where the first line
+    # must be an identifier) or we hit a newline and the character following
+    # the newline is the identifier prefix of `!`.
+    while start >= 0:
+        if mm[start] == NEWLINE:
+            if mm[start+1] == ID_START:
+                break
+            else:
+                # We're hitting a ":" and we need to reset end to this newline
+                end = start
+                # and we want to keep going...
+        start -= 1
+    start += 1
+
+    # Start should now be pointing at the `!` of the identifier line.
+
+    size = mm.size()
+    while end < size and mm[end] != ord('\n'):
+        end += 1
+
+    # end should now be pointing at the trailing newline.
+
+    # Skip the leading `!` and decode the utf-8 encoded symbol
+    line_sym = mm[start+1:end].decode('utf-8')
+    return (line_sym, start, end)
+
+def bisect_for_payload(mm, search_sym):
+    '''
+    Bisect the mmap to look for an exact symbol match `sym`, and returning the
+    payload line which may be either inline JSON or external offsets to be
+    retrieved from another map.
+    '''
+
+    first = 0
+    count = mm.size()
+    while count > 0:
+        step = int(count / 2)
+        pos = first + step
+
+        (line_sym, line_start, line_end) = get_id_line(mm, pos)
+        print('sym', search_sym, 'count', count, 'step', step, 'pos', pos)
+        print('  line_sym', line_sym, line_start, line_end)
+        sys.stdout.flush()
+
+        if line_sym == search_sym:
+            ## Exact Match!
+            mm.seek(line_end + 1)
+            payload_line = mm.readline().decode('utf-8')
+            return payload_line
+        elif line_sym < search_sym:
+            ## Bisect latter half
+            # We might as well exclude the payload line we're skipping as well.
+            # Because payload lines are intentionally limited during the
+            # creation of `crossref`, we know this should fault an acceptable
+            # number of pages which may have already been pre-fetched.
+            next_newline = mm.find(b'\n', line_end + 1)
+            if next_newline != -1:
+                first = next_newline + 1
+            else:
+                # If there was no newline, then we're at the end and we might
+                # as well stop.
+                return None
+            # Halve count and also subtract off the parts of the identifier line
+            # and payload line we're skipping.
+            count -= step + (pos - first)
+        else:
+            ## Bisect first half
+            # Halve count and subtract off the part of the identifier line that
+            # we can eliminate from consideration.
+            count = step - (pos - line_start)
+
+    return None
+
+def lookup_raw(tree_name, sym):
+    '''
+    Look up the given symbol from `crossref` and parse and return the resulting
+    JSON as objects.
+    '''
+    (inline_mm, extra_mm) = repo_data[tree_name]
+
+    if not inline_mm:
+        return None
+
+    payload = bisect_for_payload(inline_mm, sym)
+    if not payload:
+        return None
+
+    if payload[0] == ':':
+        return json.loads(payload[1:])
+    elif payload[0] != '@':
+        # Fail if we're seeing something other than an external ref.
+        return None
+
+    (braceOffset, lengthWithNewline) = payload[1:].split(' ')
+    (braceOffset, lengthWithNewline) = (int(braceOffset, 16), int(lengthWithNewline, 16))
+
+    # exclude the newline
+    data = extra_mm[braceOffset:(braceOffset + lengthWithNewline - 1)]
+
+    result = json.loads(data)
+    return result
 
 def lookup_merging(tree_name, symbols):
     '''
@@ -53,19 +170,28 @@ def lookup_merging(tree_name, symbols):
     '''
     symbols = symbols.split(',')
 
-    (mm, crossrefs) = repo_data[tree_name]
-
     results = {}
     for symbol in symbols:
-        s = crossrefs.get(symbol)
-        if s == None:
+        result = lookup_raw(tree_name, symbol)
+        if result is None:
+            # This was existing behavior to fail if we encounter any incorrect
+            # symbols.  I'm currently leaving this in place because a request
+            # for a symbol we don't know suggests 1 of 3 things:
+            #
+            # 1. The query is from a prior indexing and is stale, and it's
+            #    probably better to return no results than incorrect results,
+            #    as someone can then refresh pages/etc. and see a correct
+            #    result.  That said, going forward, it likely would make sense
+            #    to be able to convey that stale results are implied and signal
+            #    that upwards.  This seems like a job for the rust rewrite.
+            # 2. There's a bug somewhere!  Returning no results is better in
+            #    this case because it is more likely to get eyes on the problem,
+            #    whereas returning partial results will potentially result in
+            #    the problem being hidden.
+            # 3. A rogue/broken client is trying to generate load, in which case
+            #    giving up sooner is better.  However this won't prevent
+            #    a competent rogue client from generating infinite load.
             return {}
-
-        (startPos, endPos) = s.split(',')
-        (startPos, endPos) = (int(startPos), int(endPos))
-
-        data = mm[startPos:endPos]
-        result = json.loads(data)
 
         for (k, v) in result.items():
             if k == 'callees':
@@ -82,16 +208,4 @@ def lookup_single_symbol(tree_name, symbol):
     Look up a single symbol, returning its results dict if it existed or None
     if it didn't exist.
     '''
-    (mm, crossrefs) = repo_data[tree_name]
-
-    s = crossrefs.get(symbol)
-    if s == None:
-        return None
-
-    (startPos, endPos) = s.split(',')
-    (startPos, endPos) = (int(startPos), int(endPos))
-
-    data = mm[startPos:endPos]
-    result = json.loads(data)
-
-    return result
+    return lookup_raw(tree_name, symbol)

--- a/router/identifiers.py
+++ b/router/identifiers.py
@@ -54,6 +54,9 @@ def bisect(mm, needle, upper_bound):
         line = get_line(mm, pos).upper()
         if line < needle or (upper_bound and line == needle):
             first = pos + 1
+            # Effectively: count = count - int(count/2) - 1
+            # In other words: count = step; count -= 1;
+            # Compensating for moving first a byte forward.
             count -= step + 1
         else:
             count = step

--- a/router/identifiers.py
+++ b/router/identifiers.py
@@ -31,9 +31,8 @@ def get_line(mm, pos):
 
     start = end = pos
 
-    while start >= 0 and mm[start] != ord('\n'):
+    while start > 0 and mm[start - 1] != ord('\n'):
         start -= 1
-    start += 1
 
     size = mm.size()
     while end < size and mm[end] != ord('\n'):

--- a/scripts/crossref.sh
+++ b/scripts/crossref.sh
@@ -16,6 +16,8 @@ cd -
 
 $MOZSEARCH_PATH/tools/target/release/crossref $CONFIG_FILE $TREE_NAME ${TMPDIR:-/tmp}/files
 
+# Re-sort the identifiers file so that it's case-insensitive.  (It was written
+# to disk from a case-sensitive BTreeMap.)
 ID_FILE=$INDEX_ROOT/identifiers
 LC_ALL=C sort -f $ID_FILE > ${TMPDIR:-/tmp}/ids
 mv ${TMPDIR:-/tmp}/ids $ID_FILE

--- a/tests/tests/checks/inputs/id__big_cpp__abstractart_beart__json
+++ b/tests/tests/checks/inputs/id__big_cpp__abstractart_beart__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::AbstractArt::beArt

--- a/tests/tests/checks/inputs/id__big_cpp__thing__json
+++ b/tests/tests/checks/inputs/id__big_cpp__thing__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::Thing

--- a/tests/tests/checks/inputs/xref__big_cpp__abstractart__beart__json
+++ b/tests/tests/checks/inputs/xref__big_cpp__abstractart__beart__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::AbstractArt::beArt | crossref-lookup

--- a/tests/tests/checks/inputs/xref__big_cpp__thing__json
+++ b/tests/tests/checks/inputs/xref__big_cpp__thing__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::Thing | crossref-lookup

--- a/tests/tests/checks/snapshots/check_glob@id__big_cpp__abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@id__big_cpp__abstractart_beart__json.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_check_insta.rs
+expression: json!(pairs)
+
+---
+[
+  {
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+    "id": "outerNS::AbstractArt::beArt"
+  }
+]

--- a/tests/tests/checks/snapshots/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/check_glob@merge__big_cpp.snap
@@ -1469,18 +1469,18 @@ expression: "&json_results"
   {
     "loc": "00183:4-9",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00183:4-9",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::Thing",
     "sym": "T_outerNS::Thing",
     "type": "class outerNS::Thing",
     "typesym": "T_outerNS::Thing"
-  },
-  {
-    "loc": "00183:4-9",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Thing::Thing",
-    "sym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00183:10-18",
@@ -1518,18 +1518,18 @@ expression: "&json_results"
   {
     "loc": "00192:4-9",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00192:4-9",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::Human",
     "sym": "T_outerNS::Human",
     "type": "class outerNS::Human",
     "typesym": "T_outerNS::Human"
-  },
-  {
-    "loc": "00192:4-9",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Human::Human",
-    "sym": "_ZN7outerNS5HumanC1Ev"
   },
   {
     "loc": "00196:7-17",
@@ -1587,18 +1587,18 @@ expression: "&json_results"
   {
     "loc": "00209:4-9",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00209:4-9",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::Thing",
     "sym": "T_outerNS::Thing",
     "type": "class outerNS::Thing",
     "typesym": "T_outerNS::Thing"
-  },
-  {
-    "loc": "00209:4-9",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Thing::Thing",
-    "sym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00209:11-18",
@@ -1654,19 +1654,19 @@ expression: "&json_results"
   {
     "loc": "00211:31-37",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_"
+  },
+  {
+    "loc": "00211:31-37",
+    "source": 1,
     "syntax": "",
     "pretty": "variable victor",
     "sym": "V_c3d4ef45607c3527_c9114c22356",
     "no_crossref": 1,
     "type": "WhatsYourVector<class outerNS::Superhero>",
     "typesym": "T_WhatsYourVector"
-  },
-  {
-    "loc": "00211:31-37",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
-    "sym": "_ZN15WhatsYourVectorC1EPT_"
   },
   {
     "loc": "00211:39-47",
@@ -1690,19 +1690,19 @@ expression: "&json_results"
   {
     "loc": "00213:10-13",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev"
+  },
+  {
+    "loc": "00213:10-13",
+    "source": 1,
     "syntax": "",
     "pretty": "variable bob",
     "sym": "V_bb56ff45607c3527_872688b",
     "no_crossref": 1,
     "type": "class outerNS::Human",
     "typesym": "T_outerNS::Human"
-  },
-  {
-    "loc": "00213:10-13",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Human::Human",
-    "sym": "_ZN7outerNS5HumanC1Ev"
   },
   {
     "loc": "00214:4-19",
@@ -1723,19 +1723,19 @@ expression: "&json_results"
   {
     "loc": "00214:27-45",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
+    "sym": "_ZN15WhatsYourVectorC1EPT_"
+  },
+  {
+    "loc": "00214:27-45",
+    "source": 1,
     "syntax": "",
     "pretty": "variable goodReferenceRight",
     "sym": "V_442fff45607c3527_bbca21f4b95005a5",
     "no_crossref": 1,
     "type": "WhatsYourVector<class outerNS::Human>",
     "typesym": "T_WhatsYourVector"
-  },
-  {
-    "loc": "00214:27-45",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor WhatsYourVector::WhatsYourVector<T>",
-    "sym": "_ZN15WhatsYourVectorC1EPT_"
   },
   {
     "loc": "00214:47-50",
@@ -1846,18 +1846,18 @@ expression: "&json_results"
   {
     "loc": "00258:4-9",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00258:4-9",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::Thing",
     "sym": "T_outerNS::Thing",
     "type": "class outerNS::Thing",
     "typesym": "T_outerNS::Thing"
-  },
-  {
-    "loc": "00258:4-9",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Thing::Thing",
-    "sym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00258:14-22",
@@ -2289,18 +2289,18 @@ expression: "&json_results"
   {
     "loc": "00420:4-9",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei"
+  },
+  {
+    "loc": "00420:4-9",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::Thing",
     "sym": "T_outerNS::Thing",
     "type": "class outerNS::Thing",
     "typesym": "T_outerNS::Thing"
-  },
-  {
-    "loc": "00420:4-9",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::Thing::Thing",
-    "sym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00420:10-16",
@@ -2346,18 +2346,18 @@ expression: "&json_results"
   {
     "loc": "00430:4-15",
     "source": 1,
+    "syntax": "constructor,use",
+    "pretty": "constructor outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev"
+  },
+  {
+    "loc": "00430:4-15",
+    "source": 1,
     "syntax": "type,use",
     "pretty": "type outerNS::AbstractArt",
     "sym": "T_outerNS::AbstractArt",
     "type": "class outerNS::AbstractArt",
     "typesym": "T_outerNS::AbstractArt"
-  },
-  {
-    "loc": "00430:4-15",
-    "source": 1,
-    "syntax": "constructor,use",
-    "pretty": "constructor outerNS::AbstractArt::AbstractArt",
-    "sym": "_ZN7outerNS11AbstractArtC1Ev"
   },
   {
     "loc": "00433:7-12",
@@ -2418,39 +2418,11 @@ expression: "&json_results"
     "type": "void (void)"
   },
   {
-    "loc": "00473:5-33",
+    "loc": "00235:7-18",
     "structured": 1,
-    "pretty": "i_was_declared_in_the_header",
-    "sym": "i_was_declared_in_the_header",
-    "kind": "function",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00442:6-14",
-    "structured": 1,
-    "pretty": "outerNS::innerNS::InnerCat",
-    "sym": "T_outerNS::innerNS::InnerCat",
-    "kind": "class",
-    "implKind": "",
-    "sizeBytes": 1,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00311:7-20",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::isFriendlyCat",
-    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
-    "kind": "method",
+    "pretty": "outerNS::OuterCat::mIsFriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+    "kind": "field",
     "parentsym": "T_outerNS::OuterCat",
     "implKind": "",
     "sizeBytes": null,
@@ -2458,17 +2430,29 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
+    "props": []
   },
   {
-    "loc": "00156:15-25",
+    "loc": "00236:7-28",
     "structured": 1,
-    "pretty": "outerNS::Thing::takeDamage",
-    "sym": "_ZN7outerNS5Thing10takeDamageEi",
-    "kind": "method",
+    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+    "kind": "field",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00145:7-15",
+    "structured": 1,
+    "pretty": "outerNS::Thing::mDefunct",
+    "sym": "F_<T_outerNS::Thing>_mDefunct",
+    "kind": "field",
     "parentsym": "T_outerNS::Thing",
     "implKind": "",
     "sizeBytes": null,
@@ -2476,57 +2460,128 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": [
-      "instance",
-      "virtual",
-      "user"
-    ]
+    "props": []
   },
   {
-    "loc": "00067:14-35",
+    "loc": "00141:6-9",
     "structured": 1,
-    "pretty": "GlobalContext::decideCatBooleanTrait",
-    "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
-    "kind": "method",
-    "parentsym": "T_GlobalContext",
+    "pretty": "outerNS::Thing::mHP",
+    "sym": "F_<T_outerNS::Thing>_mHP",
+    "kind": "field",
+    "parentsym": "T_outerNS::Thing",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": [
-      "static",
-      "user"
-    ]
+    "props": []
   },
   {
-    "loc": "00188:6-15",
+    "loc": "00024:6-19",
     "structured": 1,
-    "pretty": "outerNS::Superhero",
-    "sym": "T_outerNS::Superhero",
+    "pretty": "GlobalContext",
+    "sym": "T_GlobalContext",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [
+      {
+        "pretty": "GlobalContext::decideBooleanTrait",
+        "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
+        "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideCatBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+        "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      },
+      {
+        "pretty": "GlobalContext::decideDogBooleanTrait",
+        "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00075:8-25",
+    "structured": 1,
+    "pretty": "GlobalContext::LessGlobalContext",
+    "sym": "T_GlobalContext::LessGlobalContext",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [
+      {
+        "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+        "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+        "props": [
+          "static",
+          "user"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00417:6-17",
+    "structured": 1,
+    "pretty": "outerNS::AbstractArt",
+    "sym": "T_outerNS::AbstractArt",
     "kind": "class",
     "implKind": "",
     "sizeBytes": 16,
     "supers": [
       {
-        "pretty": "outerNS::Human",
-        "sym": "T_outerNS::Human",
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
         "props": []
       }
     ],
     "methods": [
       {
-        "pretty": "outerNS::Superhero::Superhero",
-        "sym": "_ZN7outerNS9SuperheroC1Ev",
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1Ev",
         "props": [
           "instance",
           "user"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::takeDamage",
-        "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+        "pretty": "outerNS::AbstractArt::beArt",
+        "sym": "_ZN7outerNS11AbstractArt5beArtEv",
         "props": [
           "instance",
           "virtual",
@@ -2534,32 +2589,32 @@ expression: "&json_results"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::operator=",
-        "sym": "_ZN7outerNS9SuperheroaSERKS0_",
+        "pretty": "outerNS::AbstractArt::operator=",
+        "sym": "_ZN7outerNS11AbstractArtaSERKS0_",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::operator=",
-        "sym": "_ZN7outerNS9SuperheroaSEOS0_",
+        "pretty": "outerNS::AbstractArt::operator=",
+        "sym": "_ZN7outerNS11AbstractArtaSEOS0_",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::~Superhero",
-        "sym": "_ZN7outerNS9SuperheroD1Ev",
+        "pretty": "outerNS::AbstractArt::~AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtD1Ev",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::Superhero",
-        "sym": "_ZN7outerNS9SuperheroC1ERKS0_",
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1ERKS0_",
         "props": [
           "instance",
           "defaulted",
@@ -2567,12 +2622,65 @@ expression: "&json_results"
         ]
       },
       {
-        "pretty": "outerNS::Superhero::Superhero",
-        "sym": "_ZN7outerNS9SuperheroC1EOS0_",
+        "pretty": "outerNS::AbstractArt::AbstractArt",
+        "sym": "_ZN7outerNS11AbstractArtC1EOS0_",
         "props": [
           "instance",
           "defaulted",
           "constexpr"
+        ]
+      }
+    ],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00205:6-11",
+    "structured": 1,
+    "pretty": "outerNS::Couch",
+    "sym": "T_outerNS::Couch",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 16,
+    "supers": [
+      {
+        "pretty": "outerNS::Thing",
+        "sym": "T_outerNS::Thing",
+        "props": []
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "outerNS::Couch::Couch",
+        "sym": "_ZN7outerNS5CouchC1Ei",
+        "props": [
+          "instance",
+          "user"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::operator=",
+        "sym": "_ZN7outerNS5CouchaSERKS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::operator=",
+        "sym": "_ZN7outerNS5CouchaSEOS0_",
+        "props": [
+          "instance",
+          "defaulted"
+        ]
+      },
+      {
+        "pretty": "outerNS::Couch::~Couch",
+        "sym": "_ZN7outerNS5CouchD1Ev",
+        "props": [
+          "instance",
+          "defaulted"
         ]
       }
     ],
@@ -2650,94 +2758,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [],
     "props": []
-  },
-  {
-    "loc": "00340:7-11",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::meet",
-    "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00235:7-18",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::mIsFriendly",
-    "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
-    "kind": "field",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00148:2-7",
-    "structured": 1,
-    "pretty": "outerNS::Thing::Thing",
-    "sym": "_ZN7outerNS5ThingC1Ei",
-    "kind": "method",
-    "parentsym": "T_outerNS::Thing",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00330:7-38",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
-    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00424:15-20",
-    "structured": 1,
-    "pretty": "outerNS::AbstractArt::beArt",
-    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
-    "kind": "method",
-    "parentsym": "T_outerNS::AbstractArt",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "virtual",
-      "user"
-    ]
   },
   {
     "loc": "00221:6-14",
@@ -2930,68 +2950,32 @@ expression: "&json_results"
     "props": []
   },
   {
-    "loc": "00248:2-10",
+    "loc": "00188:6-15",
     "structured": 1,
-    "pretty": "outerNS::OuterCat::OuterCat",
-    "sym": "_ZN7outerNS8OuterCatC1Ebb",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00208:2-7",
-    "structured": 1,
-    "pretty": "outerNS::Couch::Couch",
-    "sym": "_ZN7outerNS5CouchC1Ei",
-    "kind": "method",
-    "parentsym": "T_outerNS::Couch",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00417:6-17",
-    "structured": 1,
-    "pretty": "outerNS::AbstractArt",
-    "sym": "T_outerNS::AbstractArt",
+    "pretty": "outerNS::Superhero",
+    "sym": "T_outerNS::Superhero",
     "kind": "class",
     "implKind": "",
     "sizeBytes": 16,
     "supers": [
       {
-        "pretty": "outerNS::Thing",
-        "sym": "T_outerNS::Thing",
+        "pretty": "outerNS::Human",
+        "sym": "T_outerNS::Human",
         "props": []
       }
     ],
     "methods": [
       {
-        "pretty": "outerNS::AbstractArt::AbstractArt",
-        "sym": "_ZN7outerNS11AbstractArtC1Ev",
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1Ev",
         "props": [
           "instance",
           "user"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::beArt",
-        "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+        "pretty": "outerNS::Superhero::takeDamage",
+        "sym": "_ZN7outerNS9Superhero10takeDamageEi",
         "props": [
           "instance",
           "virtual",
@@ -2999,32 +2983,32 @@ expression: "&json_results"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::operator=",
-        "sym": "_ZN7outerNS11AbstractArtaSERKS0_",
+        "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSERKS0_",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::operator=",
-        "sym": "_ZN7outerNS11AbstractArtaSEOS0_",
+        "pretty": "outerNS::Superhero::operator=",
+        "sym": "_ZN7outerNS9SuperheroaSEOS0_",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::~AbstractArt",
-        "sym": "_ZN7outerNS11AbstractArtD1Ev",
+        "pretty": "outerNS::Superhero::~Superhero",
+        "sym": "_ZN7outerNS9SuperheroD1Ev",
         "props": [
           "instance",
           "defaulted"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::AbstractArt",
-        "sym": "_ZN7outerNS11AbstractArtC1ERKS0_",
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1ERKS0_",
         "props": [
           "instance",
           "defaulted",
@@ -3032,8 +3016,8 @@ expression: "&json_results"
         ]
       },
       {
-        "pretty": "outerNS::AbstractArt::AbstractArt",
-        "sym": "_ZN7outerNS11AbstractArtC1EOS0_",
+        "pretty": "outerNS::Superhero::Superhero",
+        "sym": "_ZN7outerNS9SuperheroC1EOS0_",
         "props": [
           "instance",
           "defaulted",
@@ -3147,42 +3131,6 @@ expression: "&json_results"
     "props": []
   },
   {
-    "loc": "00419:2-13",
-    "structured": 1,
-    "pretty": "outerNS::AbstractArt::AbstractArt",
-    "sym": "_ZN7outerNS11AbstractArtC1Ev",
-    "kind": "method",
-    "parentsym": "T_outerNS::AbstractArt",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00351:7-11",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::meet",
-    "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
     "loc": "00448:6-13",
     "structured": 1,
     "pretty": "outerNS::innerNS::AnonCat",
@@ -3197,111 +3145,122 @@ expression: "&json_results"
     "props": []
   },
   {
-    "loc": "00390:7-12",
+    "loc": "00442:6-14",
     "structured": 1,
-    "pretty": "outerNS::OuterCat::shred",
-    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00315:7-27",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
-    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
-    "kind": "method",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00429:2-14",
-    "structured": 1,
-    "pretty": "outerNS::PracticalArt::PracticalArt",
-    "sym": "_ZN7outerNS12PracticalArtC1Ev",
-    "kind": "method",
-    "parentsym": "T_outerNS::PracticalArt",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "instance",
-      "user"
-    ]
-  },
-  {
-    "loc": "00205:6-11",
-    "structured": 1,
-    "pretty": "outerNS::Couch",
-    "sym": "T_outerNS::Couch",
+    "pretty": "outerNS::innerNS::InnerCat",
+    "sym": "T_outerNS::innerNS::InnerCat",
     "kind": "class",
     "implKind": "",
-    "sizeBytes": 16,
-    "supers": [
-      {
-        "pretty": "outerNS::Thing",
-        "sym": "T_outerNS::Thing",
-        "props": []
-      }
-    ],
-    "methods": [
-      {
-        "pretty": "outerNS::Couch::Couch",
-        "sym": "_ZN7outerNS5CouchC1Ei",
-        "props": [
-          "instance",
-          "user"
-        ]
-      },
-      {
-        "pretty": "outerNS::Couch::operator=",
-        "sym": "_ZN7outerNS5CouchaSERKS0_",
-        "props": [
-          "instance",
-          "defaulted"
-        ]
-      },
-      {
-        "pretty": "outerNS::Couch::operator=",
-        "sym": "_ZN7outerNS5CouchaSEOS0_",
-        "props": [
-          "instance",
-          "defaulted"
-        ]
-      },
-      {
-        "pretty": "outerNS::Couch::~Couch",
-        "sym": "_ZN7outerNS5CouchD1Ev",
-        "props": [
-          "instance",
-          "defaulted"
-        ]
-      }
-    ],
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [],
     "fields": [],
     "overrides": [],
     "props": []
+  },
+  {
+    "loc": "00460:6-21",
+    "structured": 1,
+    "pretty": "outerNS::innerNS::NondebugAnonCat",
+    "sym": "T_outerNS::innerNS::NondebugAnonCat",
+    "kind": "class",
+    "implKind": "",
+    "sizeBytes": 1,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": []
+  },
+  {
+    "loc": "00087:4-25",
+    "structured": 1,
+    "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
+    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext::LessGlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00027:14-32",
+    "structured": 1,
+    "pretty": "GlobalContext::decideBooleanTrait",
+    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00067:14-35",
+    "structured": 1,
+    "pretty": "GlobalContext::decideCatBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00122:14-35",
+    "structured": 1,
+    "pretty": "GlobalContext::decideDogBooleanTrait",
+    "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
+  },
+  {
+    "loc": "00071:14-42",
+    "structured": 1,
+    "pretty": "GlobalContext::decideBestFriendBooleanTrait",
+    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "kind": "method",
+    "parentsym": "T_GlobalContext",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "static",
+      "user"
+    ]
   },
   {
     "loc": "00063:14-47",
@@ -3322,12 +3281,31 @@ expression: "&json_results"
     ]
   },
   {
-    "loc": "00182:2-7",
+    "loc": "00424:15-20",
     "structured": 1,
-    "pretty": "outerNS::Human::Human",
-    "sym": "_ZN7outerNS5HumanC1Ev",
+    "pretty": "outerNS::AbstractArt::beArt",
+    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
     "kind": "method",
-    "parentsym": "T_outerNS::Human",
+    "parentsym": "T_outerNS::AbstractArt",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00419:2-13",
+    "structured": 1,
+    "pretty": "outerNS::AbstractArt::AbstractArt",
+    "sym": "_ZN7outerNS11AbstractArtC1Ev",
+    "kind": "method",
+    "parentsym": "T_outerNS::AbstractArt",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3364,12 +3342,12 @@ expression: "&json_results"
     ]
   },
   {
-    "loc": "00027:14-32",
+    "loc": "00429:2-14",
     "structured": 1,
-    "pretty": "GlobalContext::decideBooleanTrait",
-    "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
+    "pretty": "outerNS::PracticalArt::PracticalArt",
+    "sym": "_ZN7outerNS12PracticalArtC1Ev",
     "kind": "method",
-    "parentsym": "T_GlobalContext",
+    "parentsym": "T_outerNS::PracticalArt",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3377,17 +3355,17 @@ expression: "&json_results"
     "fields": [],
     "overrides": [],
     "props": [
-      "static",
+      "instance",
       "user"
     ]
   },
   {
-    "loc": "00071:14-42",
+    "loc": "00208:2-7",
     "structured": 1,
-    "pretty": "GlobalContext::decideBestFriendBooleanTrait",
-    "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
+    "pretty": "outerNS::Couch::Couch",
+    "sym": "_ZN7outerNS5CouchC1Ei",
     "kind": "method",
-    "parentsym": "T_GlobalContext",
+    "parentsym": "T_outerNS::Couch",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3395,72 +3373,17 @@ expression: "&json_results"
     "fields": [],
     "overrides": [],
     "props": [
-      "static",
+      "instance",
       "user"
     ]
   },
   {
-    "loc": "00024:6-19",
+    "loc": "00182:2-7",
     "structured": 1,
-    "pretty": "GlobalContext",
-    "sym": "T_GlobalContext",
-    "kind": "class",
-    "implKind": "",
-    "sizeBytes": 1,
-    "supers": [],
-    "methods": [
-      {
-        "pretty": "GlobalContext::decideBooleanTrait",
-        "sym": "_ZN13GlobalContext18decideBooleanTraitEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      },
-      {
-        "pretty": "GlobalContext::decideEnigmaticAnimalBooleanTrait",
-        "sym": "_ZN13GlobalContext33decideEnigmaticAnimalBooleanTraitEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      },
-      {
-        "pretty": "GlobalContext::decideCatBooleanTrait",
-        "sym": "_ZN13GlobalContext21decideCatBooleanTraitEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      },
-      {
-        "pretty": "GlobalContext::decideBestFriendBooleanTrait",
-        "sym": "_ZN13GlobalContext28decideBestFriendBooleanTraitEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      },
-      {
-        "pretty": "GlobalContext::decideDogBooleanTrait",
-        "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      }
-    ],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00122:14-35",
-    "structured": 1,
-    "pretty": "GlobalContext::decideDogBooleanTrait",
-    "sym": "_ZN13GlobalContext21decideDogBooleanTraitEv",
+    "pretty": "outerNS::Human::Human",
+    "sym": "_ZN7outerNS5HumanC1Ev",
     "kind": "method",
-    "parentsym": "T_GlobalContext",
+    "parentsym": "T_outerNS::Human",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3468,7 +3391,170 @@ expression: "&json_results"
     "fields": [],
     "overrides": [],
     "props": [
-      "static",
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00156:15-25",
+    "structured": 1,
+    "pretty": "outerNS::Thing::takeDamage",
+    "sym": "_ZN7outerNS5Thing10takeDamageEi",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "virtual",
+      "user"
+    ]
+  },
+  {
+    "loc": "00166:12-18",
+    "structured": 1,
+    "pretty": "outerNS::Thing::ignore",
+    "sym": "_ZN7outerNS5Thing6ignoreEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00148:2-7",
+    "structured": 1,
+    "pretty": "outerNS::Thing::Thing",
+    "sym": "_ZN7outerNS5ThingC1Ei",
+    "kind": "method",
+    "parentsym": "T_outerNS::Thing",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00311:7-20",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isFriendlyCat",
+    "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00315:7-27",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+    "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00330:7-38",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+    "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00351:7-11",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00340:7-11",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::meet",
+    "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00390:7-12",
+    "structured": 1,
+    "pretty": "outerNS::OuterCat::shred",
+    "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+    "kind": "method",
+    "parentsym": "T_outerNS::OuterCat",
+    "implKind": "",
+    "sizeBytes": null,
+    "supers": [],
+    "methods": [],
+    "fields": [],
+    "overrides": [],
+    "props": [
+      "instance",
       "user"
     ]
   },
@@ -3491,42 +3577,12 @@ expression: "&json_results"
     ]
   },
   {
-    "loc": "00145:7-15",
+    "loc": "00248:2-10",
     "structured": 1,
-    "pretty": "outerNS::Thing::mDefunct",
-    "sym": "F_<T_outerNS::Thing>_mDefunct",
-    "kind": "field",
-    "parentsym": "T_outerNS::Thing",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00236:7-28",
-    "structured": 1,
-    "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
-    "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
-    "kind": "field",
-    "parentsym": "T_outerNS::OuterCat",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00191:2-11",
-    "structured": 1,
-    "pretty": "outerNS::Superhero::Superhero",
-    "sym": "_ZN7outerNS9SuperheroC1Ev",
+    "pretty": "outerNS::OuterCat::OuterCat",
+    "sym": "_ZN7outerNS8OuterCatC1Ebb",
     "kind": "method",
-    "parentsym": "T_outerNS::Superhero",
+    "parentsym": "T_outerNS::OuterCat",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3563,30 +3619,12 @@ expression: "&json_results"
     ]
   },
   {
-    "loc": "00087:4-25",
+    "loc": "00191:2-11",
     "structured": 1,
-    "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
-    "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
+    "pretty": "outerNS::Superhero::Superhero",
+    "sym": "_ZN7outerNS9SuperheroC1Ev",
     "kind": "method",
-    "parentsym": "T_GlobalContext::LessGlobalContext",
-    "implKind": "",
-    "sizeBytes": null,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": [
-      "static",
-      "user"
-    ]
-  },
-  {
-    "loc": "00166:12-18",
-    "structured": 1,
-    "pretty": "outerNS::Thing::ignore",
-    "sym": "_ZN7outerNS5Thing6ignoreEv",
-    "kind": "method",
-    "parentsym": "T_outerNS::Thing",
+    "parentsym": "T_outerNS::Superhero",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],
@@ -3599,49 +3637,11 @@ expression: "&json_results"
     ]
   },
   {
-    "loc": "00075:8-25",
+    "loc": "00473:5-33",
     "structured": 1,
-    "pretty": "GlobalContext::LessGlobalContext",
-    "sym": "T_GlobalContext::LessGlobalContext",
-    "kind": "class",
-    "implKind": "",
-    "sizeBytes": 1,
-    "supers": [],
-    "methods": [
-      {
-        "pretty": "GlobalContext::LessGlobalContext::decideWhetherToDecide",
-        "sym": "_ZN13GlobalContext17LessGlobalContext21decideWhetherToDecideEv",
-        "props": [
-          "static",
-          "user"
-        ]
-      }
-    ],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00460:6-21",
-    "structured": 1,
-    "pretty": "outerNS::innerNS::NondebugAnonCat",
-    "sym": "T_outerNS::innerNS::NondebugAnonCat",
-    "kind": "class",
-    "implKind": "",
-    "sizeBytes": 1,
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [],
-    "props": []
-  },
-  {
-    "loc": "00141:6-9",
-    "structured": 1,
-    "pretty": "outerNS::Thing::mHP",
-    "sym": "F_<T_outerNS::Thing>_mHP",
-    "kind": "field",
-    "parentsym": "T_outerNS::Thing",
+    "pretty": "i_was_declared_in_the_header",
+    "sym": "i_was_declared_in_the_header",
+    "kind": "function",
     "implKind": "",
     "sizeBytes": null,
     "supers": [],

--- a/tests/tests/checks/snapshots/check_glob@xref__big_cpp__abstractart__beart__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@xref__big_cpp__abstractart__beart__json.snap
@@ -1,0 +1,48 @@
+---
+source: tests/test_check_insta.rs
+expression: "json!(sl.symbol_crossref_infos.into_iter().map(| sci |\n                                               sci.crossref_info).collect :: <\n      Value > ())"
+
+---
+[
+  {
+    "defs": [
+      {
+        "path": "big_cpp.cpp",
+        "lines": [
+          {
+            "lno": 424,
+            "bounds": [
+              13,
+              18
+            ],
+            "line": "virtual void beArt() = 0;",
+            "context": "outerNS::AbstractArt",
+            "contextsym": "T_outerNS::AbstractArt",
+            "peekRange": "422-424"
+          }
+        ]
+      }
+    ],
+    "meta": {
+      "structured": 1,
+      "pretty": "outerNS::AbstractArt::beArt",
+      "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+      "kind": "method",
+      "parentsym": "T_outerNS::AbstractArt",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "virtual",
+        "user"
+      ],
+      "overriddenBy": [
+        "_ZN7outerNS12PracticalArt5beArtEv"
+      ]
+    }
+  }
+]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -2367,8 +2367,7 @@ dependencies = [
 [[package]]
 name = "ustr"
 version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbd539d8973e229b9d04f15d36e6a8f8d8f85f946b366f06bb001aaed3fa9dd9"
+source = "git+https://github.com/asutherland/ustr?rev=e87cb1584a1142486514d323bc7c18406cfe4806#e87cb1584a1142486514d323bc7c18406cfe4806"
 dependencies = [
  "ahash",
  "byteorder",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -45,7 +45,14 @@ structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 tokio-stream = "0.1.8"
 url = "2.2.2"
-ustr = { version = "0.8.1", features = ["serialization"] }
+# We need https://github.com/anderslanglands/ustr/pull/21
+# which is the fix for https://github.com/anderslanglands/ustr/issues/20
+# in order for our BTreeMap orderings in crossref.rs to be right.
+# I'm using my branch with fixed tests for the repo/revision since I won't
+# delete the the repo.  And once the crate is updated, we can switch back to
+# a variant of:
+# ustr = { version = "0.8.1", features = ["serialization"] }
+ustr = { git = "https://github.com/asutherland/ustr", rev = "e87cb1584a1142486514d323bc7c18406cfe4806", features = ["serialization"] }
 
 # Build release mode with line number info for easier debugging when
 # we hit panics in production

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -3,12 +3,14 @@ use flate2::read::GzDecoder;
 use futures_core::stream::BoxStream;
 use serde_json::{from_str, Value};
 use std::io::Read;
-use tokio::{fs::File};
+use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 
 use super::server_interface::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
 
 use crate::config::{load, TreeConfigPaths};
+use crate::file_format::crossref_lookup::CrossrefLookupMap;
+use crate::file_format::identifiers::IdentMap;
 
 /// IO errors amount to a 404 for our purposes which means a sticky problem.
 impl From<std::io::Error> for ServerError {
@@ -62,12 +64,19 @@ struct LocalIndex {
     // likely the model we should use.
     config_paths: TreeConfigPaths,
     tree_name: String,
+    // Note: IdentMap internally handles the identifiers db not existing
+    ident_map: IdentMap,
+    // But for crossref, it's on us.
+    crossref_lookup_map: Option<CrossrefLookupMap>,
 }
 
 #[async_trait]
 impl AbstractServer for LocalIndex {
     fn translate_analysis_path(&self, sf_path: &str) -> Result<String> {
-        Ok(format!("{}/analysis/{}.gz", self.config_paths.index_path, sf_path))
+        Ok(format!(
+            "{}/analysis/{}.gz",
+            self.config_paths.index_path, sf_path
+        ))
     }
 
     async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
@@ -101,6 +110,30 @@ impl AbstractServer for LocalIndex {
         Ok(raw_str)
     }
 
+    async fn crossref_lookup(&self, symbol: &str) -> Result<Value> {
+        match &self.crossref_lookup_map {
+            Some(crossref) => crossref.lookup(symbol),
+            None => Ok(Value::Null),
+        }
+    }
+
+    async fn search_identifiers(
+        &self,
+        needle: &str,
+        exact_match: bool,
+        ignore_case: bool,
+        match_limit: usize,
+    ) -> Result<Vec<(String, String)>> {
+        let mut results = vec![];
+        for ir in self
+            .ident_map
+            .lookup(needle, exact_match, ignore_case, match_limit)
+        {
+            results.push((ir.symbol, ir.id));
+        }
+        Ok(results)
+    }
+
     async fn perform_query(&self, _q: &str) -> Result<Value> {
         // TODO: For this to work, we want to be able to directly invoke the
         // underpinnings of the web server, which entails porting router.py into
@@ -125,9 +158,19 @@ pub fn make_local_server(
         }
     };
 
+    let ident_path = format!("{}/identifiers", tree_config.paths.index_path);
+    let ident_map = IdentMap::new(&ident_path);
+
+    let crossref_path = format!("{}/crossref", tree_config.paths.index_path);
+    let crossref_extra_path = format!("{}/crossref-extra", tree_config.paths.index_path);
+
+    let crossref_lookup_map = CrossrefLookupMap::new(&crossref_path, &crossref_extra_path);
+
     Ok(Box::new(LocalIndex {
         // We don't need the blame_map and hg_map (yet)
         config_paths: tree_config.paths,
         tree_name: tree_name.to_string(),
+        ident_map,
+        crossref_lookup_map,
     }))
 }

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -105,6 +105,24 @@ impl AbstractServer for RemoteServer {
         Ok(html)
     }
 
+    async fn crossref_lookup(&self, _symbol: &str) -> Result<Value> {
+        // Let's require local index for now; we'll expose this once this
+        // mechanism is exposed to the web so we can talk to the corresponding
+        // local server over https.
+        //
+        // That is, we could build this on top of the existing router.py, but
+        // the legacy rep is definitely not what we want and although the
+        // "sorch" endpoint that's an artifact of the fancy-branch prototype
+        // is closer, it's probably better if that doesn't get stabilized.
+        Err(ServerError::Unsupported)
+    }
+
+    async fn search_identifiers(&self, _needle: &str, _exact_match: bool, _ignore_case: bool, _match_limit: usize) -> Result<Vec<(String, String)>> {
+        // Same rationale as crossref_lookup.
+        Err(ServerError::Unsupported)
+    }
+
+
     async fn perform_query(&self, q: &str) -> Result<Value> {
         let mut url = self.search_url.clone();
         // If adding more parameters, considering using `query_pairs_mut()`.

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -45,6 +45,39 @@ async fn main() {
             println!("Void result.");
             0
         }
+        Ok(PipelineValues::IdentifierList(il)) => {
+            for identifier in il.identifiers {
+                println!("{}", identifier);
+            }
+            0
+        }
+        Ok(PipelineValues::SymbolList(sl)) => {
+            match sl.from_identifiers {
+                Some(identifiers) => {
+                    for (sym, ident) in sl.symbols.iter().zip(identifiers.iter()) {
+                        println!("{} from {}", sym, ident);
+                    }
+                }
+                None => {
+                    for sym in sl.symbols {
+                        println!("{}", sym);
+                    }
+                }
+            }
+            0
+        }
+        Ok(PipelineValues::SymbolCrossrefInfoList(sl)) => {
+            for symbol_info in sl.symbol_crossref_infos {
+                if output_format == OutputFormat::Concise {
+                    println!("{}", symbol_info.crossref_info);
+                } else if output_format == OutputFormat::Pretty {
+                    if let Ok(pretty) = to_string_pretty(&symbol_info.crossref_info) {
+                        println!("{}", pretty);
+                    }
+                }
+            }
+            0
+        }
         Ok(PipelineValues::HtmlExcerpts(he)) => {
             for file_excerpts in he.by_file {
                 //println!("HTML excerpts from: {}", file_excerpts.file);

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -8,7 +8,7 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_filter_analysis::FilterAnalysisCommand, cmd_merge_analyses::MergeAnalysesCommand};
+use super::{cmd_filter_analysis::FilterAnalysisCommand, cmd_merge_analyses::MergeAnalysesCommand, cmd_crossref_lookup::CrossrefLookupCommand, cmd_search_identifiers::SearchIdentifiersCommand};
 use super::cmd_query::QueryCommand;
 use super::cmd_show_html::ShowHtmlCommand;
 
@@ -63,11 +63,13 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
         }
 
         match opts.cmd {
+            Command::CrossrefLookup(cl) => {
+                commands.push(Box::new(CrossrefLookupCommand { args: cl }))
+            }
+
             Command::FilterAnalysis(fa) => {
                 commands.push(Box::new(FilterAnalysisCommand { args: fa }));
             }
-
-            Command::IdentifierLookup(_il) => (),
 
             Command::MergeAnalyses(ma) => {
                 commands.push(Box::new(MergeAnalysesCommand{ args: ma }))
@@ -81,6 +83,9 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
                 commands.push(Box::new(QueryCommand { args: q }))
             }
 
+            Command::SearchIdentifiers(si) => {
+                commands.push(Box::new(SearchIdentifiersCommand { args: si }))
+            },
 
             Command::ShowHtml(sh) => {
                 commands.push(Box::new(ShowHtmlCommand { args: sh }));

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -1,0 +1,62 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::interface::{
+    PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolList,
+};
+
+use crate::abstract_server::{AbstractServer, Result};
+
+/// Return the crossref data for one or more symbols received via pipeline or as
+/// explicit arguments.
+#[derive(Debug, StructOpt)]
+pub struct CrossrefLookup {
+    /// Explicit symbols to lookup.
+    symbols: Vec<String>,
+    // TODO: It might make sense to provide a way to filter the looked up data
+    // by kind, although that could of course be its own command too.
+}
+
+pub struct CrossrefLookupCommand {
+    pub args: CrossrefLookup,
+}
+
+#[async_trait]
+impl PipelineCommand for CrossrefLookupCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let symbol_list = match input {
+            PipelineValues::SymbolList(sl) => sl,
+            // Right now we're assuming that we're the first command in the
+            // pipeline so that we would have no inputs if someone wants to use
+            // arguments...
+            PipelineValues::Void => SymbolList {
+                symbols: self.args.symbols.clone(),
+                from_identifiers: None,
+            },
+            // TODO: Figure out a better way to handle a nonsensical pipeline
+            // configuration / usage.
+            _ => {
+                return Ok(PipelineValues::Void);
+            }
+        };
+
+        let mut symbol_crossref_infos = vec![];
+        for symbol in symbol_list.symbols {
+            let info = server.crossref_lookup(&symbol).await?;
+            symbol_crossref_infos.push(SymbolCrossrefInfo {
+                symbol,
+                crossref_info: info,
+            });
+        }
+
+        Ok(PipelineValues::SymbolCrossrefInfoList(
+            SymbolCrossrefInfoList {
+                symbol_crossref_infos,
+            },
+        ))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_filter_analysis.rs
+++ b/tools/src/cmd_pipeline/cmd_filter_analysis.rs
@@ -10,6 +10,7 @@ use crate::{
     cmd_pipeline::interface::JsonRecordsByFile,
 };
 
+/// Filter the contents of a single analysis file.
 #[derive(Debug, StructOpt)]
 pub struct FilterAnalysis {
     /// Tree-relative analysis file path
@@ -25,12 +26,14 @@ pub struct FilterAnalysis {
     query_opts: SymbolicQueryOpts,
 }
 
-/// Filter a stream of analysis records via raw JSON manipulation rather than
-/// using the strongly typed `analysis.rs` types.
 pub struct FilterAnalysisCommand {
     pub args: FilterAnalysis,
 }
 
+/// ### Implementation Note
+/// Filtering is currently performed via generic JSON rather than the strongly
+/// typed `analysis.rs` types, but this pre-dates the change to using serde-json
+/// and it probably makes sense to switch to using the raw types.
 #[async_trait]
 impl PipelineCommand for FilterAnalysisCommand {
     async fn execute(

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -11,6 +11,7 @@ use crate::{
     file_format::merger::merge_files,
 };
 
+/// Merge analysis files from different build configs into one analysis file.
 #[derive(Debug, StructOpt)]
 pub struct MergeAnalyses {
     /// Tree-relative analysis file paths

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -15,12 +15,12 @@ use crate::{
     cmd_pipeline::interface::{HtmlExcerpts, HtmlExcerptsByFile},
 };
 
-#[derive(Debug, StructOpt)]
-pub struct ProductionFilter {}
-
 /// Normalize HTML or JSON records for production environment checks so that
 /// details like line numbers or `data-i` indexes that are subject to churn
 /// due to changes elsewhere in the file are normalized to "NORM".
+#[derive(Debug, StructOpt)]
+pub struct ProductionFilter {}
+
 pub struct ProductionFilterCommand {
     pub args: ProductionFilter,
 }

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -6,6 +6,9 @@ use crate::{
     abstract_server::{AbstractServer, Result},
 };
 
+/// Run a traditional searchfox query against the web server.  This will turn
+/// into a no-op when run against a local index at this time, but in the future
+/// may be able to spin up the necessary pieces.
 #[derive(Debug, StructOpt)]
 pub struct Query {
   /// Query string

--- a/tools/src/cmd_pipeline/cmd_search_identifiers.rs
+++ b/tools/src/cmd_pipeline/cmd_search_identifiers.rs
@@ -1,0 +1,75 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::interface::{IdentifierList, PipelineCommand, PipelineValues, SymbolList};
+
+use crate::abstract_server::{AbstractServer, Result};
+
+/// Return the crossref data for one or more symbols received via pipeline or as
+/// explicit arguments.
+#[derive(Debug, StructOpt)]
+pub struct SearchIdentifiers {
+    /// Explicit identifiers to search.
+    identifiers: Vec<String>,
+
+    /// Should this be an exact-match?  By default we do a prefix search.
+    #[structopt(short, long)]
+    exact_match: bool,
+
+    /// Should this be case-sensitive?  By default we are case-insensitive.
+    #[structopt(short, long)]
+    case_sensitive: bool,
+
+    #[structopt(short, long, default_value = "0")]
+    limit: usize,
+}
+
+pub struct SearchIdentifiersCommand {
+    pub args: SearchIdentifiers,
+}
+
+#[async_trait]
+impl PipelineCommand for SearchIdentifiersCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let identifier_list = match input {
+            PipelineValues::IdentifierList(il) => il,
+            // Right now we're assuming that we're the first command in the
+            // pipeline so that we would have no inputs if someone wants to use
+            // arguments...
+            PipelineValues::Void => IdentifierList {
+                identifiers: self.args.identifiers.clone(),
+            },
+            // TODO: Figure out a better way to handle a nonsensical pipeline
+            // configuration / usage.
+            _ => {
+                return Ok(PipelineValues::Void);
+            }
+        };
+
+        let mut symbols: Vec<String> = vec![];
+        let mut from_identifiers: Vec<String> = vec![];
+        for id in identifier_list.identifiers {
+            for (sym, from_ident) in server
+                .search_identifiers(
+                    &id,
+                    self.args.exact_match,
+                    !self.args.case_sensitive,
+                    self.args.limit,
+                )
+                .await?
+            {
+                symbols.push(sym);
+                from_identifiers.push(from_ident);
+            }
+        }
+
+        Ok(PipelineValues::SymbolList(SymbolList {
+            symbols,
+            from_identifiers: Some(from_identifiers),
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -10,9 +10,6 @@ use crate::{
     cmd_pipeline::interface::{HtmlExcerpts, HtmlExcerptsByFile},
 };
 
-#[derive(Debug, StructOpt)]
-pub struct ShowHtml {}
-
 /// Output the HTML lines corresponding to the JSON records received via input.
 ///
 /// There's also likely a use-case to process an HTML file as a root where we
@@ -23,6 +20,9 @@ pub struct ShowHtml {}
 /// be driven by command-line use-cases; in particular, the experience of
 /// evolving a more targeted query.  Having to modify a command up-stream should
 /// be considered undesirable.
+#[derive(Debug, StructOpt)]
+pub struct ShowHtml {}
+
 pub struct ShowHtmlCommand {
     pub args: ShowHtml,
 }

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -28,10 +28,39 @@ pub struct SymbolicQueryOpts {
 
 /// The input and output of each pipeline segment
 pub enum PipelineValues {
+    IdentifierList(IdentifierList),
+    SymbolList(SymbolList),
+    SymbolCrossrefInfoList(SymbolCrossrefInfoList),
     JsonValue(JsonValue),
     JsonRecords(JsonRecords),
     HtmlExcerpts(HtmlExcerpts),
     Void,
+}
+
+/// A list of (searchfox) identifiers.
+pub struct IdentifierList {
+    pub identifiers: Vec<String>,
+}
+
+/// A list of (searchfox) symbols.
+pub struct SymbolList {
+    pub symbols: Vec<String>,
+    /// If present, these correspond to the identifiers that give us the
+    /// symbols.  This is used in cases where an non-exact_match identifier
+    /// search is performed and so we may not actually know what the identifiers
+    /// actually were.
+    pub from_identifiers: Option<Vec<String>>,
+}
+
+/// A symbol and its cross-reference information.
+pub struct SymbolCrossrefInfo {
+    pub symbol: String,
+    pub crossref_info: Value,
+}
+
+/// A list of `SymbolCrossrefInfo`s.
+pub struct SymbolCrossrefInfoList {
+    pub symbol_crossref_infos: Vec<SymbolCrossrefInfo>,
 }
 
 /// JSON records are raw analysis records from a single file (for now)

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -5,10 +5,12 @@ pub mod builder;
 pub mod interface;
 pub mod parser;
 
+mod cmd_crossref_lookup;
 mod cmd_filter_analysis;
 mod cmd_merge_analyses;
 mod cmd_prod_filter;
 mod cmd_query;
+mod cmd_search_identifiers;
 mod cmd_show_html;
 
 pub use builder::{build_pipeline};

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -1,10 +1,12 @@
 use clap::arg_enum;
 use structopt::StructOpt;
 
+use super::cmd_crossref_lookup::CrossrefLookup;
 use super::cmd_filter_analysis::FilterAnalysis;
 use super::cmd_merge_analyses::MergeAnalyses;
 use super::cmd_prod_filter::ProductionFilter;
 use super::cmd_query::Query;
+use super::cmd_search_identifiers::SearchIdentifiers;
 use super::cmd_show_html::ShowHtml;
 
 arg_enum! {
@@ -41,13 +43,11 @@ pub struct ToolOpts {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
+    CrossrefLookup(CrossrefLookup),
     FilterAnalysis(FilterAnalysis),
-    IdentifierLookup(IdentifierLookup),
     MergeAnalyses(MergeAnalyses),
     ProductionFilter(ProductionFilter),
     Query(Query),
+    SearchIdentifiers(SearchIdentifiers),
     ShowHtml(ShowHtml),
 }
-
-#[derive(Debug, StructOpt)]
-pub struct IdentifierLookup {}

--- a/tools/src/file_format/crossref_lookup.rs
+++ b/tools/src/file_format/crossref_lookup.rs
@@ -1,0 +1,195 @@
+extern crate memmap;
+
+use self::memmap::{Mmap, Protection};
+use std::collections::HashMap;
+use std::str;
+
+use serde_json::{from_slice, Value};
+
+use crate::{config, abstract_server::Result, abstract_server::{ServerError, ErrorDetails, ErrorLayer}};
+
+#[derive(Debug)]
+pub struct CrossrefLookupMap {
+    inline_mm: Mmap,
+    extra_mm: Mmap,
+}
+
+const SPACE: u8 = ' ' as u8;
+const NEWLINE: u8 = '\n' as u8;
+const ID_START: u8 = '!' as u8;
+const INLINE_STORED: u8 = ':' as u8;
+const EXTERNALLY_STORED: u8 = '@' as u8;
+
+fn make_crossref_data_error(sym: &str) -> ServerError {
+    ServerError::StickyProblem(ErrorDetails {
+        layer: ErrorLayer::DataLayer,
+        message: format!("bad crossref data for symbol: {}", sym),
+    })
+}
+
+// This implementation is a port of `crossrefs.py` (which was adapted from
+// `identifiers.py`) and informed by `identifiers.rs` (which presumably was
+// adapted from `identifiers.py` as well).
+impl CrossrefLookupMap {
+    pub fn new(inline_path: &str, extra_path: &str) -> Option<CrossrefLookupMap> {
+        let inline_mm = match Mmap::open_path(inline_path, Protection::Read) {
+            Ok(mmap) => mmap,
+            Err(_) => {
+                return None
+            }
+        };
+        let extra_mm = match Mmap::open_path(extra_path, Protection::Read) {
+          Ok(mmap) => mmap,
+          Err(_) => {
+              return None
+          }
+      };
+        Some(CrossrefLookupMap { inline_mm, extra_mm })
+    }
+
+    pub fn load(config: &config::Config) -> HashMap<String, Option<CrossrefLookupMap>> {
+        let mut result = HashMap::new();
+        for (tree_name, tree_config) in &config.trees {
+            println!("Loading crossref {}", tree_name);
+            let inline_path = format!("{}/crossref", tree_config.paths.index_path);
+            let extra_path = format!("{}/crossref-extra", tree_config.paths.index_path);
+            let map = CrossrefLookupMap::new(&inline_path, &extra_path);
+            result.insert(tree_name.clone(), map);
+        }
+        result
+    }
+
+    // Given a memory map and a position, expand from `pos` to find the identifier
+    // line (`!` prefixed) that covers the position.  Returns (the identifier,
+    // the offset of the `!` from the start of the identifier line, the offset of
+    // the newline ending the identifier line).
+    //
+    // `pos` is either inside an identifier line or a payload line that follows an
+    // identifier line, so we always walk backwards until we find an identifier.
+    // We should never need to walk forward (to find the start of the identifier
+    // line) because the result of any comparison should always tell the bisection
+    // to bisect in the positive direction (because the file is sorted), which
+    // should then find the subsequent record (if that's the one we're looking
+    // for, etc.).
+    fn get_id_line(&self, pos: usize) -> (&[u8], usize, usize) {
+        let mut pos = pos;
+        let bytes: &[u8] = unsafe { self.inline_mm.as_slice() };
+        if bytes[pos] == NEWLINE {
+            pos -= 1;
+        }
+
+        let mut start = pos;
+        let mut end = pos;
+
+        while start > 0 {
+            if bytes[start - 1] == NEWLINE {
+                if bytes[start] == ID_START {
+                    break;
+                } else {
+                    // We're hitting a ":" and we need to reset end to this newlin
+                    end = start - 1
+                    // and we want to keep going...
+                }
+            }
+            start -= 1;
+        }
+
+        // Start should now be pointing at the `!` of the identifier line.
+
+        let size = self.inline_mm.len();
+        while end < size && bytes[end] != NEWLINE {
+            end += 1;
+        }
+
+        // end should now be pointing at the trailing newline.
+
+        // Skip the leading `!`
+        (&bytes[start+1..end], start, end)
+    }
+
+    // Bisect the mmap to look for an exact symbol match `sym`, and returning the
+    // payload line which may be either inline JSON or external offsets to be
+    // retrieved from another map.
+    fn bisect_for_payload(&self, search_sym: &[u8]) -> &[u8] {
+        let mut first = 0;
+        let mmap_end = self.inline_mm.len();
+        let bytes: &[u8] = unsafe { self.inline_mm.as_slice() };
+        let mut count = mmap_end;
+
+        while count > 0 {
+            let step = count / 2;
+            let pos = first + step;
+
+            let (line_sym, line_start, line_end) = self.get_id_line(pos);
+
+            if line_sym == search_sym {
+                // Exact Match!  Extract the payload line.
+                let payload_start = line_end + 1;
+                let mut payload_end = payload_start + 1;
+                while payload_end < mmap_end && bytes[payload_end] != NEWLINE {
+                    payload_end += 1;
+                }
+                return &bytes[payload_start..payload_end];
+            } else if line_sym < search_sym {
+                // ## Bisect latter half
+                // We might as well exclude the payload line we're skipping as well.
+                // Because payload lines are intentionally limited during the
+                // creation of `crossref`, we know this should fault an acceptable
+                // number of pages which may have already been pre-fetched.
+                while first < mmap_end && bytes[first] != NEWLINE {
+                    first += 1;
+                }
+                // move past the newline
+                first += 1;
+
+                // Halve count and also subtract off the parts of the identifier line
+                // and payload line we're skipping.
+                count -= step + (pos - first)
+            } else {
+                // ## Bisect first half
+                // Halve count and subtract off the part of the identifier line that
+                // we can eliminate from consideration.
+                count = step - (pos - line_start)
+            }
+        }
+
+        &[]
+    }
+
+    pub fn lookup(
+        &self,
+        sym: &str,
+    ) -> Result<Value> {
+        let payload = self.bisect_for_payload(sym.as_bytes());
+        let payload_len = payload.len();
+        // Finding nothing (a miss!) is not an error and so is an in-band null.
+        if payload_len == 0 {
+            return Ok(Value::Null);
+        }
+        // Let's also rule out results that are too short and therefore must be
+        // an error.
+        if payload_len < 3 {
+            return Err(make_crossref_data_error(sym));
+        }
+
+        let marker_char = payload[0];
+
+        if marker_char == INLINE_STORED {
+            return from_slice(&payload[1..]).or(Ok(Value::Null));
+        } else if marker_char != EXTERNALLY_STORED {
+            // Fail if we're seeing something other than an external ref.
+            return Err(make_crossref_data_error(sym));
+        }
+
+        let mut space_pos = 2;
+        while space_pos < payload_len && payload[space_pos] != SPACE {
+            space_pos += 1;
+        }
+
+        let brace_offset = unsafe { usize::from_str_radix(str::from_utf8_unchecked(&payload[1..space_pos]), 16).map_err(|_| make_crossref_data_error(sym))? };
+        let length_with_newline = unsafe { usize::from_str_radix(str::from_utf8_unchecked(&payload[space_pos+1..]), 16).map_err(|_| make_crossref_data_error(sym))? };
+        
+        let extra_bytes: &[u8] = unsafe { self.extra_mm.as_slice() };
+        return Ok(from_slice(&extra_bytes[brace_offset..brace_offset + length_with_newline - 1])?);
+    }
+}

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -23,6 +23,7 @@ fn uppercase(s: &[u8]) -> Vec<u8> {
     result
 }
 
+#[derive(Debug)]
 pub struct IdentMap {
     mmap: Option<Mmap>,
 }
@@ -53,7 +54,7 @@ fn demangle_name(name: &str) -> String {
 }
 
 impl IdentMap {
-    fn new(filename: &str) -> IdentMap {
+    pub fn new(filename: &str) -> IdentMap {
         let mmap = match Mmap::open_path(filename, Protection::Read) {
             Ok(mmap) => Some(mmap),
             Err(e) => {
@@ -130,13 +131,11 @@ impl IdentMap {
         first
     }
 
-    // NEED A WAY TO LIMIT NUMBER OF RESULTS RETURNED TO 6
-    // Also need to apply c++filt to the ident as a better human-readable name
     pub fn lookup(
         &self,
         needle: &str,
-        complete: bool,
-        fold_case: bool,
+        exact_match: bool,
+        ignore_case: bool,
         max_results: usize,
     ) -> Vec<IdentResult> {
         let mmap = match self.mmap {
@@ -159,11 +158,11 @@ impl IdentMap {
 
             {
                 let suffix = &id[needle.len()..];
-                if suffix.contains(':') || suffix.contains('.') || (complete && suffix.len() > 0) {
+                if suffix.contains(':') || suffix.contains('.') || (exact_match && suffix.len() > 0) {
                     continue;
                 }
             }
-            if !fold_case && !id.starts_with(needle) {
+            if !ignore_case && !id.starts_with(needle) {
                 continue;
             }
 

--- a/tools/src/file_format/mod.rs
+++ b/tools/src/file_format/mod.rs
@@ -1,3 +1,4 @@
 pub mod analysis;
+pub mod crossref_lookup;
 pub mod identifiers;
 pub mod merger;


### PR DESCRIPTION
This changes the crossref format so that we can binary search it and save ourselves a bunch of memory (https://bugzilla.mozilla.org/show_bug.cgi?id=1702916).  This also implements a rust crossref lookup and does all the searchfox-tool/test_check_insta hookup (https://bugzilla.mozilla.org/show_bug.cgi?id=1749176) so we're a primitive closer to being able to replace router.py in rust.  We still need the livegrep hookup, but it seems like grpc support exists for tokio already.

My tentative plan is to temporarily stand up a 3rd web-server process written in rust on top of tokio so we can incrementally experiment with the migration and new functionality without worrying about breaking what's already working.  Ideally it will reach a point where nginx can either point at the old router.py/web-server.rs or the new server and no one notices except for some speedups here and there.  The memory the binary search crossref saves us in router.py should cover the extra memory overhead of the extra server which I'm going to dub the "pipeline-server" because it could allow the searchfox-tool style pipelines to be done by users from the web, but I'm not wedded to anything.

I'm going to land this now and re-provision because I've already had a successful "dev" run with the python changes, the design decision behind this was previously circulated/discussed on https://bugzilla.mozilla.org/show_bug.cgi?id=1702916, and tomorrow is still the weekend and I'll have time to fix things if things explode a bunch.  That said, please do feel free to provide review comments and I will strive to address them in a timely fashion.