### PR TITLE
Bug 1567724 - Clean up moot parallel handle_error logic, use lsof

### DIFF
--- a/infrastructure/aws/main.sh
+++ b/infrastructure/aws/main.sh
@@ -25,12 +25,9 @@ handle_error() {
         if [ -d "/mnt/index-scratch" ]; then
             mv -f /mnt/index-scratch/* /index/interrupted
         fi
-        # When GNU parallel is passed `--files` it will place the output of jobs
-        # in `.par` files in `/tmp`.  Currently only output.sh uses this, but
-        # the output is very interesting.
-        mkdir -p /index/tmp
-        cp /tmp/*.par /index/tmp || true
-        cp /tmp/*.joblog /index/tmp || true
+        # try and get a list of open files that might have caused problems
+        # unmounting /index or moving things from /mnt/index-scratch to /index.
+        lsof | grep /index
     fi
 
     # Send failure email and shut down. Release channel failures get sent to the


### PR DESCRIPTION
- Removes the moot logic to move GNU parallel files from /tmp because
  we now put them in INDEX_ROOT/diags/output.
- Add a call to lsof that grep filters to try and identify anything
  that might have caused a failure to unmount.  I'm not running this
  under sudo, but in theory that could make sense.  (But everything
  we notionally run is same-user...)