### PR TITLE
Bug 1749232 - Implement "traverse" command with graph support infra

### DIFF
--- a/tests/tests/checks/inputs/traverse_callees__big_cpp__outercat_meet__json
+++ b/tests/tests/checks/inputs/traverse_callees__big_cpp__outercat_meet__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse

--- a/tests/tests/checks/snapshots/check_glob@traverse_callees__big_cpp__outercat_meet__json.snap
+++ b/tests/tests/checks/snapshots/check_glob@traverse_callees__big_cpp__outercat_meet__json.snap
@@ -1,0 +1,506 @@
+---
+source: tests/test_check_insta.rs
+expression: sgc.to_json()
+
+---
+{
+  "symbol_metas": {
+    "F_<T_outerNS::OuterCat>_mIsFriendly": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::mIsFriendly",
+      "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+      "kind": "field",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": []
+    },
+    "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+      "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+      "kind": "field",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": []
+    },
+    "F_<T_outerNS::Thing>_mDefunct": {
+      "structured": 1,
+      "pretty": "outerNS::Thing::mDefunct",
+      "sym": "F_<T_outerNS::Thing>_mDefunct",
+      "kind": "field",
+      "parentsym": "T_outerNS::Thing",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": []
+    },
+    "F_<T_outerNS::Thing>_mHP": {
+      "structured": 1,
+      "pretty": "outerNS::Thing::mHP",
+      "sym": "F_<T_outerNS::Thing>_mHP",
+      "kind": "field",
+      "parentsym": "T_outerNS::Thing",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": []
+    },
+    "T_outerNS::Couch": {
+      "structured": 1,
+      "pretty": "outerNS::Couch",
+      "sym": "T_outerNS::Couch",
+      "kind": "class",
+      "implKind": "",
+      "sizeBytes": 16,
+      "supers": [
+        {
+          "pretty": "outerNS::Thing",
+          "sym": "T_outerNS::Thing",
+          "props": []
+        }
+      ],
+      "methods": [
+        {
+          "pretty": "outerNS::Couch::Couch",
+          "sym": "_ZN7outerNS5CouchC1Ei",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Couch::operator=",
+          "sym": "_ZN7outerNS5CouchaSERKS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Couch::operator=",
+          "sym": "_ZN7outerNS5CouchaSEOS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Couch::~Couch",
+          "sym": "_ZN7outerNS5CouchD1Ev",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        }
+      ],
+      "fields": [],
+      "overrides": [],
+      "props": []
+    },
+    "T_outerNS::Human": {
+      "structured": 1,
+      "pretty": "outerNS::Human",
+      "sym": "T_outerNS::Human",
+      "kind": "class",
+      "implKind": "",
+      "sizeBytes": 16,
+      "supers": [
+        {
+          "pretty": "outerNS::Thing",
+          "sym": "T_outerNS::Thing",
+          "props": []
+        }
+      ],
+      "methods": [
+        {
+          "pretty": "outerNS::Human::Human",
+          "sym": "_ZN7outerNS5HumanC1Ev",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Human::operator=",
+          "sym": "_ZN7outerNS5HumanaSERKS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Human::operator=",
+          "sym": "_ZN7outerNS5HumanaSEOS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Human::~Human",
+          "sym": "_ZN7outerNS5HumanD1Ev",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Human::Human",
+          "sym": "_ZN7outerNS5HumanC1ERKS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        },
+        {
+          "pretty": "outerNS::Human::Human",
+          "sym": "_ZN7outerNS5HumanC1EOS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        }
+      ],
+      "fields": [],
+      "overrides": [],
+      "props": [],
+      "subclasses": [
+        "T_outerNS::Superhero"
+      ]
+    },
+    "T_outerNS::Thing": {
+      "structured": 1,
+      "pretty": "outerNS::Thing",
+      "sym": "T_outerNS::Thing",
+      "kind": "class",
+      "implKind": "",
+      "sizeBytes": 16,
+      "supers": [],
+      "methods": [
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1Ei",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::ignore",
+          "sym": "_ZN7outerNS5Thing6ignoreEv",
+          "props": [
+            "instance",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::takeDamage",
+          "sym": "_ZN7outerNS5Thing10takeDamageEi",
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::operator=",
+          "sym": "_ZN7outerNS5ThingaSERKS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::operator=",
+          "sym": "_ZN7outerNS5ThingaSEOS0_",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::~Thing",
+          "sym": "_ZN7outerNS5ThingD1Ev",
+          "props": [
+            "instance",
+            "defaulted"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1ERKS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        },
+        {
+          "pretty": "outerNS::Thing::Thing",
+          "sym": "_ZN7outerNS5ThingC1EOS0_",
+          "props": [
+            "instance",
+            "defaulted",
+            "constexpr"
+          ]
+        }
+      ],
+      "fields": [
+        {
+          "pretty": "outerNS::Thing::mHP",
+          "sym": "F_<T_outerNS::Thing>_mHP",
+          "type": "int",
+          "typesym": "",
+          "offsetBytes": 8,
+          "bitPositions": null,
+          "sizeBytes": 4
+        },
+        {
+          "pretty": "outerNS::Thing::mDefunct",
+          "sym": "F_<T_outerNS::Thing>_mDefunct",
+          "type": "_Bool",
+          "typesym": "",
+          "offsetBytes": 12,
+          "bitPositions": null,
+          "sizeBytes": 1
+        }
+      ],
+      "overrides": [],
+      "props": [],
+      "subclasses": [
+        "T_outerNS::Human",
+        "T_outerNS::Couch",
+        "T_outerNS::OuterCat",
+        "T_outerNS::AbstractArt"
+      ]
+    },
+    "_ZN7outerNS5Thing10takeDamageEi": {
+      "structured": 1,
+      "pretty": "outerNS::Thing::takeDamage",
+      "sym": "_ZN7outerNS5Thing10takeDamageEi",
+      "kind": "method",
+      "parentsym": "T_outerNS::Thing",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "virtual",
+        "user"
+      ],
+      "overriddenBy": [
+        "_ZN7outerNS9Superhero10takeDamageEi"
+      ]
+    },
+    "_ZN7outerNS5Thing6ignoreEv": {
+      "structured": 1,
+      "pretty": "outerNS::Thing::ignore",
+      "sym": "_ZN7outerNS5Thing6ignoreEv",
+      "kind": "method",
+      "parentsym": "T_outerNS::Thing",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat13isFriendlyCatEv": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::isFriendlyCat",
+      "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+      "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+      "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat4meetERNS_5CouchE": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::meet",
+      "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat4meetERNS_5HumanE": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::meet",
+      "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat5shredERNS_5ThingE": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::shred",
+      "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    },
+    "_ZN7outerNS8OuterCat7destroyERNS_5ThingE": {
+      "structured": 1,
+      "pretty": "outerNS::OuterCat::destroy",
+      "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+      "kind": "method",
+      "parentsym": "T_outerNS::OuterCat",
+      "implKind": "",
+      "sizeBytes": null,
+      "supers": [],
+      "methods": [],
+      "fields": [],
+      "overrides": [],
+      "props": [
+        "instance",
+        "user"
+      ]
+    }
+  },
+  "graphs": [
+    {
+      "nodes": [
+        "_ZN7outerNS5Thing10takeDamageEi",
+        "_ZN7outerNS5Thing6ignoreEv",
+        "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+        "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+        "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+        "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+        "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+        "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+        "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+      ],
+      "edges": [
+        {
+          "from": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+          "to": "_ZN7outerNS8OuterCat13isFriendlyCatEv"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+          "to": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+          "to": "_ZN7outerNS8OuterCat13isFriendlyCatEv"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+          "to": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+          "to": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+          "to": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+          "to": "_ZN7outerNS5Thing6ignoreEv"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+          "to": "_ZN7outerNS5Thing10takeDamageEi"
+        },
+        {
+          "from": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+          "to": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+        }
+      ]
+    }
+  ]
+}

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -417,6 +417,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279fb028e20b3c4c320317955b77c5e0c9701f05a1d309905d6fc702cdc5053e"
+
+[[package]]
 name = "flate2"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -942,7 +948,7 @@ dependencies = [
  "ena",
  "itertools 0.10.3",
  "lalrpop-util",
- "petgraph",
+ "petgraph 0.5.1",
  "pico-args",
  "regex 1.5.4",
  "regex-syntax 0.6.25",
@@ -1355,7 +1361,17 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
 dependencies = [
- "fixedbitset",
+ "fixedbitset 0.2.0",
+ "indexmap",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
+dependencies = [
+ "fixedbitset 0.4.1",
  "indexmap",
 ]
 
@@ -2251,6 +2267,7 @@ dependencies = [
  "malloc_size_of_derive",
  "memmap",
  "num_cpus",
+ "petgraph 0.6.0",
  "regex 1.5.4",
  "reqwest",
  "rls-analysis",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -31,6 +31,7 @@ malloc_size_of = { path = "./malloc_size_of" }
 malloc_size_of_derive = "0.1"
 memmap = "0.5.0"
 num_cpus = "1"
+petgraph = "0.6.0"
 regex = "1"
 reqwest = "0.11.3"
 rls-analysis = "0.18.1"

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -41,6 +41,9 @@ pub enum ErrorLayer {
     /// The error seems to be related to the indexed data in question rather
     /// than the server, like the data was not indexed.
     DataLayer,
+    /// Our data structure doesn't work like it's supposed to and we don't want
+    /// to panic, so we return this instead.
+    RuntimeInvariantViolation,
     /// We're not sure if it was a server issue or a data issue.
     UnknownLayer,
 }

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -11,6 +11,7 @@ use crate::{
 use super::{cmd_filter_analysis::FilterAnalysisCommand, cmd_merge_analyses::MergeAnalysesCommand, cmd_crossref_lookup::CrossrefLookupCommand, cmd_search_identifiers::SearchIdentifiersCommand};
 use super::cmd_query::QueryCommand;
 use super::cmd_show_html::ShowHtmlCommand;
+use super::cmd_traverse::TraverseCommand;
 
 use super::interface::ServerPipeline;
 
@@ -89,6 +90,10 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
 
             Command::ShowHtml(sh) => {
                 commands.push(Box::new(ShowHtmlCommand { args: sh }));
+            }
+
+            Command::Traverse(t) => {
+                commands.push(Box::new(TraverseCommand { args: t }));
             }
         }
     }

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -1,0 +1,132 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::interface::{
+    PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolList,
+};
+
+use crate::abstract_server::{AbstractServer, Result};
+
+/// Render a received graph into a dot, svg, or json-wrapped-svg which also
+/// includes embedded crossref information.
+#[derive(Debug, StructOpt)]
+pub struct Graph {
+    /// Explicit symbols to lookup.
+    symbols: Vec<String>,
+    // TODO: It might make sense to provide a way to filter the looked up data
+    // by kind, although that could of course be its own command too.
+}
+
+/// ## Graph Implementation Thoughts / Rationale ##
+///
+/// ### Latency, Pre-Computation, and Interaction ###
+///
+/// #### Pre-Graph Status Quo ####
+///
+/// Current searchfox UX is that while search may take a few seconds (the first
+/// time the query is experienced; we do cache), when they arrive, you'll have
+/// all the results you're going to get unless you continue typing.  There's no
+/// async trickle-in.
+///
+/// While there can be upsides to async data retrieval, this primarily makes
+/// sense for cases where the data being asynchronously populated is reliably
+/// known to be at the end of the current results list.  Asynchronous retrieval
+/// that leads to visual and interaction instability can be frustrating,
+/// especially when it's not clear if the results have stabilized.
+///
+/// One thing we haven't done yet in the normal searchfox UI (but did experiment
+/// with in the fancy branch) is to allow iterative (faceted) filtering of the
+/// displayed results.  There has only been the ability to collapse sections of
+/// results.  But we could do more with this.
+///
+/// #### Application to Graphing ####
+///
+/// When building the graph, we will potentially gather information about edges
+/// to nodes that don't make the initial cut for presentation.  But rather than
+/// discarding them, we'll keep them around in the dataset that we serve up so
+/// that the collapsed clusters can be interactively expanded or additional data
+/// (ex: on fields accessed) can be provided in a detail display when clicking
+/// on nodes, etc.
+///
+/// Using IndexedDB as an example of what this means, from the fancy branch we
+/// already know that edges can potentially fall into the following groups:
+/// - In-module function calls.  This covers both "boring" getters/setters and
+///   assertions that don't express interseting control flow, as well as more
+///   significant helper modules that potentially in turn call other non-boring
+///   methods.
+/// - Cross-module function calls to non-core-infrastructure modules.  In IDB
+///   this would mean Quota Manager and mozStorage are both moduleles that
+///   involve core application-domain logic.
+/// - Cross-module function calls to "boring" core-infrastructure modules.  For
+///   example, the fancy branch elides all calls to smart pointers and XPCOM
+///   string classes because these usually are not interesting on their own and
+///   the field is instead more interesting.  Note that the fancy branch ended
+///   up filtering to only in-module edges eventually, which meant that this
+///   additional filtering was somewhat mooted and potentially was not
+///   sufficient as it would not have prevented data structure spam, etc.
+///
+/// As noted above, the fancy branch prototype found that limiting calls to the
+/// same module as determined by source path provided a reasonable filtering,
+/// but it's quite possible that the interesting bits are in fact happening in
+/// other modules.  So, at least as long as a work limit isn't it, we could
+/// traverse into the other modules but make a choice at presentation time to
+/// collapse those edges by having clustered by module and simpifying the edges
+/// so that they go to a single node representation of the cluster that can be
+/// clicked on to be expanded.
+///
+/// The expansion can be handled by using existing JS code (built on graphviz
+/// compiled to WASM) that can animate a transition between the different
+/// rendered graph states.
+///
+/// Note that this is currently an end state of the proposal at
+/// https://bugzilla.mozilla.org/show_bug.cgi?id=1749232 and we won't be
+/// implementing this initially, but this will inform how the graph is modeled.
+/// That said, it's quite possible most of this logic will be implemented as a
+/// graph transformation pass that clusters nodes.  The initial transitive
+/// traversal might instead be focused on a work limit heuristic based on rough
+/// order-of-magnitude weight adjustments.
+///
+pub struct GraphCommand {
+    pub args: Graph,
+}
+
+#[async_trait]
+impl PipelineCommand for GraphCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        // XXX this is still just crossref-lookup cut-and-pasted
+        let symbol_list = match input {
+            PipelineValues::SymbolList(sl) => sl,
+            // Right now we're assuming that we're the first command in the
+            // pipeline so that we would have no inputs if someone wants to use
+            // arguments...
+            PipelineValues::Void => SymbolList {
+                symbols: self.args.symbols.clone(),
+                from_identifiers: None,
+            },
+            // TODO: Figure out a better way to handle a nonsensical pipeline
+            // configuration / usage.
+            _ => {
+                return Ok(PipelineValues::Void);
+            }
+        };
+
+        let mut symbol_crossref_infos = vec![];
+        for symbol in symbol_list.symbols {
+            let info = server.crossref_lookup(&symbol).await?;
+            symbol_crossref_infos.push(SymbolCrossrefInfo {
+                symbol,
+                crossref_info: info,
+            });
+        }
+
+        Ok(PipelineValues::SymbolCrossrefInfoList(
+            SymbolCrossrefInfoList {
+                symbol_crossref_infos,
+            },
+        ))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -1,0 +1,131 @@
+use std::collections::HashSet;
+
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::{
+    interface::{PipelineCommand, PipelineValues},
+    symbol_graph::{
+        DerivedSymbolInfo, NamedSymbolGraph, SymbolGraphCollection, SymbolGraphNodeSet,
+    },
+};
+
+use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+/// Processes piped-in crossref symbol data, recursively traversing the given
+/// edges, building up a graph that also holds onto the crossref data for all
+/// traversed symbols.
+#[derive(Debug, StructOpt)]
+pub struct Traverse {
+    /// The edge to traverse, currently "uses" or "callees".
+    ///
+    /// ### SPECULATIVELY WRITTEN BUT LET'S SEE HOW WE HANDLE THE ABOVE FIRST ###
+    ///
+    /// The edge to traverse, this is either a 'kind' ("uses", "defs", "assignments",
+    /// "decls", "forwards", "idl", "ipc") or one of the synthetic edges ("calls-from",
+    /// "calls-to").
+    ///
+    /// The "calls-from" and "calls-to" synthetic edges have special behaviors:
+    /// - Ignores edges to nodes that are not 'callable' as indicated by their
+    ///   structured analysis "kind" being "function" or "method".
+    /// - Ignores edges to nodes that don't seem to be inside the same
+    ///
+    /// The fancy prototype previously did but we don't do yet:
+    /// - Ignores edges to nodes that are 'boring' as determined by hardcoded
+    #[structopt(long, short, default_value = "callees")]
+    edge: String,
+}
+
+pub struct TraverseCommand {
+    pub args: Traverse,
+}
+
+#[async_trait]
+impl PipelineCommand for TraverseCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let cil = match input {
+            PipelineValues::SymbolCrossrefInfoList(cil) => cil,
+            // TODO: Figure out a better way to handle a nonsensical pipeline
+            // configuration / usage.
+            _ => {
+                return Ok(PipelineValues::Void);
+            }
+        };
+
+        let mut sym_node_set = SymbolGraphNodeSet::new();
+        let mut graph = NamedSymbolGraph::new("only".to_string());
+
+        // A to-do list of nodes we have not yet traversed.
+        let mut to_traverse = Vec::new();
+        // Nodes that have been scheduled to be traversed or ruled out.  A node
+        // in this set should not be added to `to_traverse`.
+        let mut considered = HashSet::new();
+
+        // Propagate the starting symbols into the graph and queue them up for
+        // traversal.
+        for info in cil.symbol_crossref_infos {
+            to_traverse.push(info.symbol.clone());
+            considered.insert(info.symbol.clone());
+            sym_node_set.add_symbol(DerivedSymbolInfo::new(
+                &info.symbol,
+                info.crossref_info.clone(),
+            ));
+        }
+
+        // General operation:
+        // - We pull a node to be traversed off the queue.  This ends up depth
+        //   first.
+        // - We check if we already have the crossref info for the symbol and
+        //   look it up if not.  There's an asymmetry here between the initial
+        //   set of symbols we're traversing from which we already have cached
+        //   values for and the new edges we discover, but it's not a concern.
+        // - We traverse the list of edges.
+        while let Some(sym) = to_traverse.pop() {
+            let (sym_id, sym_info) =
+                sym_node_set.ensure_symbol(&sym, server).await?;
+
+            let edges = sym_info.crossref_info[&self.args.edge].clone();
+
+            if let Some(sym_edges) = edges.as_array() {
+                let bad_data = || {
+                    let edge = self.args.edge.clone();
+                    ServerError::StickyProblem(ErrorDetails {
+                        layer: ErrorLayer::DataLayer,
+                        message: format!("Bad edge info in sym {sym} on edge {edge}"),
+                    })
+                };
+                match self.args.edge.as_str() {
+                    "callees" => {
+                        for target in sym_edges {
+                            let target_sym = target["sym"].as_str().ok_or_else(bad_data)?;
+                            //let target_kind = target["kind"].as_str().ok_or_else(bad_data)?;
+
+                            let (target_id, target_info) =
+                                sym_node_set.ensure_symbol(&target_sym, server).await?;
+
+                            if target_info.is_callable() {
+                                graph.add_edge(sym_id.clone(), target_id);
+                                if considered.insert(target_info.symbol.clone()) {
+                                    to_traverse.push(target_info.symbol.clone());
+                                }
+                            }
+                        }
+                    }
+                    "uses" => {}
+                    _ => {}
+                }
+            }
+        }
+
+        let graph_coll = SymbolGraphCollection {
+            node_set: sym_node_set,
+            graphs: vec![graph],
+        };
+
+        Ok(PipelineValues::SymbolGraphCollection(graph_coll))
+    }
+}

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -1,10 +1,12 @@
 use async_trait::async_trait;
 use clap::arg_enum;
 use serde_json::Value;
-use std::collections::HashSet;
+use std::collections::{HashSet};
 use structopt::StructOpt;
 
 pub use crate::abstract_server::{AbstractServer, Result};
+
+use super::symbol_graph::SymbolGraphCollection;
 
 arg_enum! {
   #[derive(Debug, PartialEq)]
@@ -31,6 +33,7 @@ pub enum PipelineValues {
     IdentifierList(IdentifierList),
     SymbolList(SymbolList),
     SymbolCrossrefInfoList(SymbolCrossrefInfoList),
+    SymbolGraphCollection(SymbolGraphCollection),
     JsonValue(JsonValue),
     JsonRecords(JsonRecords),
     HtmlExcerpts(HtmlExcerpts),
@@ -62,6 +65,8 @@ pub struct SymbolCrossrefInfo {
 pub struct SymbolCrossrefInfoList {
     pub symbol_crossref_infos: Vec<SymbolCrossrefInfo>,
 }
+
+
 
 /// JSON records are raw analysis records from a single file (for now)
 pub struct JsonRecordsByFile {

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -4,6 +4,7 @@ extern crate structopt;
 pub mod builder;
 pub mod interface;
 pub mod parser;
+pub mod symbol_graph;
 
 mod cmd_crossref_lookup;
 mod cmd_filter_analysis;
@@ -12,6 +13,7 @@ mod cmd_prod_filter;
 mod cmd_query;
 mod cmd_search_identifiers;
 mod cmd_show_html;
+mod cmd_traverse;
 
 pub use builder::{build_pipeline};
 pub use interface::{PipelineCommand, PipelineValues};

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -8,6 +8,7 @@ use super::cmd_prod_filter::ProductionFilter;
 use super::cmd_query::Query;
 use super::cmd_search_identifiers::SearchIdentifiers;
 use super::cmd_show_html::ShowHtml;
+use super::cmd_traverse::Traverse;
 
 arg_enum! {
     #[derive(Debug, PartialEq)]
@@ -50,4 +51,5 @@ pub enum Command {
     Query(Query),
     SearchIdentifiers(SearchIdentifiers),
     ShowHtml(ShowHtml),
+    Traverse(Traverse),
 }

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -1,0 +1,289 @@
+use std::collections::{HashMap, BTreeMap, BTreeSet};
+
+use petgraph::{
+    graph::{DefaultIx, NodeIndex},
+    Directed, Graph,
+};
+use serde_json::{Value, json};
+
+use crate::abstract_server::{Result, AbstractServer, ServerError, ErrorDetails, ErrorLayer};
+
+/**
+Graph abstraction for symbols built on top of petgraph.
+
+### Motivation / Implementation Rationale
+
+Conceptually, we want our graphs to operate in terms of searchfox symbols
+where the symbol names are the identifiers and we associate a bunch of
+information with the symbol.  In the JS fancy branch we were able to easily
+implement a (naive, unoptimized) graph with strings as keys.  However,
+petgraph is not architected to be used directly in this way.  Graph supports
+using arbitrary values but operates in terms of the `NodeIndex<Ix>` values
+returned by `add_node`.  GraphMap does exist and allows adding edges
+directly by using the nodes directly (or rather, their "weights"), but
+requires the weights to implement `Copy`, which is not the case for String.
+Additionally, https://timothy.hobbs.cz/rust-play/petgraph-internals.html
+indicates GraphMap has worse performance characteristics.
+
+To this end, we implement wrappers around Petgraph that let us operate in
+a more ergonomic fashion.  We structure our wrappers to support the creation
+of multiple graphs backed by a shared pool of symbol information,
+recognizing that:
+- petgraph's `Graph` doesn't really like having nodes/edges removed (which
+  is why `StableGraph` exists), favoring a graph that is incrementally built
+  in an append-only fashion and then used immediately thereafter.
+- For debugging and to make it easier for people to understand how searchfox
+  works here, it's desirable to be able to visualize the various graph
+  states that are produced in the process of the algorithms.  Which means
+  that an approach where we take graphs as immutable inputs and produce new
+  immutable graphs as output works for us.
+- This probably works out better with rust's ownership model?
+
+For a more sophisticated and elegant approach to things like this, it's
+worth considering the approach used by cargo-guppy at
+https://github.com/facebookincubator/cargo-guppy/tree/main/guppy/src/graph
+which is built using custom index classes and other sophisticated things
+that I (:asuth) likely won't understand until after this implementation
+is working.
+
+### Structs and their relationships
+
+- SymbolGraphNodeSet holds the collection of symbols, which consists of a
+  vector of the per-symbol crossref information wrapped into a
+  DerivedSymbolInfo which provides us a location to put optionally caching
+  getters for facts about the symbol that can be internally derived from
+  just the symbol's crossref information.
+- SymbolGraphNodeId is a u32 identifier for the symbol which is what we use
+  as the node weight in the graphs.  The identifier is just the index of the
+  DerivedSymbolInfo in its containing vec.
+- NamedSymbolGraph wraps the underlying Graph and provides manipulation
+  methods that operate using SymbolGraphNodeId values as nodes that can be
+  used to describe edges.  This should gain metadata fields
+- SymbolGraphCollection bundles a SymbolGraphNodeSet with all of the
+  NamedSymbolGraph instances that depend on the node set and are appropriate
+  to surface through the pipeline as results or interesting intermediary
+  states for debugging.
+*/
+
+/// A symbol and its cross-reference information plus caching helpers.
+pub struct DerivedSymbolInfo {
+    pub symbol: String,
+    pub crossref_info: Value,
+}
+
+pub fn semantic_kind_is_callable(semantic_kind: &str) -> bool {
+  match semantic_kind {
+    "function" => true,
+    "method" => true,
+    _ => false,
+  }
+}
+
+impl DerivedSymbolInfo {
+  pub fn is_callable(&self) -> bool {
+    let is_callable = match self.crossref_info.pointer("/meta/kind") {
+        Some(Value::String(sem_kind)) => semantic_kind_is_callable(sem_kind),
+        _ => false,
+    };
+    return is_callable;
+  }
+}
+
+impl DerivedSymbolInfo {
+    pub fn new(symbol: &str, crossref_info: Value) -> Self {
+        DerivedSymbolInfo {
+            symbol: symbol.to_string(),
+            crossref_info,
+        }
+    }
+}
+
+/// A collection of one or more graphs that share a common underlying set of
+/// per-symbol information across the graphs.
+pub struct SymbolGraphCollection {
+    pub node_set: SymbolGraphNodeSet,
+    pub graphs: Vec<NamedSymbolGraph>,
+}
+
+impl SymbolGraphCollection {
+    /// Return a sorted Object mapping from symbol identifiers to their meta, if
+    /// available.  We sort the symbols for stability for testing purposes and
+    /// for human readability reasons.
+    pub fn symbols_meta_to_json(&self) -> Value {
+        let mut metas = BTreeMap::new();
+        for sym_info in self.node_set.symbol_crossref_infos.iter() {
+            if let Some(meta) = sym_info.crossref_info.get("meta") {
+                metas.insert(sym_info.symbol.clone(), meta.clone());
+            }
+        }
+
+        json!(metas)
+    }
+
+    /// Convert the graph with the given index to a { nodes, edges } rep where:
+    ///
+    /// - nodes is a sorted array of symbol strings.
+    /// - edges is a sorted array of { from, to } where from/to are symbol
+    ///   strings and the sort is over [from, to]
+    pub fn graph_to_json(&self, graph_idx: usize) -> Value {
+        let graph = match self.graphs.get(graph_idx) {
+            Some(g) => g,
+            None => return json!({}),
+        };
+
+        // I am biasing for code readability over performance.  In particular,
+        // note that we need not infer the nodes from the edges, but it's less
+        // code this way.
+        let mut nodes = BTreeSet::new();
+        let mut edges = BTreeMap::new();
+        for (source_id, target_id) in graph.list_edges() {
+            let source_info = self.node_set.get(&source_id);
+            nodes.insert(source_info.symbol.clone());
+            let source_sym = source_info.symbol.clone();
+
+            let target_info = self.node_set.get(&target_id);
+            nodes.insert(target_info.symbol.clone());
+            let target_sym = target_info.symbol.clone();
+
+            edges.insert(
+                format!("{}-{}", source_sym, target_sym),
+                json!({ "from": source_sym, "to": target_sym }));
+        }
+
+        json!({
+            "nodes": nodes.into_iter().collect::<Vec<String>>(),
+            "edges": edges.into_values().collect::<Value>(),
+        })
+    }
+
+    pub fn to_json(&self) -> Value {
+        let mut graphs = vec![];
+        for i in 0..self.graphs.len() {
+            graphs.push(self.graph_to_json(i));
+        }
+
+        json!({
+            "symbol_metas": self.symbols_meta_to_json(),
+            "graphs": graphs,
+        })
+    }
+}
+
+/// A graph whose nodes are symbols from a `SymbolGraphNodeSet`.
+pub struct NamedSymbolGraph {
+    pub name: String,
+    graph: Graph<u32, (), Directed>,
+    /// Maps SymbolGraphNodeId values to NodeIndex values when the node is
+    /// present in the graph.  Exclusively used by ensure_node and it's likely
+    /// this could be improved to more directly use NodeIndex.
+    node_id_to_ix: HashMap<u32, DefaultIx>,
+    /// Inverted/reverse map of the above.
+    node_ix_to_id: HashMap<DefaultIx, u32>,
+}
+
+impl NamedSymbolGraph {
+    pub fn new(name: String) -> Self {
+        NamedSymbolGraph {
+            name,
+            graph: Graph::new(),
+            node_id_to_ix: HashMap::new(),
+            node_ix_to_id: HashMap::new(),
+        }
+    }
+
+    pub fn containts_node(&self, sym_id: SymbolGraphNodeId) -> bool {
+      self.node_id_to_ix.contains_key(&sym_id.0)
+    }
+
+    fn ensure_node(&mut self, sym_id: SymbolGraphNodeId) -> NodeIndex {
+        if let Some(idx) = self.node_id_to_ix.get(&sym_id.0) {
+            return NodeIndex::new(*idx as usize);
+        }
+
+        let idx = self.graph.add_node(sym_id.0).index() as u32;
+        self.node_id_to_ix.insert(sym_id.0, idx);
+        self.node_ix_to_id.insert(idx, sym_id.0);
+
+        NodeIndex::new(idx as usize)
+    }
+
+    pub fn add_edge(&mut self, source: SymbolGraphNodeId, target: SymbolGraphNodeId) {
+        let source_ix = self.ensure_node(source);
+        let target_ix = self.ensure_node(target);
+        self.graph.add_edge(source_ix, target_ix, ());
+    }
+
+    pub fn list_edges(&self) -> Vec<(SymbolGraphNodeId, SymbolGraphNodeId)> {
+        let mut id_edges = vec![];
+        for edge in self.graph.raw_edges() {
+            let source_id = self.node_ix_to_id.get(&(edge.source().index() as u32)).unwrap();
+            let target_id = self.node_ix_to_id.get(&(edge.target().index() as u32)).unwrap();
+            id_edges.push((SymbolGraphNodeId(*source_id), SymbolGraphNodeId(*target_id)));
+        }
+        id_edges
+    }
+}
+
+/// Wrapped u32 identifier for DerivedSymbolInfo nodes in a SymbolGraphNodeSet
+/// for type safety.  The values correspond to the index of the node in the
+/// `symbol_crossref_infos` vec in `SymbolGraphNodeSet`.
+#[derive(Clone)]
+pub struct SymbolGraphNodeId(u32);
+
+pub struct SymbolGraphNodeSet {
+    pub symbol_crossref_infos: Vec<DerivedSymbolInfo>,
+    pub symbol_to_index_map: BTreeMap<String, u32>,
+}
+
+fn make_data_invariant_err() -> ServerError {
+    ServerError::StickyProblem(ErrorDetails {
+        layer: ErrorLayer::RuntimeInvariantViolation,
+        message: "SymbolGraphNodeSet desynchronized".to_string(),
+    })
+}
+
+impl SymbolGraphNodeSet {
+    pub fn new() -> Self {
+        SymbolGraphNodeSet {
+            symbol_crossref_infos: vec![],
+            symbol_to_index_map: BTreeMap::new(),
+        }
+    }
+
+    pub fn get(&self, node_id: &SymbolGraphNodeId) -> &DerivedSymbolInfo {
+        // It's very much an invariant that only we mint SymbolGraphNodeId's, so
+        // the entry should always exist.
+        self.symbol_crossref_infos.get(node_id.0 as usize).unwrap()
+    }
+
+    /// Look-up a symbol returning its id (for graph purposes) and its
+    /// DerivedSymbolInfo (for data inspection).
+    pub fn lookup_symbol(&self, symbol: &str) -> Option<(SymbolGraphNodeId, &DerivedSymbolInfo)> {
+        if let Some(index) = self.symbol_to_index_map.get(symbol) {
+            let sym_info = self.symbol_crossref_infos.get(*index as usize);
+            sym_info.map(|info| (SymbolGraphNodeId(*index), info))
+        } else {
+            None
+        }
+    }
+
+    /// Add a symbol and return the unwrapped data that lookup_symbol would have provided.
+    pub fn add_symbol(&mut self, sym_info: DerivedSymbolInfo) -> (SymbolGraphNodeId, &DerivedSymbolInfo) {
+        let index = self.symbol_crossref_infos.len();
+        let symbol = sym_info.symbol.clone();
+        self.symbol_crossref_infos.push(sym_info);
+        self.symbol_to_index_map
+            .insert(symbol, index as u32);
+        (SymbolGraphNodeId(index as u32), self.symbol_crossref_infos.get(index).unwrap())
+    }
+
+    pub async fn ensure_symbol(&mut self, sym: &str, server: &Box<dyn AbstractServer + Send + Sync>) -> Result<(SymbolGraphNodeId, &DerivedSymbolInfo)> {
+        if let Some(index) = self.symbol_to_index_map.get(sym) {
+            let sym_info = self.symbol_crossref_infos.get(*index as usize).ok_or_else(make_data_invariant_err)?;
+            return Ok((SymbolGraphNodeId(*index), sym_info));
+        }
+
+        let info = server.crossref_lookup(&sym).await?;
+        Ok(self.add_symbol(DerivedSymbolInfo::new(&sym, info)))
+    }
+}

--- a/tools/src/file_format/crossref_lookup.rs
+++ b/tools/src/file_format/crossref_lookup.rs
@@ -188,7 +188,7 @@ impl CrossrefLookupMap {
 
         let brace_offset = unsafe { usize::from_str_radix(str::from_utf8_unchecked(&payload[1..space_pos]), 16).map_err(|_| make_crossref_data_error(sym))? };
         let length_with_newline = unsafe { usize::from_str_radix(str::from_utf8_unchecked(&payload[space_pos+1..]), 16).map_err(|_| make_crossref_data_error(sym))? };
-        
+
         let extra_bytes: &[u8] = unsafe { self.extra_mm.as_slice() };
         return Ok(from_slice(&extra_bytes[brace_offset..brace_offset + length_with_newline - 1])?);
     }

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -100,6 +100,9 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                                 .collect::<Value>());
                             insta::assert_json_snapshot!(crossref_json);
                         }
+                        Ok(PipelineValues::SymbolGraphCollection(sgc)) => {
+                            insta::assert_json_snapshot!(sgc.to_json());
+                        }
                         Ok(PipelineValues::HtmlExcerpts(he)) => {
                             let mut aggr_str = String::new();
                             for file_excerpts in he.by_file {


### PR DESCRIPTION
Note that all new functionality in this patch is not exposed to the
web and because RemoteServer::crossref_lookup is a no-op, the
functionality can only be used against a local index.

This implements:
- A basic graph abstraction in `symbol_graph.rs`.  petgraph is fairly
  low level and is not geared towards storing heavy-weight metadata
  with nodes or edges so we add some decidedly non-clever wrappers
  but which should largely be type-safe.
  - This includes serialization of the graph to JSON in a rep that
    tries to sort everything so that the test output and human
    inspection will be largely sane.  I did not optimize for
    performance/memory here; I used BTreeMap and BTreeSet and called
    it a day.
- A core "traverse" command which only implements "callees" right now.
- A single check that provides coverage of taking 2 input symbols'
  crossref data (OuterCat::meet is overloaded) and produces a graph
  that only has edges involving callable nodes.  I inspected the
  result and have verified it's correct.

Dependency-wise this:
- Adds petgraph without "serde-1" enabled because we don't actually
  need it because we're using a sufficiently custom rep that the
  petgraph native output is not useful and we now already know how
  to render our rep to reasonably sane JSON.