### PR TITLE
Bug 1770501 - Show Copy as Markdown also on not-latest page.

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -191,7 +191,7 @@ var Panel = new (class Panel {
 
   copyMarkdown(type) {
     const { node, getText } = this.markdown[type];
-    if (node.disabled) {
+    if (!node || node.disabled) {
       return;
     }
 
@@ -220,6 +220,9 @@ var Panel = new (class Panel {
 
   updateMarkdownState() {
     for (const [_, { node, isEnabled }] of Object.entries(this.markdown)) {
+      if (!node) {
+        continue;
+      }
       if (isEnabled()) {
         node.disabled = false;
         node.removeAttribute("aria-disabled");

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -20,7 +20,7 @@ use tools::config;
 use tools::describe;
 use tools::file_format::analysis::{read_analysis, read_jumps, read_source};
 use tools::find_source_file;
-use tools::format::format_file_data;
+use tools::format::{format_file_data, create_markdown_panel_section};
 use tools::languages;
 
 use tools::output::{InfoBox, PanelItem, PanelSection, F};
@@ -648,32 +648,7 @@ fn main() {
             }
         }
 
-        let mut markdown_panel_items = vec![];
-        markdown_panel_items.push(PanelItem {
-            title: "Filename Link".to_owned(),
-            link: String::new(),
-            update_link_lineno: "",
-            accel_key: Some('F'),
-            copyable: true,
-        });
-        markdown_panel_items.push(PanelItem {
-            title: "Symbol Link".to_owned(),
-            link: String::new(),
-            update_link_lineno: "",
-            accel_key: Some('S'),
-            copyable: true,
-        });
-        markdown_panel_items.push(PanelItem {
-            title: "Code Block".to_owned(),
-            link: String::new(),
-            update_link_lineno: "",
-            accel_key: Some('C'),
-            copyable: true,
-        });
-        panel.push(PanelSection {
-            name: "Copy as Markdown".to_owned(),
-            items: markdown_panel_items,
-        });
+        panel.push(create_markdown_panel_section());
 
         let mut tools_items = vec![];
         if let Some(ref hg_root) = tree_config.paths.hg_root {

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -648,7 +648,7 @@ fn main() {
             }
         }
 
-        panel.push(create_markdown_panel_section());
+        panel.push(create_markdown_panel_section(true));
 
         let mut tools_items = vec![];
         if let Some(ref hg_root) = tree_config.paths.hg_root {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -743,10 +743,13 @@ pub fn format_path(
             copyable: false,
         });
     }
-    let panel = vec![PanelSection {
-        name: "Revision control".to_owned(),
-        items: vcs_panel_items,
-    }];
+    let panel = vec![
+        PanelSection {
+            name: "Revision control".to_owned(),
+            items: vcs_panel_items,
+        },
+        create_markdown_panel_section(),
+    ];
 
     format_file_data(
         cfg,
@@ -762,6 +765,35 @@ pub fn format_path(
         &None,
         writer,
     )
+}
+
+pub fn create_markdown_panel_section() -> PanelSection {
+    let mut markdown_panel_items = vec![];
+    markdown_panel_items.push(PanelItem {
+        title: "Filename Link".to_owned(),
+        link: String::new(),
+        update_link_lineno: "",
+        accel_key: Some('F'),
+        copyable: true,
+    });
+    markdown_panel_items.push(PanelItem {
+        title: "Symbol Link".to_owned(),
+        link: String::new(),
+        update_link_lineno: "",
+        accel_key: Some('S'),
+        copyable: true,
+    });
+    markdown_panel_items.push(PanelItem {
+        title: "Code Block".to_owned(),
+        link: String::new(),
+        update_link_lineno: "",
+        accel_key: Some('C'),
+        copyable: true,
+    });
+    PanelSection {
+        name: "Copy as Markdown".to_owned(),
+        items: markdown_panel_items,
+    }
 }
 
 fn split_lines(s: &str) -> Vec<&str> {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -748,7 +748,7 @@ pub fn format_path(
             name: "Revision control".to_owned(),
             items: vcs_panel_items,
         },
-        create_markdown_panel_section(),
+        create_markdown_panel_section(false),
     ];
 
     format_file_data(
@@ -767,7 +767,7 @@ pub fn format_path(
     )
 }
 
-pub fn create_markdown_panel_section() -> PanelSection {
+pub fn create_markdown_panel_section(add_symbol_link: bool) -> PanelSection {
     let mut markdown_panel_items = vec![];
     markdown_panel_items.push(PanelItem {
         title: "Filename Link".to_owned(),
@@ -776,13 +776,15 @@ pub fn create_markdown_panel_section() -> PanelSection {
         accel_key: Some('F'),
         copyable: true,
     });
-    markdown_panel_items.push(PanelItem {
-        title: "Symbol Link".to_owned(),
-        link: String::new(),
-        update_link_lineno: "",
-        accel_key: Some('S'),
-        copyable: true,
-    });
+    if (add_symbol_link) {
+        markdown_panel_items.push(PanelItem {
+            title: "Symbol Link".to_owned(),
+            link: String::new(),
+            update_link_lineno: "",
+            accel_key: Some('S'),
+            copyable: true,
+        });
+    }
     markdown_panel_items.push(PanelItem {
         title: "Code Block".to_owned(),
         link: String::new(),


### PR DESCRIPTION
Given the panel for non-latest page is generated in `format_path` in `tools/src/format.rs`, not in `main` in `tools/src/bin/output-file.rs`, the "Copy as Markdown" panel section needs to be added to both of them.
I've factored out the PanelSection creation into `create_markdown_panel_section` and let both of them call it.