### PR TITLE
Bug 1764957 - idempotently check out mozsearch for email purposes

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -32,8 +32,12 @@ sudo apt-get install -y git
 git config --global pull.ff only
 
 # we have git, so let's check out mozsearch now so we can have our email sending
-# script in case of an error.
-git clone -b master https://github.com/mozsearch/mozsearch mozsearch
+# script in case of an error.  (We're doing a dir check because for the VM for
+# the web-server our code here will already have run, and we might as well have
+# the same logic although it's not our goal to allow re-provisioning.)
+if [ ! -d mozsearch ]; then
+  git clone -b master https://github.com/mozsearch/mozsearch mozsearch
+fi
 
 # the base image we're building against is inherently not up-to-date (new base
 # images are released only monthly), so let's be consistently up-to-date.

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -10,8 +10,11 @@ sudo apt-get install -y git
 git config --global pull.ff only
 
 # we have git, so let's check out mozsearch now so we can have our email sending
-# script in case of an error.
-git clone -b master https://github.com/mozsearch/mozsearch mozsearch
+# script in case of an error.  (For the VM the dir may already exist thanks to
+# us having already provisioned the indexer.)
+if [ ! -d mozsearch ]; then
+  git clone -b master https://github.com/mozsearch/mozsearch mozsearch
+fi
 
 # the base image we're building against is inherently not up-to-date (new base
 # images are released only monthly), so let's be consistently up-to-date.


### PR DESCRIPTION
In 747998194e3526085c7def0e986479b9c8dd36a2 I added a clone at the top
of both provisioner scripts but didn't deal with the reality that we
run both scripts for VM provisioning and that `git clone` will error if
you try and clone into an existing dir, even if the result would be the
same.  So we do a dir-check first.  (Also note that I think the update
steps at the bottom of each script would have created mozsearch too, so
it's really the lack of a check that's the problem.)

xref https://github.com/mozsearch/mozsearch/pull/501 which landed that
commit.