### PR TITLE
Bug 1728376 - Late-follow up heuristic limit change

### DIFF
--- a/router/router.py
+++ b/router/router.py
@@ -64,7 +64,8 @@ def merge_defs_from_symbols_as(tree_name, mix_target, symbol_names, as_key):
     it can know to generate a search link for each specific type.
     '''
     # Do not do anything if there's too many results!
-    if len(symbol_names) >= 50:
+    # This was previously 50 but nsIAsyncInputStream has 60 subclasses.
+    if len(symbol_names) >= 100:
         return
 
     aggr_defs = []


### PR DESCRIPTION
Nika ran into an odd gap in `nsIAsyncInputStream::Available` results which turned out to be due to this limit.

I believe my general concerns previously were:
- router.py should not OOM / take forever if someone searches for nsISupports
- Adding more than 50 symbols potentially grows the result set too much.

Unfortunately, when we decide not to merge, we don't currently emit a marker that says "hey, there were some other potential results here, but we didn't show them" which means that this limit is a real hard cliff in terms of user experience.  I'd been hoping to do more follow-ups shortly after this, but ended up running out of professional time to work on this, and my personal efforts have more been on foundational rust-based work.  So I'm doubling the limit for now and will plan to improve these use-cases with the rust-based query work I'm doing.