### PR TITLE
Bug 1763005 - generate markdown explanations of test pipelines

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -227,7 +233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9213f7cd7c27e95c2b57c49f0e69b1ea65b27138da84a170133fd21b07659c00"
 dependencies = [
  "num",
- "time",
+ "time 0.1.43",
 ]
 
 [[package]]
@@ -387,6 +393,12 @@ dependencies = [
  "redox_users",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dot-generator"
@@ -794,7 +806,7 @@ dependencies = [
  "log 0.3.9",
  "mime 0.2.6",
  "num_cpus",
- "time",
+ "time 0.1.43",
  "traitobject",
  "typeable",
  "unicase",
@@ -858,6 +870,25 @@ dependencies = [
  "matches",
  "unicode-bidi",
  "unicode-normalization",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "482a2e29200b7eed25d7fdbd14423326760b7f6658d21a4cf12d55a50713c69f"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e074c19deab2501407c91ba1860fa3d6820bfde307db6d8cb851b55a10be89b"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -1046,6 +1077,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3066350882a1cd6d950d055997f379ac37fd39f81cd4d8ed186032eb3c5747"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "lalrpop"
 version = "0.19.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1157,6 +1198,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "liquid"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00f55b9db2305857de3b3ceaa0e75cb51a76aaec793875fe152e139cb8fed05c"
+dependencies = [
+ "doc-comment",
+ "liquid-core",
+ "liquid-derive",
+ "liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "liquid-core"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93764837aeac37f14b74708cd88a44d82edfa9ad2b1bcd9a3b4d8802fdd9f98"
+dependencies = [
+ "anymap2",
+ "itertools 0.10.3",
+ "kstring",
+ "liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex 1.5.4",
+ "serde",
+ "time 0.3.9",
+]
+
+[[package]]
+name = "liquid-derive"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926454345f103e8433833077acdbfaa7c3e4b90788d585a8358f02f0b8f5a469"
+dependencies = [
+ "proc-macro2",
+ "proc-quote",
+ "syn",
+]
+
+[[package]]
+name = "liquid-lib"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd06ca30ae026d26ee7fa8596f9590959e2d3726bc5a0f16a21ac4f050ec83c0"
+dependencies = [
+ "itertools 0.10.3",
+ "liquid-core",
+ "once_cell",
+ "percent-encoding 2.1.0",
+ "regex 1.5.4",
+ "time 0.3.9",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1322,15 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
 
 [[package]]
 name = "matches"
@@ -1392,6 +1499,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aba1801fb138d8e85e11d0fc70baf4fe1cdfffda7c6cd34a854905df588e5ed0"
+dependencies = [
  "libc",
 ]
 
@@ -1670,6 +1786,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-quote"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e84ab161de78c915302ca325a19bee6df272800e2ae1a43fe3ef430bab2a100"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "proc-quote-impl",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "proc-quote-impl"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fb3ec628b063cdbcf316e06a8b8c1a541d28fa6c0a8eacd2bfb2b7f49e88aa0"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,7 +1943,7 @@ dependencies = [
  "aho-corasick 0.6.10",
  "memchr 2.4.1",
  "regex-syntax 0.5.6",
- "thread_local",
+ "thread_local 0.3.6",
  "utf8-ranges",
 ]
 
@@ -1815,6 +1955,15 @@ checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick 0.7.18",
  "memchr 2.4.1",
+ "regex-syntax 0.6.25",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
  "regex-syntax 0.6.25",
 ]
 
@@ -2110,6 +2259,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shell-words"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2154,6 +2312,12 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -2310,6 +2474,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2318,6 +2491,24 @@ dependencies = [
  "libc",
  "winapi 0.3.9",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "itoa 1.0.1",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tiny-keccak"
@@ -2434,6 +2625,7 @@ dependencies = [
  "globset",
  "graphviz-rust",
  "hyper 0.10.16",
+ "include_dir",
  "insta",
  "ipdl_parser",
  "itertools 0.7.11",
@@ -2442,6 +2634,8 @@ dependencies = [
  "json-structural-diff",
  "lazy_static",
  "linkify",
+ "liquid",
+ "liquid-core",
  "log 0.4.14",
  "lol_html",
  "malloc_size_of",
@@ -2461,6 +2655,8 @@ dependencies = [
  "structopt",
  "tokio",
  "tokio-stream",
+ "tracing",
+ "tracing-subscriber",
  "url 2.2.2",
  "ustr",
  "walkdir",
@@ -2474,22 +2670,78 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.29"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375a639232caf30edfc78e8d89b2d4c375515393e7af7e16f01cd96917fb2105"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
 ]
 
 [[package]]
-name = "tracing-core"
-version = "0.1.21"
+name = "tracing-attributes"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4ed65637b8390770814083d20756f87bfa2c21bf2f110babdc5438351746e4"
+checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+dependencies = [
+ "lazy_static",
+ "log 0.4.14",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
+dependencies = [
+ "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex 1.5.4",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local 1.1.4",
+ "time 0.3.9",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -2610,6 +2862,12 @@ name = "utf8-ranges"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ae116fef2b7fea257ed6440d3cfcff7f190865f170cdad00bb6465bf18ecba"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "vcpkg"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -19,6 +19,7 @@ graphviz-rust = "0.2.0"
 git2 = "0.13.20"
 globset = "0.4.8"
 hyper = "0.10"
+include_dir = "0.7.2"
 insta = { version = "1.14.0" }
 ipdl_parser = { path = "./ipdl_parser" }
 # asuth picked this version because our Cargo.lock already had 0.7.11 for our
@@ -29,6 +30,8 @@ jemallocator = "0.3.2"
 json-structural-diff = "0.1.0"
 lazy_static = "1.1"
 linkify = "0.2.0"
+liquid = "0.26.0"
+liquid-core = "0.26.0"
 log = "0.4.0"
 lol_html = { git = "https://github.com/cloudflare/lol-html", rev = "8860fa455db627a5c227d014e1cecbe1832eb0ed" }
 malloc_size_of = { path = "./malloc_size_of" }
@@ -50,6 +53,8 @@ serde_repr = "0.1"
 structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 tokio-stream = "0.1.8"
+tracing = "0.1.32"
+tracing-subscriber = { version = "0.3.10", features = ["std", "env-filter", "fmt", "local-time", "registry", "json"] }
 url = "2.2.2"
 # We need https://github.com/anderslanglands/ustr/pull/21
 # which is the fix for https://github.com/anderslanglands/ustr/issues/20

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -1,6 +1,5 @@
 use std::{
     env::args_os,
-    io::{self, Write},
 };
 
 use serde_json::{to_string_pretty, Value};
@@ -53,7 +52,7 @@ async fn main() {
         }
     };
 
-    let results = pipeline.run().await;
+    let results = pipeline.run(false).await;
 
     let emit_json = |val: &Value| {
         if output_format == OutputFormat::Concise {
@@ -110,8 +109,8 @@ async fn main() {
             }
             0
         }
-        Ok(PipelineValues::FileBlob(fb)) => {
-            let _ = io::stdout().write_all(&fb.contents);
+        Ok(PipelineValues::TextFile(fb)) => {
+            println!("{}", fb.contents);
             0
         }
         Ok(PipelineValues::JsonRecords(jr)) => {

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -17,6 +17,8 @@ pub struct CrossrefLookup {
     // by kind, although that could of course be its own command too.
 }
 
+
+#[derive(Debug)]
 pub struct CrossrefLookupCommand {
     pub args: CrossrefLookup,
 }

--- a/tools/src/cmd_pipeline/cmd_filter_analysis.rs
+++ b/tools/src/cmd_pipeline/cmd_filter_analysis.rs
@@ -26,6 +26,7 @@ pub struct FilterAnalysis {
     query_opts: SymbolicQueryOpts,
 }
 
+#[derive(Debug)]
 pub struct FilterAnalysisCommand {
     pub args: FilterAnalysis,
 }

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -6,7 +6,7 @@ use graphviz_rust::cmd::{CommandArg, Format};
 use graphviz_rust::exec;
 use graphviz_rust::printer::{DotPrinter, PrinterContext};
 
-use super::interface::{FileBlob, PipelineCommand, PipelineValues};
+use super::interface::{TextFile, PipelineCommand, PipelineValues};
 
 use crate::abstract_server::{AbstractServer, Result};
 
@@ -99,6 +99,7 @@ pub struct Graph {
 /// traversal might instead be focused on a work limit heuristic based on rough
 /// order-of-magnitude weight adjustments.
 ///
+#[derive(Debug)]
 pub struct GraphCommand {
     pub args: Graph,
 }
@@ -122,9 +123,9 @@ impl PipelineCommand for GraphCommand {
         let dot_graph = graphs.graph_to_graphviz(graphs.graphs.len() - 1);
         if self.args.format == GraphFormat::RawDot {
             let raw_dot_str = dot_graph.print(&mut PrinterContext::default());
-            return Ok(PipelineValues::FileBlob(FileBlob {
+            return Ok(PipelineValues::TextFile(TextFile {
                 mime_type: "text/x-dot".to_string(),
-                contents: raw_dot_str.as_bytes().to_vec(),
+                contents: raw_dot_str,
             }));
         }
         let (format, mime_type) = match self.args.format {
@@ -136,8 +137,8 @@ impl PipelineCommand for GraphCommand {
             dot_graph,
             &mut PrinterContext::default(),
             vec![CommandArg::Format(format)],
-        )?.as_bytes().to_vec();
-        Ok(PipelineValues::FileBlob(FileBlob {
+        )?;
+        Ok(PipelineValues::TextFile(TextFile {
             mime_type,
             contents: graph_contents,
         }))

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -24,6 +24,7 @@ pub struct MergeAnalyses {
 
 /// Command brought into existence to test the analysis-merging logic of
 /// `merge-analyses.rs`.
+#[derive(Debug)]
 pub struct MergeAnalysesCommand {
     pub args: MergeAnalyses,
 }

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -21,6 +21,7 @@ use crate::{
 #[derive(Debug, StructOpt)]
 pub struct ProductionFilter {}
 
+#[derive(Debug)]
 pub struct ProductionFilterCommand {
     pub args: ProductionFilter,
 }

--- a/tools/src/cmd_pipeline/cmd_search.rs
+++ b/tools/src/cmd_pipeline/cmd_search.rs
@@ -35,6 +35,7 @@ pub struct Search {
 }
 
 
+#[derive(Debug)]
 pub struct SearchCommand {
   pub args: Search,
 }

--- a/tools/src/cmd_pipeline/cmd_search_identifiers.rs
+++ b/tools/src/cmd_pipeline/cmd_search_identifiers.rs
@@ -24,6 +24,7 @@ pub struct SearchIdentifiers {
     limit: usize,
 }
 
+#[derive(Debug)]
 pub struct SearchIdentifiersCommand {
     pub args: SearchIdentifiers,
 }

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -23,6 +23,7 @@ use crate::{
 #[derive(Debug, StructOpt)]
 pub struct ShowHtml {}
 
+#[derive(Debug)]
 pub struct ShowHtmlCommand {
     pub args: ShowHtml,
 }

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -36,6 +36,7 @@ pub struct Traverse {
     edge: String,
 }
 
+#[derive(Debug)]
 pub struct TraverseCommand {
     pub args: Traverse,
 }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,10 +1,10 @@
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
 extern crate log;
 extern crate clap;
 extern crate chrono;
 extern crate git2;
+extern crate include_dir;
 #[macro_use]
 extern crate itertools;
 extern crate linkify;
@@ -13,10 +13,14 @@ extern crate regex;
 extern crate malloc_size_of_derive;
 extern crate jemalloc_sys;
 extern crate jemallocator;
+extern crate liquid;
 extern crate malloc_size_of;
 extern crate serde;
 extern crate serde_json;
 extern crate structopt;
+#[macro_use]
+extern crate tracing;
+extern crate tracing_subscriber;
 
 pub mod abstract_server;
 pub mod file_format;
@@ -31,6 +35,7 @@ pub mod glob_helper;
 pub mod languages;
 pub mod links;
 pub mod output;
+pub mod templating;
 pub mod tokenize;
 
 #[global_allocator]

--- a/tools/src/templating/builder.rs
+++ b/tools/src/templating/builder.rs
@@ -1,0 +1,47 @@
+use std::borrow;
+
+use include_dir::{include_dir, Dir};
+use liquid::Template;
+
+use super::JsonFilterParser;
+
+static TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/templates");
+
+#[derive(Default, Debug, Clone, Copy)]
+struct StaticTemplateSource;
+
+impl liquid::partials::PartialSource for StaticTemplateSource {
+    fn contains(&self, _name: &str) -> bool {
+        true
+    }
+
+    fn names(&self) -> Vec<&str> {
+        vec![]
+    }
+
+    fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
+        match TEMPLATE_DIR.get_file(name) {
+            Some(file) => file.contents_utf8().map(|s| borrow::Cow::from(s)),
+            _ => None,
+        }
+    }
+}
+
+pub fn build_and_parse(s: &str) -> Template {
+    liquid::ParserBuilder::with_stdlib()
+        .filter(JsonFilterParser)
+        .partials(liquid::partials::LazyCompiler::<StaticTemplateSource>::empty())
+        .build()
+        .unwrap()
+        .parse(s)
+        .unwrap()
+}
+
+pub fn build_and_parse_pipeline_explainer() -> Template {
+    let template_str = TEMPLATE_DIR
+        .get_file("pipeline_explainer.liquid")
+        .unwrap()
+        .contents_utf8()
+        .unwrap();
+    build_and_parse(template_str)
+}

--- a/tools/src/templating/liquid_exts.rs
+++ b/tools/src/templating/liquid_exts.rs
@@ -1,0 +1,24 @@
+use liquid_core::Result;
+use liquid_core::Runtime;
+use liquid_core::{Display_filter, Filter, FilterReflection, ParseFilter};
+use liquid_core::{Value, ValueView};
+use serde_json::to_string_pretty;
+
+#[derive(Clone, ParseFilter, FilterReflection)]
+#[filter(
+    name = "json",
+    description = "Render the provided object into pretty-printed JSON.",
+    parsed(JsonFilter)
+)]
+pub struct JsonFilterParser;
+
+#[derive(Debug, Default, Display_filter)]
+#[name = "downcase"]
+struct JsonFilter;
+
+impl Filter for JsonFilter {
+    fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
+        let s = to_string_pretty(&input.to_value()).unwrap_or_else(|_e| "".to_string());
+        Ok(Value::scalar(s))
+    }
+}

--- a/tools/src/templating/mod.rs
+++ b/tools/src/templating/mod.rs
@@ -1,0 +1,5 @@
+pub mod builder;
+pub mod liquid_exts;
+
+pub use liquid_exts::JsonFilterParser;
+

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -1,11 +1,89 @@
-use std::str;
+use std::{
+    io, str,
+    sync::{Arc, Mutex, MutexGuard, TryLockError},
+};
 
-use serde_json::{json, Value};
-use tokio::fs::{read_to_string, create_dir_all};
+use serde_json::{from_str, json, Value};
+use tokio::fs::{create_dir_all, read_to_string, write};
 use tools::{
     abstract_server::ServerError,
-    cmd_pipeline::{build_pipeline, PipelineValues}, glob_helper::block_in_place_glob_tree,
+    cmd_pipeline::{build_pipeline, PipelineValues},
+    glob_helper::block_in_place_glob_tree,
+    templating::builder::build_and_parse_pipeline_explainer,
 };
+use tracing::dispatcher::Dispatch;
+use tracing_subscriber::fmt::MakeWriter;
+
+/// MockWriter and MockMakeWriter is currently taken verbatim from the MIT licensed
+/// tracing project that is an existing dependency.  It exists only as a cfg(test)
+/// module in
+/// https://github.com/tokio-rs/tracing/blob/master/tracing-subscriber/src/fmt/mod.rs
+/// hence the need to replicate the code here.
+pub struct MockWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl MockWriter {
+    pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self { buf }
+    }
+
+    pub(crate) fn map_error<Guard>(err: TryLockError<Guard>) -> io::Error {
+        match err {
+            TryLockError::WouldBlock => io::Error::from(io::ErrorKind::WouldBlock),
+            TryLockError::Poisoned(_) => io::Error::from(io::ErrorKind::Other),
+        }
+    }
+
+    pub(crate) fn buf(&self) -> io::Result<MutexGuard<'_, Vec<u8>>> {
+        self.buf.try_lock().map_err(Self::map_error)
+    }
+}
+
+impl io::Write for MockWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buf()?.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.buf()?.flush()
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct MockMakeWriter {
+    buf: Arc<Mutex<Vec<u8>>>,
+}
+
+impl MockMakeWriter {
+    // currently unused
+    /*
+    pub(crate) fn new(buf: Arc<Mutex<Vec<u8>>>) -> Self {
+        Self { buf }
+    }
+
+    pub(crate) fn buf(&self) -> MutexGuard<'_, Vec<u8>> {
+        self.buf.lock().unwrap()
+    }
+    */
+
+    pub(crate) fn get_string(&self) -> String {
+        let mut buf = self.buf.lock().expect("lock shouldn't be poisoned");
+        let string = std::str::from_utf8(&buf[..])
+            .expect("formatter should not have produced invalid utf-8")
+            .to_owned();
+        buf.clear();
+        string
+    }
+}
+
+impl<'a> MakeWriter<'a> for MockMakeWriter {
+    type Writer = MockWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        MockWriter::new(self.buf.clone())
+    }
+}
 
 /// Glob-style insta test where we process all of the searchfox-tool command
 /// lines under TREE/checks/inputs and output the results of those pipelines to
@@ -29,6 +107,8 @@ use tools::{
 #[tokio::test(flavor = "multi_thread")]
 async fn test_check_glob() -> Result<(), std::io::Error> {
     if let Ok(check_root) = std::env::var("CHECK_ROOT") {
+        let explain_template = build_and_parse_pipeline_explainer();
+
         let input_path = format!("{}/inputs", check_root);
         let snapshot_root_path = format!("{}/snapshots", check_root);
 
@@ -44,7 +124,19 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
             let snapshot_path = format!("{}/{}", snapshot_root_path, rel_path);
             create_dir_all(snapshot_path.clone()).await?;
             settings.set_snapshot_path(snapshot_path);
-            settings.set_snapshot_suffix(filename);
+            settings.set_snapshot_suffix(filename.clone());
+
+            let make_writer = MockMakeWriter::default();
+            let subscriber = tracing_subscriber::fmt()
+                .json()
+                .with_env_filter("tools=trace")
+                .with_current_span(false)
+                .with_writer(make_writer.clone())
+                .finish();
+
+            let dispatcher = Dispatch::new(subscriber);
+            let _trace_guard = tracing::dispatcher::set_default(&dispatcher);
+            let mut server_kind = "unknown".to_string();
 
             settings
                 .bind_async(async {
@@ -57,7 +149,8 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                             return;
                         }
                     };
-                    let results = pipeline.run().await;
+                    server_kind = pipeline.server_kind.clone();
+                    let results = pipeline.run(true).await;
 
                     // TODO: In theory we should perhaps block_in_place here, but also it doesn't
                     // matter.
@@ -103,8 +196,8 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                             }
                             insta::assert_snapshot!(&aggr_str);
                         }
-                        Ok(PipelineValues::FileBlob(fb)) => {
-                            insta::assert_snapshot!(str::from_utf8(&fb.contents).unwrap_or("ERROR"));
+                        Ok(PipelineValues::TextFile(fb)) => {
+                            insta::assert_snapshot!(&fb.contents);
                         }
                         Ok(PipelineValues::JsonRecords(jr)) => {
                             let mut json_results = vec![];
@@ -129,6 +222,23 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                     }
                 })
                 .await;
+
+            let log_values: Vec<Value> = make_writer
+                .get_string()
+                .lines()
+                .map(|s| from_str(s).unwrap())
+                .collect();
+
+            let explain_dir = format!("{}/explanations/{}", check_root, rel_path);
+            create_dir_all(explain_dir.clone()).await?;
+            let explain_path = format!("{}{}-{}.md", explain_dir, filename, server_kind);
+
+            let globals = liquid::object!({
+                "logs": log_values,
+            });
+
+            let output = explain_template.render(&globals).unwrap();
+            write(explain_path, output).await?;
         }
     }
 


### PR DESCRIPTION
This provides the backbone of the pipeline explanation mechanism, but
the templates in use right now just output the subscriber::fmt JSON
output for each logged event right now.  A few additional steps are
required to make this useful.

This patch can and will generate explanations parallel to the inputs
and checks sub-trees, but I haven't checked them in yet because they
are bad and include timestamps which means they would be a churn
nightmare.

Those next expected steps are:
- Add more tracing events, in particular for the server API calls.
- Have the events have some kind of semantic tag that helps the
  template figure out how to present things.
- Make the template use that semantic tag!
- Make sure the explanation markdown files are stable across
  multiple runs (no timestamps!).

In terms of what's been done in the patch:
- We add tracing as a dependency and do some bare bones event generation.
  - I added a bunch of Debug derives for the pipeline structures so that
    tracing's field mechanism could dump them to the logs in a readable
    fashion.  Another alternative we might still want to pursue is
    instead deriving Serialize so they can be encoded as JSON instead,
    but I'm not sure that helps comprehension in any meaningful way and
    it's a non-goal to allow populating those structures via Deserialize
    at this time.
  - I added a bunch of Serialize derives for the core pipline values so
    that they can easily be dumped as JSON.
    - In the case of SymbolGraphCollection, I hacked a trivial struct
      serializer that just reuses our existing to_json helpers.  This is
      not maximally efficient, but it doesn't need to be.  I did think
      about re-writing the to_json logic to just be custom serialization
      implementations, but that seemed like it would be much less
      readable and also potentially less performant for the actual hot
      paths and we would never serialize to anything but JSON anyways.
- We copy the tracing project's test MockWriter/MakeMockWriter as a means
  of letting us retrieve the contents of the JSON log output from an
  in-memory buffer without touching disk.  This is useful for the tests
  and will also be useful for the pipeline-server, ideally.
- For our tests, we use the dispatcher mechanism to try and set our
  subscriber to be active for the current test using a guard, which
  ideally should provide a means of us being able to have the subscriber
  follow task dispatches from our test tasks to other threads without
  having us scooping up logging from other uninvolved threads.
  - This approach comes from the advice at
    https://github.com/tokio-rs/tracing/issues/1517
  - It's not clear that I fully understand the ramifications of the
    threading model aspects of this, but it is clear that the guard
    approach is preferable to the FnOnce approach of subscriber::with_default
    https://docs.rs/tracing/0.1.32/tracing/subscriber/fn.with_default.html
    if only to avoid massive indentation problems and hassles related to
    our use of async functions!
  - In general I do expect parallelism from the pipline jobs to result in
    explicit new task schedulings, which seems like we can probably make
    the dispatcher approach work if necessary with glue logic.  I'm not
    expecting us to have any other kinds of pre-existing threads we'd be
    trying to communicate with, or if we did, it seems like a reasonable
    API / logging boundary.
  - A general motivation was that I understand cargo may try and run tests
    in parallel by default and I didn't want to build things in such a way
    that would aggressively preclude this.  I also was planning / hoping
    for this to work for the pipeline-server being able to easily log only
    for its own request.
  - Our general control and data-flow can all also just nest under a
    single root span or with some other distinct request identifier, so
    that's also a way we could pull the data back out in production.  I
    definitely have a lot of learning to do about `tracing` and am very
    excited to do so as it seems like an amazing, well-thought-out lib!
- We add liquid templating with a base template.
- We add a custom filter so we can render the liquid values as JSON;
  this is something that is notionally part of the language standard lib
  but is not yet in the rust implementation and it was not immediately
  obvious to me how to fashion an upstream-able fix, so I started with
  just getting it working at all.
- We add include_dir as a dep so that liquid's mechanism that use a VFS
  sorta setup like `render` and `layout` can do that and we don't have
  to do any legwork beyond just adding new files to `tools/templates`.
  - This isn't fully tested/used yet.
- We generate separate explanations for "local" and "remote" which
  makes sense because we expect the server ops to differ when we start
  logging those, but was also mainly just a hack because right now the
  "remote" checks run last and will frequently bail out because of
  no-ops (which cause the test to be skipped partway through) and so
  their explanations are fundamentally boring!