### PR TITLE
Bug 1567724 - Only load the desired tree for perf reasons.

### DIFF
--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -260,7 +260,7 @@ pub fn make_local_server(
     config_path: &str,
     tree_name: &str,
 ) -> Result<Box<dyn AbstractServer + Send + Sync>> {
-    let mut config = load(config_path, false);
+    let mut config = load(config_path, false, Some(&tree_name));
     let tree_config = match config.trees.remove(&tree_name.to_string()) {
         Some(t) => t,
         None => {

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -87,9 +87,9 @@ fn main() {
     env_logger::init();
     let args: Vec<_> = env::args().collect();
 
-    let cfg = config::load(&args[1], false);
-
     let tree_name = &args[2];
+    let cfg = config::load(&args[1], false, Some(&tree_name));
+
     let tree_config = cfg.trees.get(tree_name).unwrap();
 
     let filenames_file = &args[3];

--- a/tools/src/bin/derive-per-file-info.rs
+++ b/tools/src/bin/derive-per-file-info.rs
@@ -298,10 +298,10 @@ fn main() {
 
     let args: Vec<_> = env::args().collect();
 
-    let cfg = config::load(&args[1], true);
+    let tree_name = &args[2];
+    let cfg = config::load(&args[1], true, Some(&tree_name));
     println!("Config file read");
 
-    let tree_name = &args[2];
     let tree_config = cfg.trees.get(tree_name).unwrap();
 
     // ## Build empty derived info structures

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -395,10 +395,10 @@ fn main() {
     let (base_args, fname_args) = args.split_at(3);
 
     let pre_config = Instant::now();
-    let cfg = config::load(&base_args[1], true);
+    let tree_name = &base_args[2];
+    let cfg = config::load(&base_args[1], true, Some(&tree_name));
     println!("Config file read, duration: {}us", pre_config.elapsed().as_micros() as u64);
 
-    let tree_name = &base_args[2];
     let tree_config = cfg.trees.get(tree_name).unwrap();
 
     let pre_jumps = Instant::now();

--- a/tools/src/bin/print-identifiers.rs
+++ b/tools/src/bin/print-identifiers.rs
@@ -7,9 +7,10 @@ use tools::file_format::identifiers::IdentMap;
 
 fn main() {
     env_logger::init();
-    let cfg = config::load(&env::args().nth(1).unwrap(), false);
+    let tree_name = &env::args().nth(2).unwrap();
+    let cfg = config::load(&env::args().nth(1).unwrap(), false, Some(tree_name));
     let id_map = IdentMap::load(&cfg);
-    let ids = id_map.get(&env::args().nth(2).unwrap()).unwrap();
+    let ids = id_map.get(tree_name).unwrap();
     let results = ids.lookup(&env::args().nth(3).unwrap(), false, true, 20);
     for result in results {
         println!("R `{}` = `{}`", result.id, result.symbol);

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -255,7 +255,7 @@ fn handle(
 fn main() {
     env_logger::init();
 
-    let cfg = config::load(&env::args().nth(1).unwrap(), true);
+    let cfg = config::load(&env::args().nth(1).unwrap(), true, None);
 
     // Dump config memory usage
     println!("{}", cfg.describe_mem_usage());

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -128,7 +128,7 @@ pub fn index_blame(
     (blame_map, hg_map)
 }
 
-pub fn load(config_path: &str, need_indexes: bool) -> Config {
+pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>) -> Config {
     let config_file = File::open(config_path).unwrap();
     let mut reader = BufReader::new(&config_file);
     let mut input = String::new();
@@ -144,6 +144,12 @@ pub fn load(config_path: &str, need_indexes: bool) -> Config {
 
     let mut trees = BTreeMap::new();
     for (tree_name, tree_config) in trees_obj {
+        if let Some(only_tree_name) = only_tree {
+            if tree_name != only_tree_name {
+                continue;
+            }
+        }
+
         let paths: TreeConfigPaths = serde_json::from_value(tree_config).unwrap();
 
         let git = match (&paths.git_path, &paths.git_blame_path) {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -797,7 +797,7 @@ pub fn create_markdown_panel_section(add_symbol_link: bool) -> PanelSection {
         accel_key: Some('F'),
         copyable: true,
     });
-    if (add_symbol_link) {
+    if add_symbol_link {
         markdown_panel_items.push(PanelItem {
             title: "Symbol Link".to_owned(),
             link: String::new(),


### PR DESCRIPTION
It can be quite expensive to load each tree in the config file,
especially when `need_indexes` is true, like in `output-file.rs`, to
the tune of an extra 82 seconds of loading time.  This change makes
us only load the desired tree for commands that only operate on a
single tree at a time.  The notable exception is `web-server.rs`
which inherently operates on all trees.