### PR TITLE
The indexer now needs livegrep gRPC built too.

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -127,6 +127,18 @@ if [ ! -d livegrep ]; then
   rm -rf .cache/bazel
 fi
 
+# Install gRPC python libs and generate the python modules to communicate with the codesearch server
+sudo pip3 install grpcio grpcio-tools
+mkdir livegrep-grpc3
+python3 -m grpc_tools.protoc --python_out=livegrep-grpc3 --grpc_python_out=livegrep-grpc3 -I livegrep/ livegrep/src/proto/config.proto
+python3 -m grpc_tools.protoc --python_out=livegrep-grpc3 --grpc_python_out=livegrep-grpc3 -I livegrep/ livegrep/src/proto/livegrep.proto
+touch livegrep-grpc3/src/__init__.py
+touch livegrep-grpc3/src/proto/__init__.py
+# Add the generated modules to the python path
+SITEDIR=$(python3 -m site --user-site)
+mkdir -p "$SITEDIR"
+echo "$PWD/livegrep-grpc3" > "$SITEDIR/livegrep.pth"
+
 # graphviz for diagramming
 sudo apt-get install -y graphviz
 


### PR DESCRIPTION
Now that our indexer checks run with the livegrep server running as
started by codesearch.py, we need to replicate the steps to build the
python livegrep gRPC bindings.  This was missed in local testing
because the VM runs both provisioner scripts.

This is a fixup to https://github.com/mozsearch/mozsearch/pull/505