### PR TITLE
Bug 1749176 - Add missing test snapshots.

### DIFF
--- a/tests/tests/checks/snapshots/check_glob@id__big_cpp__thing__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@id__big_cpp__thing__json.snap
@@ -1,0 +1,11 @@
+---
+source: tests/test_check_insta.rs
+expression: json!(pairs)
+
+---
+[
+  {
+    "sym": "T_outerNS::Thing",
+    "id": "outerNS::Thing"
+  }
+]

--- a/tests/tests/checks/snapshots/check_glob@xref__big_cpp__thing__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@xref__big_cpp__thing__json.snap
@@ -1,0 +1,262 @@
+---
+source: tests/test_check_insta.rs
+expression: crossref_json
+
+---
+[
+  {
+    "uses": [
+      {
+        "path": "big_cpp.cpp",
+        "lines": [
+          {
+            "lno": 166,
+            "bounds": [
+              5,
+              10
+            ],
+            "line": "void Thing::ignore() {",
+            "context": "outerNS::Thing::ignore",
+            "contextsym": "_ZN7outerNS5Thing6ignoreEv"
+          },
+          {
+            "lno": 179,
+            "bounds": [
+              20,
+              25
+            ],
+            "line": "class Human: public Thing {",
+            "context": "outerNS::Human",
+            "contextsym": "T_outerNS::Human"
+          },
+          {
+            "lno": 183,
+            "bounds": [
+              2,
+              7
+            ],
+            "line": ": Thing(HUMAN_HP) {",
+            "context": "outerNS::Human::Human",
+            "contextsym": "_ZN7outerNS5HumanC1Ev"
+          },
+          {
+            "lno": 205,
+            "bounds": [
+              21,
+              26
+            ],
+            "line": "class Couch : public Thing {",
+            "context": "outerNS::Couch",
+            "contextsym": "T_outerNS::Couch"
+          },
+          {
+            "lno": 209,
+            "bounds": [
+              2,
+              7
+            ],
+            "line": ": Thing (couchHP) {",
+            "context": "outerNS::Couch::Couch",
+            "contextsym": "_ZN7outerNS5CouchC1Ei"
+          },
+          {
+            "lno": 221,
+            "bounds": [
+              17,
+              22
+            ],
+            "line": "class OuterCat : Thing {",
+            "context": "outerNS::OuterCat",
+            "contextsym": "T_outerNS::OuterCat"
+          },
+          {
+            "lno": 258,
+            "bounds": [
+              2,
+              7
+            ],
+            "line": ": Thing(9 * HUMAN_HP)",
+            "context": "outerNS::OuterCat::OuterCat",
+            "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
+          },
+          {
+            "lno": 390,
+            "bounds": [
+              11,
+              16
+            ],
+            "line": "void shred(Thing &thing) {",
+            "context": "outerNS::OuterCat::shred",
+            "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+          },
+          {
+            "lno": 397,
+            "bounds": [
+              13,
+              18
+            ],
+            "line": "void destroy(Thing &thing) {",
+            "context": "outerNS::OuterCat::destroy",
+            "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+          },
+          {
+            "lno": 417,
+            "bounds": [
+              27,
+              32
+            ],
+            "line": "class AbstractArt : public Thing {",
+            "context": "outerNS::AbstractArt",
+            "contextsym": "T_outerNS::AbstractArt"
+          },
+          {
+            "lno": 420,
+            "bounds": [
+              2,
+              7
+            ],
+            "line": ": Thing(ART_HP) {}",
+            "context": "outerNS::AbstractArt::AbstractArt",
+            "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+          }
+        ]
+      }
+    ],
+    "defs": [
+      {
+        "path": "big_cpp.cpp",
+        "lines": [
+          {
+            "lno": 135,
+            "bounds": [
+              6,
+              11
+            ],
+            "line": "class Thing {",
+            "context": "",
+            "contextsym": "",
+            "peekRange": "135-135"
+          }
+        ]
+      }
+    ],
+    "callees": [
+      {
+        "kind": "field",
+        "pretty": "outerNS::Thing::mDefunct",
+        "sym": "F_<T_outerNS::Thing>_mDefunct"
+      },
+      {
+        "kind": "field",
+        "pretty": "outerNS::Thing::mHP",
+        "sym": "F_<T_outerNS::Thing>_mHP"
+      }
+    ],
+    "meta": {
+      "structured": 1,
+      "pretty": "outerNS::Thing",
+      "sym": "T_outerNS::Thing",
+      "kind": "class",
+      "implKind": "",
+      "sizeBytes": 16,
+      "supers": [],
+      "methods": [
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1Ei",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::ignore",
+          "sym": "_ZN7outerNS5Thing6ignoreEv",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::takeDamage",
+          "sym": "_ZN7outerNS5Thing10takeDamageEi",
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::operator=",
+          "sym": "_ZN7outerNS5ThingaSERKS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::operator=",
+          "sym": "_ZN7outerNS5ThingaSEOS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::~Thing",
+          "sym": "_ZN7outerNS5ThingD1Ev",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1ERKS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1EOS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "pretty": "outerNS::Thing::mHP",
+          "sym": "F_<T_outerNS::Thing>_mHP",
+          "type": "int",
+          "typesym": "",
+          "offsetBytes": 8,
+          "bitPositions": null,
+          "sizeBytes": 4
+        },
+        {
+          "pretty": "outerNS::Thing::mDefunct",
+          "sym": "F_<T_outerNS::Thing>_mDefunct",
+          "type": "_Bool",
+          "typesym": "",
+          "offsetBytes": 12,
+          "bitPositions": null,
+          "sizeBytes": 1
+        }
+      ],
+      "overrides": [],
+      "props": [],
+      "subclasses": [
+        "T_outerNS::Human",
+        "T_outerNS::Couch",
+        "T_outerNS::OuterCat",
+        "T_outerNS::AbstractArt"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
A current limitation of the test infrastructure is that it's very easy to accidentally
only add a single new test snapshot at a time because `make build-test-repo` stops at
the first failure.

Here are the new missing test snapshot values.