### PR TITLE
Explicitly install protoc to decrease prost-build failures.

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -94,8 +94,8 @@ sudo apt-get install -y zlib1g-dev
 # Install pkg-config (needed for Rust's OpenSSL wrappers)
 sudo apt-get install -y pkg-config
 
-# rust gRPC via tonic/tonic-build and prost-build needs cmake
-sudo apt-get install -y cmake
+# rust gRPC via tonic/tonic-build and prost-build needs protoc (and cmake?)
+sudo apt-get install -y cmake protobuf-compiler
 
 # Install python2 and six (needed for cinnabar and idl-analyze.py)
 sudo apt-get install -y python2.7 python-six

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -57,8 +57,8 @@ sudo apt-get install -y nginx
 # Install pkg-config (needed for Rust's OpenSSL wrappers)
 sudo apt-get install -y pkg-config
 
-# rust gRPC via tonic/tonic-build and prost-build needs cmake
-sudo apt-get install -y cmake
+# rust gRPC via tonic/tonic-build and prost-build needs protoc (and cmake?)
+sudo apt-get install -y cmake protobuf-compiler
 
 # Install Rust. We need rust nightly to build rls-data.
 if [ ! -d $HOME/.cargo ]; then


### PR DESCRIPTION
We've been experiencing intermittent "update" cargo build failures
which seem due to prost-build wanting to build `protoc` because we
don't already have it installed and something non-deterministic is
happening there.

It is recommended to already have `protoc` available and it seems
like that this does bypass the build process for protobuf, which will
ideally sidestep the build failures and will definitely improve build
time.  I'm not 100% clear on whether this means we can drop the cmake
dep, but we'll keep it for now.