### PR TITLE
Bug 1769936 - Add Copy as Markdown shortcuts.

### DIFF
--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -51,6 +51,11 @@
   vertical-align: middle;
 }
 
+.panel .copy.indicator {
+  display: inline-block;
+  pointer: unset;
+}
+
 .panel .copy:hover {
   background-color: var(--button-hover-background);
 }

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -53,7 +53,7 @@
 
 .panel .copy.indicator {
   display: inline-block;
-  pointer: unset;
+  cursor: unset;
 }
 
 .panel .copy:hover {

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -173,7 +173,7 @@ a:hover {
 }
 
 /* Some links look like list items */
-.panel section a,
+.panel section .item,
 .context-menu a,
 .folder-content a {
   text-decoration: none;
@@ -181,7 +181,7 @@ a:hover {
 }
 
 /* .folder-content is handled with the whole row getting hover styles, so it doesn't need this. */
-.panel section a:is(:hover, :focus),
+.panel section .item:is(:hover, :focus),
 .context-menu a:is(:hover, :focus) {
   background-color: var(--list-hover-background);
   color: var(--list-hover-color);
@@ -619,9 +619,14 @@ tr.after-context-line + tr.before-context-line {
 .panel a.field {
   background-position: 2px 10px;
 }
-.panel section a {
+.panel section .item {
   display: inline-block;
   width: 100%;
+  cursor: pointer;
+}
+.panel section .item.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }
 
 /* Info Boxes */

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -630,7 +630,7 @@ tr.after-context-line + tr.before-context-line {
   border: unset;
   text-align: unset;
 }
-.panel section button.item[disabled] {
+.panel section .item:disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -624,7 +624,13 @@ tr.after-context-line + tr.before-context-line {
   width: 100%;
   cursor: pointer;
 }
-.panel section .item.disabled {
+.panel section button.item {
+  font: unset;
+  appearance: unset;
+  border: unset;
+  text-align: unset;
+}
+.panel section button.item[disabled] {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -18,6 +18,7 @@ var DocumentTitler = new (class DocumentTitler {
 
     this.stickyTitle = null;
     this.selectionTitle = null;
+    Panel.onSelectionTitleChanged(this.selectionTitle);
   }
 
   updateTitle() {
@@ -229,6 +230,7 @@ var DocumentTitler = new (class DocumentTitler {
       this.selectionTitle =
         this._findBestPrettySymbolInSourceLineElem(sourceLine);
     }
+    Panel.onSelectionTitleChanged(this.selectionTitle);
 
     this.updateTitle();
   }
@@ -406,6 +408,7 @@ var Highlight = new (class Highlight {
     }
     this.lastSelectedLine = null;
     this.selectedLines = new Set();
+    Panel.onSelectedLineChanged(this.selectedLines);
     this.updateFromHash();
     window.addEventListener("hashchange", () => {
       this.updateFromHash();
@@ -417,11 +420,13 @@ var Highlight = new (class Highlight {
     // NOTE: The order here is intentional so that we throw above if the line
     // is not in the document.
     this.selectedLines.add(line);
+    Panel.onSelectedLineChanged(this.selectedLines);
     this.lastSelectedLine = line;
   }
 
   removeSelectedLine(line) {
     this.selectedLines.delete(line);
+    Panel.onSelectedLineChanged(this.selectedLines);
     if (this.lastSelectedLine == line) {
       this.lastSelectedLine = null;
     }

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -18,7 +18,7 @@ var DocumentTitler = new (class DocumentTitler {
 
     this.stickyTitle = null;
     this.selectionTitle = null;
-    Panel.onSelectedSymbolChanged(null);
+    this.selectedSymbol = null;
   }
 
   updateTitle() {
@@ -222,6 +222,7 @@ var DocumentTitler = new (class DocumentTitler {
    */
   processLineSelection(lastSelectedLine) {
     this.selectionTitle = null;
+    this.selectedSymbol = null;
     if (lastSelectedLine) {
       const selectedLine = document.getElementById(`line-${lastSelectedLine}`);
       const nestingContainer = selectedLine?.closest(".nesting-container");
@@ -229,12 +230,12 @@ var DocumentTitler = new (class DocumentTitler {
       const sourceLine = nestingLine?.querySelector(".source-line");
       const bestPretty = this._findBestPrettySymbolInSourceLineElem(sourceLine);
       this.selectionTitle = bestPretty.short;
-      Panel.onSelectedSymbolChanged(bestPretty.long);
-    } else {
-      Panel.onSelectedSymbolChanged(null);
+      this.selectedSymbol = bestPretty.long;
     }
 
     this.updateTitle();
+
+    Panel.onSelectedSymbolChanged();
   }
 })();
 
@@ -410,7 +411,6 @@ var Highlight = new (class Highlight {
     }
     this.lastSelectedLine = null;
     this.selectedLines = new Set();
-    Panel.onSelectedLineChanged(this.selectedLines);
     this.updateFromHash();
     window.addEventListener("hashchange", () => {
       this.updateFromHash();
@@ -422,17 +422,19 @@ var Highlight = new (class Highlight {
     // NOTE: The order here is intentional so that we throw above if the line
     // is not in the document.
     this.selectedLines.add(line);
-    Panel.onSelectedLineChanged(this.selectedLines);
     this.lastSelectedLine = line;
+
+    Panel.onSelectedLineChanged();
   }
 
   removeSelectedLine(line) {
     this.selectedLines.delete(line);
-    Panel.onSelectedLineChanged(this.selectedLines);
     if (this.lastSelectedLine == line) {
       this.lastSelectedLine = null;
     }
     document.getElementById("line-" + line).classList.remove("highlighted");
+
+    Panel.onSelectedLineChanged();
   }
 
   toggleSelectedLine(line) {
@@ -634,3 +636,5 @@ var Highlight = new (class Highlight {
     }
   }
 })();
+
+Panel.onSelectedLineChanged();

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -18,7 +18,7 @@ var DocumentTitler = new (class DocumentTitler {
 
     this.stickyTitle = null;
     this.selectionTitle = null;
-    Panel.onSelectionTitleChanged(this.selectionTitle);
+    Panel.onSelectedSymbolChanged(null);
   }
 
   updateTitle() {
@@ -120,9 +120,9 @@ var DocumentTitler = new (class DocumentTitler {
    *   a `(`.
    */
   _findBestPrettySymbolInSourceLineElem(elem) {
-    let bestPretty = null;
+    let bestPretty = null, bestShortPretty = null;
     if (!elem) {
-      return bestPretty;
+      return { long: bestPretty, short: bestShortPretty };
     }
 
     const symElems = elem.querySelectorAll("[data-i]");
@@ -192,10 +192,10 @@ var DocumentTitler = new (class DocumentTitler {
       }
 
       // Shorten any namespaces.
-      bestPretty = this._shortenNamespaces(bestPretty);
+      bestShortPretty = this._shortenNamespaces(bestPretty);
     }
 
-    return bestPretty;
+    return { long: bestPretty, short: bestShortPretty };
   }
 
   /**
@@ -209,7 +209,7 @@ var DocumentTitler = new (class DocumentTitler {
       const useSticky = stickyElems[stickyElems.length - 1];
       const stickySourceLine = useSticky.querySelector(".source-line");
       this.stickyTitle =
-        this._findBestPrettySymbolInSourceLineElem(stickySourceLine);
+        this._findBestPrettySymbolInSourceLineElem(stickySourceLine).short;
     }
 
     this.updateTitle();
@@ -227,10 +227,12 @@ var DocumentTitler = new (class DocumentTitler {
       const nestingContainer = selectedLine?.closest(".nesting-container");
       const nestingLine = nestingContainer?.querySelector(".nesting-sticky-line");
       const sourceLine = nestingLine?.querySelector(".source-line");
-      this.selectionTitle =
-        this._findBestPrettySymbolInSourceLineElem(sourceLine);
+      const bestPretty = this._findBestPrettySymbolInSourceLineElem(sourceLine);
+      this.selectionTitle = bestPretty.short;
+      Panel.onSelectedSymbolChanged(bestPretty.long);
+    } else {
+      Panel.onSelectedSymbolChanged(null);
     }
-    Panel.onSelectionTitleChanged(this.selectionTitle);
 
     this.updateTitle();
   }

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -10,34 +10,34 @@ var Panel = new (class Panel {
     this.logNode = this.findItem("Log");
     this.rawNode = this.findItem("Raw");
 
-    this.selectedLines = [];
-    this.selectedSymbol = "";
     this.markdown = {
       "filename": {
         node: this.findItem("Filename Link"),
         isEnabled: () => {
-          return this.selectedLines.length > 0;
+          return Highlight?.selectedLines.size > 0;
         },
-        getText: (url, filename) => {
+        getText: url => {
+          const filename = new URL(url).pathname.match(/\/([^\/]+)$/)[1];
           return `[${filename}](${url})`;
         },
       },
       "symbol": {
         node: this.findItem("Symbol Link"),
         isEnabled: () => {
-          return this.selectedSymbol;
+          return DocumentTitler?.selectedSymbol;
         },
-        getText: (url, filename) => {
-          return `[${this.selectedSymbol}](${url})`;
+        getText: url => {
+          return `[${DocumentTitler.selectedSymbol}](${url})`;
         },
       },
       "block": {
         node: this.findItem("Code Block"),
         isEnabled: () => {
-          return this.selectedLines.length > 0;
+          return Highlight?.selectedLines.size > 0;
         },
-        getText: (url, filename) => {
-          const lang = this.getLanguageFor(filename);
+        getText: url => {
+          const file = document.getElementById("file");
+          const lang = file.getAttribute("data-markdown-slug") || "";
           return [url, "```" + lang, ...this.formatSelectedLines(), "```"].join("\n");
         },
       },
@@ -52,16 +52,9 @@ var Panel = new (class Panel {
       this.maybeHandleAccelerator(event)
     );
 
-    for (let copy of this.panel.querySelectorAll(".copy")) {
+    for (let copy of this.panel.querySelectorAll("button.copy")) {
       copy.addEventListener("click", e => {
         e.preventDefault();
-
-        for (const [name, { node }] of Object.entries(this.markdown)) {
-          if (copy.parentNode == node) {
-            this.copyMarkdown(name);
-            return;
-          }
-        }
 
         if (copy.hasAttribute("data-copying")) {
           return;
@@ -86,17 +79,18 @@ var Panel = new (class Panel {
     }
 
     for (const [name, { node }] of Object.entries(this.markdown)) {
-      if (node) {
-        node.addEventListener("click", event => {
-          if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
-            return;
-          }
-
-          this.copyMarkdown(name);
-          
-          event.preventDefault();
-        });
+      if (!node) {
+        continue;
       }
+      node.addEventListener("click", event => {
+        if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey) {
+          return;
+        }
+
+        this.copyMarkdown(name);
+        
+        event.preventDefault();
+      });
     }
 
     // If the user toggles it in a different tab, update the checkbox/state here
@@ -156,15 +150,12 @@ var Panel = new (class Panel {
         case "f":
         case "F":
           return this.markdown.filename.node;
-          break;
         case "s":
         case "S":
           return this.markdown.symbol.node;
-          break;
         case "c":
         case "C":
           return this.markdown.block.node;
-          break;
       }
     })();
 
@@ -200,79 +191,21 @@ var Panel = new (class Panel {
 
   copyMarkdown(type) {
     const { node, getText } = this.markdown[type];
-    if (node.classList.contains("disabled")) {
+    if (node.disabled) {
       return;
     }
 
     const copy = node.querySelector(".copy");
     const url = this.permalinkNode ? this.permalinkNode.href : document.location.href;
-    const filename = new URL(url).pathname.match(/\/([^\/]+)$/)[1];
-    const text = getText(url, filename);;
+    const text = getText(url);;
 
     this.copyText(copy, text);
-  }
-
-  getLanguageFor(filename) {
-    filename = filename.replace(/\.in$/, "");
-
-    const langs = {
-      // suffix => language
-      ".c": "c",
-      ".cc": "cpp",
-      ".configure": "python",
-      ".cpp": "cpp",
-      ".css": "css",
-      ".diff": "diff",
-      ".h": "cpp",
-      ".headers": "http",
-      ".hh": "cpp",
-      ".hpp": "cpp",
-      ".htm": "html",
-      ".html": "html",
-      ".java": "java",
-      ".js": "js",
-      ".jsm": "js",
-      ".json": "json",
-      ".jsx": "js",
-      ".m": "c",
-      ".mathml": "mathml",
-      ".md": "md",
-      ".mjs": "js",
-      ".mm": "cpp",
-      ".mozbuild": "py",
-      ".patch": "diff",
-      ".pl": "perl",
-      ".py": "python",
-      ".rs": "rust",
-      ".rst": "rest",
-      ".scss": "css",
-      ".sjs": "js",
-      ".svg": "xml",
-      ".toml": "toml",
-      ".ts": "js",
-      ".xht": "xhtml",
-      ".xhtml": "xhtml",
-      ".xml": "xml",
-      ".xul": "xul",
-      ".yaml": "yaml",
-      ".yml": "yaml",
-      "^headers^": "http",
-      "moz.build": "py",
-    };
-
-    for (const [suffix, lang] of Object.entries(langs)) {
-      if (filename.endsWith(suffix)) {
-        return lang;
-      }
-    }
-
-    return "";
   }
 
   formatSelectedLines() {
     const texts = [];
     let lastLine = -1;
-    for (const line of this.selectedLines) {
+    for (const line of [...Highlight.selectedLines].sort((a, b) => a - b)) {
       if (lastLine !== -1 && lastLine != line - 1) {
         texts.push("...");
       }
@@ -288,24 +221,20 @@ var Panel = new (class Panel {
   updateMarkdownState() {
     for (const [_, { node, isEnabled }] of Object.entries(this.markdown)) {
       if (isEnabled()) {
-        node.classList.remove("disabled");
+        node.disabled = false;
         node.removeAttribute("aria-disabled");
-        node.querySelector(".copy").disabled = false;
       } else {
-        node.classList.add("disabled");
+        node.disabled = true;
         node.setAttribute("aria-disabled", "true");
-        node.querySelector(".copy").disabled = true;
       }
     }
   }
 
-  onSelectedLineChanged(selectedLines) {
-    this.selectedLines = [...selectedLines].sort((a, b) => a - b);
+  onSelectedLineChanged() {
     this.updateMarkdownState();
   }
 
-  onSelectedSymbolChanged(selectedSymbol) {
-    this.selectedSymbol = selectedSymbol;
+  onSelectedSymbolChanged() {
     this.updateMarkdownState();
   }
 })();

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -11,7 +11,7 @@ var Panel = new (class Panel {
     this.rawNode = this.findItem("Raw");
 
     this.selectedLines = [];
-    this.selectionTitle = "";
+    this.selectedSymbol = "";
     this.markdown = {
       "filename": {
         node: this.findItem("Filename Link"),
@@ -25,11 +25,10 @@ var Panel = new (class Panel {
       "symbol": {
         node: this.findItem("Symbol Link"),
         isEnabled: () => {
-          return this.selectionTitle;
+          return this.selectedSymbol;
         },
         getText: (url, filename) => {
-          const symbol = this.selectionTitle;
-          return `[${symbol}](${url})`;
+          return `[${this.selectedSymbol}](${url})`;
         },
       },
       "block": {
@@ -305,8 +304,8 @@ var Panel = new (class Panel {
     this.updateMarkdownState();
   }
 
-  onSelectionTitleChanged(selectionTitle) {
-    this.selectionTitle = selectionTitle;
+  onSelectedSymbolChanged(selectedSymbol) {
+    this.selectedSymbol = selectedSymbol;
     this.updateMarkdownState();
   }
 })();

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -14,7 +14,7 @@ var Panel = new (class Panel {
       "filename": {
         node: this.findItem("Filename Link"),
         isEnabled: () => {
-          return Highlight?.selectedLines.size > 0;
+          return true;
         },
         getText: url => {
           const filename = new URL(url).pathname.match(/\/([^\/]+)$/)[1];
@@ -196,7 +196,7 @@ var Panel = new (class Panel {
     }
 
     const copy = node.querySelector(".copy");
-    const url = this.permalinkNode ? this.permalinkNode.href : document.location.href;
+    const url = this.permalinkNode?.href || document.location.href;
     const text = getText(url);;
 
     this.copyText(copy, text);
@@ -211,7 +211,7 @@ var Panel = new (class Panel {
       }
 
       const lineElem = document.getElementById(`line-${line}`).querySelector(".source-line");
-      texts.push(lineElem.textContent.replace(/\n/g, ""));
+      texts.push(lineElem.textContent.replace(/\n/, ""));
 
       lastLine = line;
     }

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -648,6 +648,33 @@ fn main() {
             }
         }
 
+        let mut markdown_panel_items = vec![];
+        markdown_panel_items.push(PanelItem {
+            title: "Filename Link".to_owned(),
+            link: String::new(),
+            update_link_lineno: "",
+            accel_key: Some('F'),
+            copyable: true,
+        });
+        markdown_panel_items.push(PanelItem {
+            title: "Symbol Link".to_owned(),
+            link: String::new(),
+            update_link_lineno: "",
+            accel_key: Some('S'),
+            copyable: true,
+        });
+        markdown_panel_items.push(PanelItem {
+            title: "Code Block".to_owned(),
+            link: String::new(),
+            update_link_lineno: "",
+            accel_key: Some('C'),
+            copyable: true,
+        });
+        panel.push(PanelSection {
+            name: "Copy as Markdown".to_owned(),
+            items: markdown_panel_items,
+        });
+
         let mut tools_items = vec![];
         if let Some(ref hg_root) = tree_config.paths.hg_root {
             tools_items.push(PanelItem {

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct LanguageSpec {
     pub reserved_words: HashMap<String, String>,
     pub hash_comment: bool,
@@ -572,12 +572,8 @@ lazy_static! {
     };
 
     static ref HTML_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_JS),
-        c_style_comments: true,
-        backtick_strings: true,
-        regexp_literals: true,
         markdown_slug: "html",
-        .. LanguageSpec::default()
+        .. JS_SPEC.clone()
     };
 
     static ref CPP_SPEC : LanguageSpec = LanguageSpec {

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -13,6 +13,7 @@ pub struct LanguageSpec {
     // Rust is mostly C-like, with a couple of differences.
     pub rust_tweaks: bool,
     pub cxx14_digit_separators: bool,
+    pub markdown_slug: &'static str,
 }
 
 fn make_reserved(v: &[&str]) -> HashMap<String, String> {
@@ -566,6 +567,16 @@ lazy_static! {
         c_style_comments: true,
         backtick_strings: true,
         regexp_literals: true,
+        markdown_slug: "js",
+        .. LanguageSpec::default()
+    };
+
+    static ref HTML_SPEC : LanguageSpec = LanguageSpec {
+        reserved_words: make_reserved(&*RESERVED_WORDS_JS),
+        c_style_comments: true,
+        backtick_strings: true,
+        regexp_literals: true,
+        markdown_slug: "html",
         .. LanguageSpec::default()
     };
 
@@ -574,6 +585,7 @@ lazy_static! {
         c_style_comments: true,
         c_preprocessor: true,
         cxx14_digit_separators: true,
+        markdown_slug: "cpp",
         .. LanguageSpec::default()
     };
 
@@ -605,6 +617,7 @@ lazy_static! {
         reserved_words: make_reserved(&*RESERVED_WORDS_PYTHON),
         hash_comment: true,
         triple_quote_literals: true,
+        markdown_slug: "py",
         .. LanguageSpec::default()
     };
 
@@ -613,12 +626,14 @@ lazy_static! {
         hash_comment: true, // for now, for attributes
         c_style_comments: true,
         rust_tweaks: true,
+        markdown_slug: "rust",
         .. LanguageSpec::default()
     };
 
     static ref JAVA_SPEC : LanguageSpec = LanguageSpec {
         reserved_words: make_reserved(&*RESERVED_WORDS_JAVA),
         c_style_comments: true,
+        markdown_slug: "java",
         .. LanguageSpec::default()
     };
 
@@ -656,7 +671,7 @@ pub fn select_formatting(filename: &str) -> FormatAs {
         "java" => FormatAs::FormatCLike(&*JAVA_SPEC),
         "kt" => FormatAs::FormatCLike(&*KOTLIN_SPEC),
 
-        "html" | "htm" | "xhtml" | "xht" | "xml" | "xul" => FormatAs::FormatTagLike(&*JS_SPEC),
+        "html" | "htm" | "xhtml" | "xht" | "xml" | "xul" => FormatAs::FormatTagLike(&*HTML_SPEC),
 
         // Keep this list in sync with the binary types list in nginx-setup.py
         "ogg" | "ttf" | "xpi" | "png" | "bcmap" | "gif" | "ogv" | "jpg" | "jpeg" | "bmp"

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -364,20 +364,28 @@ pub fn generate_panel(
                     } else {
                         String::new()
                     };
+                    let is_link = !item.link.is_empty();
                     let copy = if item.copyable {
-                        format!(
-                            r#"<button class="icon copy" title="Copy to clipboard">{}</button>"#,
-                            COPY_ICONS
-                        )
+                        if is_link {
+                            format!(
+                                r#"<button class="icon copy" title="Copy to clipboard">{}</button>"#,
+                                COPY_ICONS
+                            )
+                        } else {
+                            format!(
+                                r#"<span class="icon copy indicator">{}</span>"#,
+                                COPY_ICONS
+                            )
+                        }
                     } else {
                         String::new()
                     };
-                    let tag = if !item.link.is_empty() {
+                    let tag = if is_link {
                         "a"
                     } else {
-                        "span"
+                        "button"
                     };
-                    let href = if !item.link.is_empty() {
+                    let href = if is_link {
                         format!(r#" href="{}""#, item.link)
                     } else {
                         String::new()

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -372,11 +372,21 @@ pub fn generate_panel(
                     } else {
                         String::new()
                     };
+                    let tag = if !item.link.is_empty() {
+                        "a"
+                    } else {
+                        "span"
+                    };
+                    let href = if !item.link.is_empty() {
+                        format!(r#" href="{}""#, item.link)
+                    } else {
+                        String::new()
+                    };
                     F::Seq(vec![
                         F::S("<li>"),
                         F::T(format!(
-                            r#"<a href="{}" title="{}" class="icon"{}>{}{}{}</a>"#,
-                            item.link, item.title, update_attr, item.title, accel, copy
+                            r#"<{}{} title="{}" class="icon item"{}>{}{}{}</{}>"#,
+                            tag, href, item.title, update_attr, item.title, accel, copy, tag
                         )),
                         F::S("</li>"),
                     ])


### PR DESCRIPTION
This adds "Copy as Markdown" section and 3 items, per [bug 1769936](https://bugzilla.mozilla.org/show_bug.cgi?id=1769936) comments,
between "Revision control" section and "Other Tools" section.

<img width="213" alt="markdown" src="https://user-images.githubusercontent.com/6299746/169148968-e93fba38-08a9-4461-bb4d-764fb7950c6f.png">

Here's the example text for each:

"Filename Link"
```
[Promise.cpp](https://searchfox.org/mozilla-central/source/js/src/builtin/Promise.cpp#443,448,451-453)
```

"Symbol Link"
```
[PromiseDebugInfo::id](https://searchfox.org/mozilla-central/source/js/src/builtin/Promise.cpp#443,448,451-453)
```

"Code Block"
````
https://searchfox.org/mozilla-central/source/js/src/builtin/Promise.cpp#443,448,451-453
```cpp
  static uint64_t id(PromiseObject* promise) {
...
    } else if (idVal.isObject()) {
...
      if (idVal.isUndefined()) {
        idVal.setDouble(++gIDGenerator);
        debugInfo->setFixedSlot(Slot_Id, idVal);
```
````

"Filename Link" and "Code Block" are enabled when there's selected line(s).
"Symbol Link" is enabled when `DocumentTitler` detected title, but I haven't tested this locally given the information isn't available.

