### PR TITLE
Operating core "query" implementation with pipeline-server.rs exposure, no UI beyond JSON

### DIFF
--- a/docs/searchfox-tool-cookbook.md
+++ b/docs/searchfox-tool-cookbook.md
@@ -49,6 +49,13 @@ searchfox-tool 'query --help'
 --tree=mozilla-central search-identifiers mozilla::GetContentWin32kLockdownEnabled | crossref-lookup | traverse --edge=uses --max-depth=9 | graph --format=svg'
 ```
 
+```
+~/mozsearch/tools/target/release/searchfox-tool '--server=/home/ubuntu/index/config.json
+--tree=mozilla-central search-identifiers GetLiveWin32kLockdownState | crossref-lookup | traverse --edge=uses --max-depth=9 | graph --format=svg'
+```
+
+
+
 ### Diffing Query Results
 
 While investigating aspects of queries that hit limits because of non-intuitive

--- a/infrastructure/web-server-run.sh
+++ b/infrastructure/web-server-run.sh
@@ -22,6 +22,7 @@ STATUS_FILE="${SERVER_ROOT}/docroot/status.txt"
 pkill codesearch || true
 pkill -f router/router.py || true
 pkill -f tools/target/release/web-server || true
+pkill -f tools/target/release/pipeline-server || true
 
 sleep 1
 
@@ -29,6 +30,10 @@ nohup $MOZSEARCH_PATH/router/router.py $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/
 
 export RUST_BACKTRACE=1
 nohup $MOZSEARCH_PATH/tools/target/release/web-server $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/rust-server.log 2> $SERVER_ROOT/rust-server.err < /dev/null &
+
+# Note that we do not currently wait for the pipeline-server and it does not
+# write to the STATUS_FILE.
+nohup $MOZSEARCH_PATH/tools/target/release/pipeline-server $CONFIG_FILE > $SERVER_ROOT/pipeline-server.log 2> $SERVER_ROOT/pipeline-server.err < /dev/null &
 
 # If WAIT was passed, wait until the servers report they loaded.
 if [[ ${4:-} = "WAIT" ]]; then

--- a/tests/tests/checks/inputs/crossref/expand/big_cpp.cpp/outercat__json
+++ b/tests/tests/checks/inputs/crossref/expand/big_cpp.cpp/outercat__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::OuterCat | crossref-lookup | crossref-expand

--- a/tests/tests/checks/inputs/search-files/anchored_doublestar_html__json
+++ b/tests/tests/checks/inputs/search-files/anchored_doublestar_html__json
@@ -1,0 +1,1 @@
+search-files "^**.html"

--- a/tests/tests/checks/inputs/search-files/anchored_fakewpt_doublestar_combi__json
+++ b/tests/tests/checks/inputs/search-files/anchored_fakewpt_doublestar_combi__json
@@ -1,0 +1,1 @@
+search-files "^fake-wpt/**.{js,ini}"

--- a/tests/tests/checks/inputs/search-files/anchored_star_html__json
+++ b/tests/tests/checks/inputs/search-files/anchored_star_html__json
@@ -1,0 +1,1 @@
+search-files "^*.html"

--- a/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__context4__json
+++ b/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__context4__json
@@ -1,0 +1,1 @@
+query "context:4 'DoubleBase::doublePure'"

--- a/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__context_alias4__json
+++ b/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__context_alias4__json
@@ -1,0 +1,1 @@
+query "C:4 'DoubleBase::doublePure'"

--- a/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__json
+++ b/tests/tests/checks/inputs/web/query/execution/simple/overs.cpp/query__doublePure__json
@@ -1,0 +1,2 @@
+query "'DoubleBase::doublePure'"
+

--- a/tests/tests/checks/inputs/web/query/parsing/simple/overs.cpp/query__parse__doublePure__context4__json
+++ b/tests/tests/checks/inputs/web/query/parsing/simple/overs.cpp/query__parse__doublePure__context4__json
@@ -1,0 +1,1 @@
+query --dump-pipeline "context:4 'DoubleBase::doublePure'"

--- a/tests/tests/checks/inputs/web/query/parsing/simple/overs.cpp/query__parse__doublePure__json
+++ b/tests/tests/checks/inputs/web/query/parsing/simple/overs.cpp/query__parse__doublePure__json
@@ -1,0 +1,1 @@
+query --dump-pipeline "'DoubleBase::doublePure'"

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@abstractart__beart__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@abstractart__beart__json.snap
@@ -1,47 +1,55 @@
 ---
 source: tests/test_check_insta.rs
-expression: crossref_json
+expression: "&to_value(scil).unwrap()"
 ---
-[
-  {
-    "defs": [
-      {
-        "path": "big_cpp.cpp",
-        "lines": [
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "_ZN7outerNS11AbstractArt5beArtEv",
+      "crossref_info": {
+        "defs": [
           {
-            "lno": 424,
-            "bounds": [
-              13,
-              18
-            ],
-            "line": "virtual void beArt() = 0;",
-            "context": "outerNS::AbstractArt",
-            "contextsym": "T_outerNS::AbstractArt",
-            "peekRange": "422-424"
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 424,
+                "bounds": [
+                  13,
+                  18
+                ],
+                "line": "virtual void beArt() = 0;",
+                "context": "outerNS::AbstractArt",
+                "contextsym": "T_outerNS::AbstractArt",
+                "peekRange": "422-424"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "meta": {
-      "structured": 1,
-      "pretty": "outerNS::AbstractArt::beArt",
-      "sym": "_ZN7outerNS11AbstractArt5beArtEv",
-      "kind": "method",
-      "parentsym": "T_outerNS::AbstractArt",
-      "implKind": "",
-      "sizeBytes": null,
-      "supers": [],
-      "methods": [],
-      "fields": [],
-      "overrides": [],
-      "props": [
-        "instance",
-        "virtual",
-        "user"
-      ],
-      "overriddenBy": [
-        "_ZN7outerNS12PracticalArt5beArtEv"
-      ]
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::AbstractArt::beArt",
+          "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+          "kind": "method",
+          "parentsym": "T_outerNS::AbstractArt",
+          "implKind": "",
+          "sizeBytes": null,
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ],
+          "overriddenBy": [
+            "_ZN7outerNS12PracticalArt5beArtEv"
+          ]
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
     }
-  }
-]
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
@@ -1,261 +1,269 @@
 ---
 source: tests/test_check_insta.rs
-expression: crossref_json
+expression: "&to_value(scil).unwrap()"
 ---
-[
-  {
-    "uses": [
-      {
-        "path": "big_cpp.cpp",
-        "lines": [
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "T_outerNS::Thing",
+      "crossref_info": {
+        "uses": [
           {
-            "lno": 166,
-            "bounds": [
-              5,
-              10
-            ],
-            "line": "void Thing::ignore() {",
-            "context": "outerNS::Thing::ignore",
-            "contextsym": "_ZN7outerNS5Thing6ignoreEv"
-          },
-          {
-            "lno": 179,
-            "bounds": [
-              20,
-              25
-            ],
-            "line": "class Human: public Thing {",
-            "context": "outerNS::Human",
-            "contextsym": "T_outerNS::Human"
-          },
-          {
-            "lno": 183,
-            "bounds": [
-              2,
-              7
-            ],
-            "line": ": Thing(HUMAN_HP) {",
-            "context": "outerNS::Human::Human",
-            "contextsym": "_ZN7outerNS5HumanC1Ev"
-          },
-          {
-            "lno": 205,
-            "bounds": [
-              21,
-              26
-            ],
-            "line": "class Couch : public Thing {",
-            "context": "outerNS::Couch",
-            "contextsym": "T_outerNS::Couch"
-          },
-          {
-            "lno": 209,
-            "bounds": [
-              2,
-              7
-            ],
-            "line": ": Thing (couchHP) {",
-            "context": "outerNS::Couch::Couch",
-            "contextsym": "_ZN7outerNS5CouchC1Ei"
-          },
-          {
-            "lno": 221,
-            "bounds": [
-              17,
-              22
-            ],
-            "line": "class OuterCat : Thing {",
-            "context": "outerNS::OuterCat",
-            "contextsym": "T_outerNS::OuterCat"
-          },
-          {
-            "lno": 258,
-            "bounds": [
-              2,
-              7
-            ],
-            "line": ": Thing(9 * HUMAN_HP)",
-            "context": "outerNS::OuterCat::OuterCat",
-            "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
-          },
-          {
-            "lno": 390,
-            "bounds": [
-              11,
-              16
-            ],
-            "line": "void shred(Thing &thing) {",
-            "context": "outerNS::OuterCat::shred",
-            "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
-          },
-          {
-            "lno": 397,
-            "bounds": [
-              13,
-              18
-            ],
-            "line": "void destroy(Thing &thing) {",
-            "context": "outerNS::OuterCat::destroy",
-            "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
-          },
-          {
-            "lno": 417,
-            "bounds": [
-              27,
-              32
-            ],
-            "line": "class AbstractArt : public Thing {",
-            "context": "outerNS::AbstractArt",
-            "contextsym": "T_outerNS::AbstractArt"
-          },
-          {
-            "lno": 420,
-            "bounds": [
-              2,
-              7
-            ],
-            "line": ": Thing(ART_HP) {}",
-            "context": "outerNS::AbstractArt::AbstractArt",
-            "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 166,
+                "bounds": [
+                  5,
+                  10
+                ],
+                "line": "void Thing::ignore() {",
+                "context": "outerNS::Thing::ignore",
+                "contextsym": "_ZN7outerNS5Thing6ignoreEv"
+              },
+              {
+                "lno": 179,
+                "bounds": [
+                  20,
+                  25
+                ],
+                "line": "class Human: public Thing {",
+                "context": "outerNS::Human",
+                "contextsym": "T_outerNS::Human"
+              },
+              {
+                "lno": 183,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(HUMAN_HP) {",
+                "context": "outerNS::Human::Human",
+                "contextsym": "_ZN7outerNS5HumanC1Ev"
+              },
+              {
+                "lno": 205,
+                "bounds": [
+                  21,
+                  26
+                ],
+                "line": "class Couch : public Thing {",
+                "context": "outerNS::Couch",
+                "contextsym": "T_outerNS::Couch"
+              },
+              {
+                "lno": 209,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing (couchHP) {",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              },
+              {
+                "lno": 221,
+                "bounds": [
+                  17,
+                  22
+                ],
+                "line": "class OuterCat : Thing {",
+                "context": "outerNS::OuterCat",
+                "contextsym": "T_outerNS::OuterCat"
+              },
+              {
+                "lno": 258,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(9 * HUMAN_HP)",
+                "context": "outerNS::OuterCat::OuterCat",
+                "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
+              },
+              {
+                "lno": 390,
+                "bounds": [
+                  11,
+                  16
+                ],
+                "line": "void shred(Thing &thing) {",
+                "context": "outerNS::OuterCat::shred",
+                "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+              },
+              {
+                "lno": 397,
+                "bounds": [
+                  13,
+                  18
+                ],
+                "line": "void destroy(Thing &thing) {",
+                "context": "outerNS::OuterCat::destroy",
+                "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+              },
+              {
+                "lno": 417,
+                "bounds": [
+                  27,
+                  32
+                ],
+                "line": "class AbstractArt : public Thing {",
+                "context": "outerNS::AbstractArt",
+                "contextsym": "T_outerNS::AbstractArt"
+              },
+              {
+                "lno": 420,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(ART_HP) {}",
+                "context": "outerNS::AbstractArt::AbstractArt",
+                "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "defs": [
-      {
-        "path": "big_cpp.cpp",
-        "lines": [
+        ],
+        "defs": [
           {
-            "lno": 135,
-            "bounds": [
-              6,
-              11
-            ],
-            "line": "class Thing {",
-            "context": "",
-            "contextsym": "",
-            "peekRange": "135-135"
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 135,
+                "bounds": [
+                  6,
+                  11
+                ],
+                "line": "class Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "135-135"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "callees": [
-      {
-        "kind": "field",
-        "pretty": "outerNS::Thing::mDefunct",
-        "sym": "F_<T_outerNS::Thing>_mDefunct"
+        ],
+        "callees": [
+          {
+            "kind": "field",
+            "pretty": "outerNS::Thing::mDefunct",
+            "sym": "F_<T_outerNS::Thing>_mDefunct"
+          },
+          {
+            "kind": "field",
+            "pretty": "outerNS::Thing::mHP",
+            "sym": "F_<T_outerNS::Thing>_mHP"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Thing",
+          "sym": "T_outerNS::Thing",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [],
+          "methods": [
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1Ei",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::ignore",
+              "sym": "_ZN7outerNS5Thing6ignoreEv",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::takeDamage",
+              "sym": "_ZN7outerNS5Thing10takeDamageEi",
+              "props": [
+                "instance",
+                "virtual",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::operator=",
+              "sym": "_ZN7outerNS5ThingaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::operator=",
+              "sym": "_ZN7outerNS5ThingaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::~Thing",
+              "sym": "_ZN7outerNS5ThingD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1ERKS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1EOS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            }
+          ],
+          "fields": [
+            {
+              "pretty": "outerNS::Thing::mHP",
+              "sym": "F_<T_outerNS::Thing>_mHP",
+              "type": "int",
+              "typesym": "",
+              "offsetBytes": 8,
+              "bitPositions": null,
+              "sizeBytes": 4
+            },
+            {
+              "pretty": "outerNS::Thing::mDefunct",
+              "sym": "F_<T_outerNS::Thing>_mDefunct",
+              "type": "_Bool",
+              "typesym": "",
+              "offsetBytes": 12,
+              "bitPositions": null,
+              "sizeBytes": 1
+            }
+          ],
+          "overrides": [],
+          "props": [],
+          "subclasses": [
+            "T_outerNS::Human",
+            "T_outerNS::Couch",
+            "T_outerNS::OuterCat",
+            "T_outerNS::AbstractArt"
+          ]
+        }
       },
-      {
-        "kind": "field",
-        "pretty": "outerNS::Thing::mHP",
-        "sym": "F_<T_outerNS::Thing>_mHP"
-      }
-    ],
-    "meta": {
-      "structured": 1,
-      "pretty": "outerNS::Thing",
-      "sym": "T_outerNS::Thing",
-      "kind": "class",
-      "implKind": "",
-      "sizeBytes": 16,
-      "supers": [],
-      "methods": [
-        {
-          "pretty": "outerNS::Thing::Thing",
-          "sym": "_ZN7outerNS5ThingC1Ei",
-          "props": [
-            "instance",
-            "user"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::ignore",
-          "sym": "_ZN7outerNS5Thing6ignoreEv",
-          "props": [
-            "instance",
-            "user"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::takeDamage",
-          "sym": "_ZN7outerNS5Thing10takeDamageEi",
-          "props": [
-            "instance",
-            "virtual",
-            "user"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::operator=",
-          "sym": "_ZN7outerNS5ThingaSERKS0_",
-          "props": [
-            "instance",
-            "defaulted"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::operator=",
-          "sym": "_ZN7outerNS5ThingaSEOS0_",
-          "props": [
-            "instance",
-            "defaulted"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::~Thing",
-          "sym": "_ZN7outerNS5ThingD1Ev",
-          "props": [
-            "instance",
-            "defaulted"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::Thing",
-          "sym": "_ZN7outerNS5ThingC1ERKS0_",
-          "props": [
-            "instance",
-            "defaulted",
-            "constexpr"
-          ]
-        },
-        {
-          "pretty": "outerNS::Thing::Thing",
-          "sym": "_ZN7outerNS5ThingC1EOS0_",
-          "props": [
-            "instance",
-            "defaulted",
-            "constexpr"
-          ]
-        }
-      ],
-      "fields": [
-        {
-          "pretty": "outerNS::Thing::mHP",
-          "sym": "F_<T_outerNS::Thing>_mHP",
-          "type": "int",
-          "typesym": "",
-          "offsetBytes": 8,
-          "bitPositions": null,
-          "sizeBytes": 4
-        },
-        {
-          "pretty": "outerNS::Thing::mDefunct",
-          "sym": "F_<T_outerNS::Thing>_mDefunct",
-          "type": "_Bool",
-          "typesym": "",
-          "offsetBytes": 12,
-          "bitPositions": null,
-          "sizeBytes": 1
-        }
-      ],
-      "overrides": [],
-      "props": [],
-      "subclasses": [
-        "T_outerNS::Human",
-        "T_outerNS::Couch",
-        "T_outerNS::OuterCat",
-        "T_outerNS::AbstractArt"
-      ]
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
     }
-  }
-]
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
@@ -1,78 +1,86 @@
 ---
 source: tests/test_check_insta.rs
-expression: crossref_json
+expression: "&to_value(scil).unwrap()"
 ---
-[
-  {
-    "uses": [
-      {
-        "path": "xpidl_cpp_consumer.cpp",
-        "lines": [
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "_ZN25nsIXPCTestObjectReadWrite18GetBooleanPropertyEPb",
+      "crossref_info": {
+        "uses": [
           {
-            "lno": 13,
-            "bounds": [
-              7,
-              25
-            ],
-            "line": "attrs->GetBooleanProperty(&string_was_too_hard);",
-            "context": "consume_attr",
-            "contextsym": "_Z12consume_attrP25nsIXPCTestObjectReadWrite"
+            "path": "xpidl_cpp_consumer.cpp",
+            "lines": [
+              {
+                "lno": 13,
+                "bounds": [
+                  7,
+                  25
+                ],
+                "line": "attrs->GetBooleanProperty(&string_was_too_hard);",
+                "context": "consume_attr",
+                "contextsym": "_Z12consume_attrP25nsIXPCTestObjectReadWrite"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "defs": [
-      {
-        "path": "__GENERATED__/dist/include/xpctest_attributes.h",
-        "lines": [
+        ],
+        "defs": [
           {
-            "lno": 122,
-            "bounds": [
-              33,
-              51
-            ],
-            "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD GetBooleanProperty(bool *aBooleanProperty) = 0;",
-            "context": "nsIXPCTestObjectReadWrite",
-            "contextsym": "T_nsIXPCTestObjectReadWrite"
+            "path": "__GENERATED__/dist/include/xpctest_attributes.h",
+            "lines": [
+              {
+                "lno": 122,
+                "bounds": [
+                  33,
+                  51
+                ],
+                "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD GetBooleanProperty(bool *aBooleanProperty) = 0;",
+                "context": "nsIXPCTestObjectReadWrite",
+                "contextsym": "T_nsIXPCTestObjectReadWrite"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "idl": [
-      {
-        "path": "xpidl/xpctest_attributes.idl",
-        "lines": [
+        ],
+        "idl": [
           {
-            "lno": 27,
-            "bounds": [
-              18,
-              33
-            ],
-            "line": "attribute boolean booleanProperty;",
-            "context": "",
-            "contextsym": ""
+            "path": "xpidl/xpctest_attributes.idl",
+            "lines": [
+              {
+                "lno": 27,
+                "bounds": [
+                  18,
+                  33
+                ],
+                "line": "attribute boolean booleanProperty;",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "callees": [],
-    "meta": {
-      "structured": 1,
-      "pretty": "nsIXPCTestObjectReadWrite::GetBooleanProperty",
-      "sym": "_ZN25nsIXPCTestObjectReadWrite18GetBooleanPropertyEPb",
-      "kind": "method",
-      "parentsym": "T_nsIXPCTestObjectReadWrite",
-      "implKind": "",
-      "sizeBytes": null,
-      "supers": [],
-      "methods": [],
-      "fields": [],
-      "overrides": [],
-      "props": [
-        "instance",
-        "virtual",
-        "user"
-      ]
+        ],
+        "callees": [],
+        "meta": {
+          "structured": 1,
+          "pretty": "nsIXPCTestObjectReadWrite::GetBooleanProperty",
+          "sym": "_ZN25nsIXPCTestObjectReadWrite18GetBooleanPropertyEPb",
+          "kind": "method",
+          "parentsym": "T_nsIXPCTestObjectReadWrite",
+          "implKind": "",
+          "sizeBytes": null,
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ]
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
     }
-  }
-]
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
@@ -1,78 +1,86 @@
 ---
 source: tests/test_check_insta.rs
-expression: crossref_json
+expression: "&to_value(scil).unwrap()"
 ---
-[
-  {
-    "uses": [
-      {
-        "path": "xpidl_cpp_consumer.cpp",
-        "lines": [
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "_ZN25nsIXPCTestObjectReadWrite18SetBooleanPropertyEb",
+      "crossref_info": {
+        "uses": [
           {
-            "lno": 16,
-            "bounds": [
-              7,
-              25
-            ],
-            "line": "attrs->SetBooleanProperty(string_was_too_hard);",
-            "context": "consume_attr",
-            "contextsym": "_Z12consume_attrP25nsIXPCTestObjectReadWrite"
+            "path": "xpidl_cpp_consumer.cpp",
+            "lines": [
+              {
+                "lno": 16,
+                "bounds": [
+                  7,
+                  25
+                ],
+                "line": "attrs->SetBooleanProperty(string_was_too_hard);",
+                "context": "consume_attr",
+                "contextsym": "_Z12consume_attrP25nsIXPCTestObjectReadWrite"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "defs": [
-      {
-        "path": "__GENERATED__/dist/include/xpctest_attributes.h",
-        "lines": [
+        ],
+        "defs": [
           {
-            "lno": 123,
-            "bounds": [
-              33,
-              51
-            ],
-            "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD SetBooleanProperty(bool aBooleanProperty) = 0;",
-            "context": "nsIXPCTestObjectReadWrite",
-            "contextsym": "T_nsIXPCTestObjectReadWrite"
+            "path": "__GENERATED__/dist/include/xpctest_attributes.h",
+            "lines": [
+              {
+                "lno": 123,
+                "bounds": [
+                  33,
+                  51
+                ],
+                "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD SetBooleanProperty(bool aBooleanProperty) = 0;",
+                "context": "nsIXPCTestObjectReadWrite",
+                "contextsym": "T_nsIXPCTestObjectReadWrite"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "idl": [
-      {
-        "path": "xpidl/xpctest_attributes.idl",
-        "lines": [
+        ],
+        "idl": [
           {
-            "lno": 27,
-            "bounds": [
-              18,
-              33
-            ],
-            "line": "attribute boolean booleanProperty;",
-            "context": "",
-            "contextsym": ""
+            "path": "xpidl/xpctest_attributes.idl",
+            "lines": [
+              {
+                "lno": 27,
+                "bounds": [
+                  18,
+                  33
+                ],
+                "line": "attribute boolean booleanProperty;",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "callees": [],
-    "meta": {
-      "structured": 1,
-      "pretty": "nsIXPCTestObjectReadWrite::SetBooleanProperty",
-      "sym": "_ZN25nsIXPCTestObjectReadWrite18SetBooleanPropertyEb",
-      "kind": "method",
-      "parentsym": "T_nsIXPCTestObjectReadWrite",
-      "implKind": "",
-      "sizeBytes": null,
-      "supers": [],
-      "methods": [],
-      "fields": [],
-      "overrides": [],
-      "props": [
-        "instance",
-        "virtual",
-        "user"
-      ]
+        ],
+        "callees": [],
+        "meta": {
+          "structured": 1,
+          "pretty": "nsIXPCTestObjectReadWrite::SetBooleanProperty",
+          "sym": "_ZN25nsIXPCTestObjectReadWrite18SetBooleanPropertyEb",
+          "kind": "method",
+          "parentsym": "T_nsIXPCTestObjectReadWrite",
+          "implKind": "",
+          "sizeBytes": null,
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ]
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
     }
-  }
-]
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
@@ -1,78 +1,86 @@
 ---
 source: tests/test_check_insta.rs
-expression: crossref_json
+expression: "&to_value(scil).unwrap()"
 ---
-[
-  {
-    "uses": [
-      {
-        "path": "xpidl_cpp_consumer.cpp",
-        "lines": [
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_",
+      "crossref_info": {
+        "uses": [
           {
-            "lno": 7,
-            "bounds": [
-              8,
-              17
-            ],
-            "line": "params->TestOctet(1, &b, &out);",
-            "context": "consume_xpidl",
-            "contextsym": "_Z13consume_xpidlP16nsIXPCTestParams"
+            "path": "xpidl_cpp_consumer.cpp",
+            "lines": [
+              {
+                "lno": 7,
+                "bounds": [
+                  8,
+                  17
+                ],
+                "line": "params->TestOctet(1, &b, &out);",
+                "context": "consume_xpidl",
+                "contextsym": "_Z13consume_xpidlP16nsIXPCTestParams"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "defs": [
-      {
-        "path": "__GENERATED__/dist/include/xpctest_params.h",
-        "lines": [
+        ],
+        "defs": [
           {
-            "lno": 51,
-            "bounds": [
-              33,
-              42
-            ],
-            "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD TestOctet(uint8_t a, uint8_t *b, uint8_t *_retval) = 0;",
-            "context": "nsIXPCTestParams",
-            "contextsym": "T_nsIXPCTestParams"
+            "path": "__GENERATED__/dist/include/xpctest_params.h",
+            "lines": [
+              {
+                "lno": 51,
+                "bounds": [
+                  33,
+                  42
+                ],
+                "line": "JS_HAZ_CAN_RUN_SCRIPT NS_IMETHOD TestOctet(uint8_t a, uint8_t *b, uint8_t *_retval) = 0;",
+                "context": "nsIXPCTestParams",
+                "contextsym": "T_nsIXPCTestParams"
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "idl": [
-      {
-        "path": "xpidl/xpctest_params.idl",
-        "lines": [
+        ],
+        "idl": [
           {
-            "lno": 24,
-            "bounds": [
-              22,
-              31
-            ],
-            "line": "octet                 testOctet(in octet a, inout octet b);",
-            "context": "",
-            "contextsym": ""
+            "path": "xpidl/xpctest_params.idl",
+            "lines": [
+              {
+                "lno": 24,
+                "bounds": [
+                  22,
+                  31
+                ],
+                "line": "octet                 testOctet(in octet a, inout octet b);",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
           }
-        ]
-      }
-    ],
-    "callees": [],
-    "meta": {
-      "structured": 1,
-      "pretty": "nsIXPCTestParams::TestOctet",
-      "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_",
-      "kind": "method",
-      "parentsym": "T_nsIXPCTestParams",
-      "implKind": "",
-      "sizeBytes": null,
-      "supers": [],
-      "methods": [],
-      "fields": [],
-      "overrides": [],
-      "props": [
-        "instance",
-        "virtual",
-        "user"
-      ]
+        ],
+        "callees": [],
+        "meta": {
+          "structured": 1,
+          "pretty": "nsIXPCTestParams::TestOctet",
+          "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_",
+          "kind": "method",
+          "parentsym": "T_nsIXPCTestParams",
+          "implKind": "",
+          "sizeBytes": null,
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [
+            "instance",
+            "virtual",
+            "user"
+          ]
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
     }
-  }
-]
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -1,0 +1,1109 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(scil).unwrap()"
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "T_outerNS::OuterCat",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 221,
+                "bounds": [
+                  6,
+                  14
+                ],
+                "line": "class OuterCat : Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "221-221"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "field",
+            "pretty": "outerNS::OuterCat::mIsFriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsFriendly"
+          },
+          {
+            "kind": "field",
+            "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly"
+          },
+          {
+            "kind": "class",
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::OuterCat",
+          "sym": "T_outerNS::OuterCat",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::Thing",
+              "sym": "T_outerNS::Thing",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::OuterCat::OuterCat",
+              "sym": "_ZN7outerNS8OuterCatC1Ebb",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::isFriendlyCat",
+              "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+              "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+              "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::meet",
+              "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::meet",
+              "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::shred",
+              "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::destroy",
+              "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::operator=",
+              "sym": "_ZN7outerNS8OuterCataSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::operator=",
+              "sym": "_ZN7outerNS8OuterCataSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::OuterCat::~OuterCat",
+              "sym": "_ZN7outerNS8OuterCatD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            }
+          ],
+          "fields": [
+            {
+              "pretty": "outerNS::OuterCat::mIsFriendly",
+              "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+              "type": "_Bool",
+              "typesym": "",
+              "offsetBytes": 13,
+              "bitPositions": null,
+              "sizeBytes": 1
+            },
+            {
+              "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+              "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+              "type": "_Bool",
+              "typesym": "",
+              "offsetBytes": 14,
+              "bitPositions": null,
+              "sizeBytes": 1
+            }
+          ],
+          "overrides": [],
+          "props": []
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::Thing",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 166,
+                "bounds": [
+                  5,
+                  10
+                ],
+                "line": "void Thing::ignore() {",
+                "context": "outerNS::Thing::ignore",
+                "contextsym": "_ZN7outerNS5Thing6ignoreEv"
+              },
+              {
+                "lno": 179,
+                "bounds": [
+                  20,
+                  25
+                ],
+                "line": "class Human: public Thing {",
+                "context": "outerNS::Human",
+                "contextsym": "T_outerNS::Human"
+              },
+              {
+                "lno": 183,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(HUMAN_HP) {",
+                "context": "outerNS::Human::Human",
+                "contextsym": "_ZN7outerNS5HumanC1Ev"
+              },
+              {
+                "lno": 205,
+                "bounds": [
+                  21,
+                  26
+                ],
+                "line": "class Couch : public Thing {",
+                "context": "outerNS::Couch",
+                "contextsym": "T_outerNS::Couch"
+              },
+              {
+                "lno": 209,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing (couchHP) {",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              },
+              {
+                "lno": 221,
+                "bounds": [
+                  17,
+                  22
+                ],
+                "line": "class OuterCat : Thing {",
+                "context": "outerNS::OuterCat",
+                "contextsym": "T_outerNS::OuterCat"
+              },
+              {
+                "lno": 258,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(9 * HUMAN_HP)",
+                "context": "outerNS::OuterCat::OuterCat",
+                "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
+              },
+              {
+                "lno": 390,
+                "bounds": [
+                  11,
+                  16
+                ],
+                "line": "void shred(Thing &thing) {",
+                "context": "outerNS::OuterCat::shred",
+                "contextsym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
+              },
+              {
+                "lno": 397,
+                "bounds": [
+                  13,
+                  18
+                ],
+                "line": "void destroy(Thing &thing) {",
+                "context": "outerNS::OuterCat::destroy",
+                "contextsym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+              },
+              {
+                "lno": 417,
+                "bounds": [
+                  27,
+                  32
+                ],
+                "line": "class AbstractArt : public Thing {",
+                "context": "outerNS::AbstractArt",
+                "contextsym": "T_outerNS::AbstractArt"
+              },
+              {
+                "lno": 420,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Thing(ART_HP) {}",
+                "context": "outerNS::AbstractArt::AbstractArt",
+                "contextsym": "_ZN7outerNS11AbstractArtC1Ev"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 135,
+                "bounds": [
+                  6,
+                  11
+                ],
+                "line": "class Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "135-135"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "field",
+            "pretty": "outerNS::Thing::mDefunct",
+            "sym": "F_<T_outerNS::Thing>_mDefunct"
+          },
+          {
+            "kind": "field",
+            "pretty": "outerNS::Thing::mHP",
+            "sym": "F_<T_outerNS::Thing>_mHP"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Thing",
+          "sym": "T_outerNS::Thing",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [],
+          "methods": [
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1Ei",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::ignore",
+              "sym": "_ZN7outerNS5Thing6ignoreEv",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::takeDamage",
+              "sym": "_ZN7outerNS5Thing10takeDamageEi",
+              "props": [
+                "instance",
+                "virtual",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::operator=",
+              "sym": "_ZN7outerNS5ThingaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::operator=",
+              "sym": "_ZN7outerNS5ThingaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::~Thing",
+              "sym": "_ZN7outerNS5ThingD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1ERKS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            },
+            {
+              "pretty": "outerNS::Thing::Thing",
+              "sym": "_ZN7outerNS5ThingC1EOS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            }
+          ],
+          "fields": [
+            {
+              "pretty": "outerNS::Thing::mHP",
+              "sym": "F_<T_outerNS::Thing>_mHP",
+              "type": "int",
+              "typesym": "",
+              "offsetBytes": 8,
+              "bitPositions": null,
+              "sizeBytes": 4
+            },
+            {
+              "pretty": "outerNS::Thing::mDefunct",
+              "sym": "F_<T_outerNS::Thing>_mDefunct",
+              "type": "_Bool",
+              "typesym": "",
+              "offsetBytes": 12,
+              "bitPositions": null,
+              "sizeBytes": 1
+            }
+          ],
+          "overrides": [],
+          "props": [],
+          "subclasses": [
+            "T_outerNS::Human",
+            "T_outerNS::Couch",
+            "T_outerNS::OuterCat",
+            "T_outerNS::AbstractArt"
+          ]
+        }
+      },
+      "relation": {
+        "SuperclassOf": [
+          "T_outerNS::OuterCat",
+          1
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::Human",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 188,
+                "bounds": [
+                  25,
+                  30
+                ],
+                "line": "class Superhero : public Human {",
+                "context": "outerNS::Superhero",
+                "contextsym": "T_outerNS::Superhero"
+              },
+              {
+                "lno": 192,
+                "bounds": [
+                  2,
+                  7
+                ],
+                "line": ": Human() {",
+                "context": "outerNS::Superhero::Superhero",
+                "contextsym": "_ZN7outerNS9SuperheroC1Ev"
+              },
+              {
+                "lno": 213,
+                "bounds": [
+                  0,
+                  5
+                ],
+                "line": "Human bob;",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              },
+              {
+                "lno": 214,
+                "bounds": [
+                  16,
+                  21
+                ],
+                "line": "WhatsYourVector<Human> goodReferenceRight(&bob);",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              },
+              {
+                "lno": 340,
+                "bounds": [
+                  10,
+                  15
+                ],
+                "line": "void meet(Human &human) {",
+                "context": "outerNS::OuterCat::meet",
+                "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 179,
+                "bounds": [
+                  6,
+                  11
+                ],
+                "line": "class Human: public Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "179-179"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "class",
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Human",
+          "sym": "T_outerNS::Human",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::Thing",
+              "sym": "T_outerNS::Thing",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::Human::Human",
+              "sym": "_ZN7outerNS5HumanC1Ev",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Human::operator=",
+              "sym": "_ZN7outerNS5HumanaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Human::operator=",
+              "sym": "_ZN7outerNS5HumanaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Human::~Human",
+              "sym": "_ZN7outerNS5HumanD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Human::Human",
+              "sym": "_ZN7outerNS5HumanC1ERKS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            },
+            {
+              "pretty": "outerNS::Human::Human",
+              "sym": "_ZN7outerNS5HumanC1EOS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "subclasses": [
+            "T_outerNS::Superhero"
+          ]
+        }
+      },
+      "relation": {
+        "CousinClassOf": [
+          "T_outerNS::OuterCat",
+          2
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::Couch",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 351,
+                "bounds": [
+                  10,
+                  15
+                ],
+                "line": "void meet(Couch &couch) {",
+                "context": "outerNS::OuterCat::meet",
+                "contextsym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 205,
+                "bounds": [
+                  6,
+                  11
+                ],
+                "line": "class Couch : public Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "205-205"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "class",
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Couch",
+          "sym": "T_outerNS::Couch",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::Thing",
+              "sym": "T_outerNS::Thing",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::Couch::Couch",
+              "sym": "_ZN7outerNS5CouchC1Ei",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Couch::operator=",
+              "sym": "_ZN7outerNS5CouchaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Couch::operator=",
+              "sym": "_ZN7outerNS5CouchaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Couch::~Couch",
+              "sym": "_ZN7outerNS5CouchD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": []
+        }
+      },
+      "relation": {
+        "CousinClassOf": [
+          "T_outerNS::OuterCat",
+          2
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::AbstractArt",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 427,
+                "bounds": [
+                  28,
+                  39
+                ],
+                "line": "class PracticalArt : public AbstractArt {",
+                "context": "outerNS::PracticalArt",
+                "contextsym": "T_outerNS::PracticalArt"
+              },
+              {
+                "lno": 430,
+                "bounds": [
+                  2,
+                  13
+                ],
+                "line": ": AbstractArt() {}",
+                "context": "outerNS::PracticalArt::PracticalArt",
+                "contextsym": "_ZN7outerNS12PracticalArtC1Ev"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 417,
+                "bounds": [
+                  6,
+                  17
+                ],
+                "line": "class AbstractArt : public Thing {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "417-417"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "class",
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::AbstractArt",
+          "sym": "T_outerNS::AbstractArt",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::Thing",
+              "sym": "T_outerNS::Thing",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::AbstractArt::AbstractArt",
+              "sym": "_ZN7outerNS11AbstractArtC1Ev",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::beArt",
+              "sym": "_ZN7outerNS11AbstractArt5beArtEv",
+              "props": [
+                "instance",
+                "virtual",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::operator=",
+              "sym": "_ZN7outerNS11AbstractArtaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::operator=",
+              "sym": "_ZN7outerNS11AbstractArtaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::~AbstractArt",
+              "sym": "_ZN7outerNS11AbstractArtD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::AbstractArt",
+              "sym": "_ZN7outerNS11AbstractArtC1ERKS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            },
+            {
+              "pretty": "outerNS::AbstractArt::AbstractArt",
+              "sym": "_ZN7outerNS11AbstractArtC1EOS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "subclasses": [
+            "T_outerNS::PracticalArt"
+          ]
+        }
+      },
+      "relation": {
+        "CousinClassOf": [
+          "T_outerNS::OuterCat",
+          2
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::Superhero",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 210,
+                "bounds": [
+                  0,
+                  9
+                ],
+                "line": "Superhero superBob;",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              },
+              {
+                "lno": 211,
+                "bounds": [
+                  16,
+                  25
+                ],
+                "line": "WhatsYourVector<Superhero> victor(&superBob);",
+                "context": "outerNS::Couch::Couch",
+                "contextsym": "_ZN7outerNS5CouchC1Ei"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 188,
+                "bounds": [
+                  6,
+                  15
+                ],
+                "line": "class Superhero : public Human {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "188-188"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "class",
+            "pretty": "outerNS::Human",
+            "sym": "T_outerNS::Human"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Superhero",
+          "sym": "T_outerNS::Superhero",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::Human",
+              "sym": "T_outerNS::Human",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::Superhero::Superhero",
+              "sym": "_ZN7outerNS9SuperheroC1Ev",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::takeDamage",
+              "sym": "_ZN7outerNS9Superhero10takeDamageEi",
+              "props": [
+                "instance",
+                "virtual",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::operator=",
+              "sym": "_ZN7outerNS9SuperheroaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::operator=",
+              "sym": "_ZN7outerNS9SuperheroaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::~Superhero",
+              "sym": "_ZN7outerNS9SuperheroD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::Superhero",
+              "sym": "_ZN7outerNS9SuperheroC1ERKS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            },
+            {
+              "pretty": "outerNS::Superhero::Superhero",
+              "sym": "_ZN7outerNS9SuperheroC1EOS0_",
+              "props": [
+                "instance",
+                "defaulted",
+                "constexpr"
+              ]
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": []
+        }
+      },
+      "relation": {
+        "CousinClassOf": [
+          "T_outerNS::OuterCat",
+          3
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    },
+    {
+      "symbol": "T_outerNS::PracticalArt",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "lines": [
+              {
+                "lno": 427,
+                "bounds": [
+                  6,
+                  18
+                ],
+                "line": "class PracticalArt : public AbstractArt {",
+                "context": "",
+                "contextsym": "",
+                "peekRange": "427-427"
+              }
+            ]
+          }
+        ],
+        "callees": [
+          {
+            "kind": "class",
+            "pretty": "outerNS::AbstractArt",
+            "sym": "T_outerNS::AbstractArt"
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::PracticalArt",
+          "sym": "T_outerNS::PracticalArt",
+          "kind": "class",
+          "implKind": "",
+          "sizeBytes": 16,
+          "supers": [
+            {
+              "pretty": "outerNS::AbstractArt",
+              "sym": "T_outerNS::AbstractArt",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "outerNS::PracticalArt::PracticalArt",
+              "sym": "_ZN7outerNS12PracticalArtC1Ev",
+              "props": [
+                "instance",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::PracticalArt::beArt",
+              "sym": "_ZN7outerNS12PracticalArt5beArtEv",
+              "props": [
+                "instance",
+                "virtual",
+                "user"
+              ]
+            },
+            {
+              "pretty": "outerNS::PracticalArt::operator=",
+              "sym": "_ZN7outerNS12PracticalArtaSERKS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::PracticalArt::operator=",
+              "sym": "_ZN7outerNS12PracticalArtaSEOS0_",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            },
+            {
+              "pretty": "outerNS::PracticalArt::~PracticalArt",
+              "sym": "_ZN7outerNS12PracticalArtD1Ev",
+              "props": [
+                "instance",
+                "defaulted"
+              ]
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": []
+        }
+      },
+      "relation": {
+        "CousinClassOf": [
+          "T_outerNS::OuterCat",
+          3
+        ]
+      },
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/identifiers/big_cpp.cpp/check_glob@abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/crossref/identifiers/big_cpp.cpp/check_glob@abstractart_beart__json.snap
@@ -1,10 +1,13 @@
 ---
 source: tests/test_check_insta.rs
-expression: json!(pairs)
+expression: "&to_value(sl).unwrap()"
 ---
-[
-  {
-    "sym": "_ZN7outerNS11AbstractArt5beArtEv",
-    "id": "outerNS::AbstractArt::beArt"
-  }
-]
+{
+  "symbols": [
+    {
+      "symbol": "_ZN7outerNS11AbstractArt5beArtEv",
+      "quality": "ExactIdentifier",
+      "from_identifier": "outerNS::AbstractArt::beArt"
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/crossref/identifiers/big_cpp.cpp/check_glob@thing__json-2.snap
+++ b/tests/tests/checks/snapshots/crossref/identifiers/big_cpp.cpp/check_glob@thing__json-2.snap
@@ -1,10 +1,13 @@
 ---
 source: tests/test_check_insta.rs
-expression: json!(pairs)
+expression: "&to_value(sl).unwrap()"
 ---
-[
-  {
-    "sym": "T_outerNS::Thing",
-    "id": "outerNS::Thing"
-  }
-]
+{
+  "symbols": [
+    {
+      "symbol": "T_outerNS::Thing",
+      "quality": "ExactIdentifier",
+      "from_identifier": "outerNS::Thing"
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__dot.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__dot.snap
@@ -5,22 +5,22 @@ expression: "&fb.contents"
 digraph  {
     "_ZN7outerNS8OuterCat4meetERNS_5HumanE"[label="outerNS::OuterCat::meet"]
     "_ZN7outerNS5Thing6ignoreEv"[label="outerNS::Thing::ignore"]
-    _ZN7outerNS8OuterCat4meetERNS_5HumanE -> _ZN7outerNS5Thing6ignoreEv 
+    "_ZN7outerNS8OuterCat4meetERNS_5HumanE" -> "_ZN7outerNS5Thing6ignoreEv" 
     "_ZN7outerNS8OuterCat4meetERNS_5CouchE"[label="outerNS::OuterCat::meet"]
     "_ZN7outerNS8OuterCat13isFriendlyCatEv"[label="outerNS::OuterCat::isFriendlyCat"]
-    _ZN7outerNS8OuterCat4meetERNS_5CouchE -> _ZN7outerNS8OuterCat13isFriendlyCatEv 
+    "_ZN7outerNS8OuterCat4meetERNS_5CouchE" -> "_ZN7outerNS8OuterCat13isFriendlyCatEv" 
     "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv"[label="outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible"]
-    _ZN7outerNS8OuterCat4meetERNS_5CouchE -> _ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv 
+    "_ZN7outerNS8OuterCat4meetERNS_5CouchE" -> "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv" 
     "_ZN7outerNS8OuterCat5shredERNS_5ThingE"[label="outerNS::OuterCat::shred"]
-    _ZN7outerNS8OuterCat4meetERNS_5CouchE -> _ZN7outerNS8OuterCat5shredERNS_5ThingE 
+    "_ZN7outerNS8OuterCat4meetERNS_5CouchE" -> "_ZN7outerNS8OuterCat5shredERNS_5ThingE" 
     "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"[label="outerNS::OuterCat::destroy"]
-    _ZN7outerNS8OuterCat4meetERNS_5CouchE -> _ZN7outerNS8OuterCat7destroyERNS_5ThingE 
-    _ZN7outerNS8OuterCat7destroyERNS_5ThingE -> _ZN7outerNS8OuterCat5shredERNS_5ThingE 
+    "_ZN7outerNS8OuterCat4meetERNS_5CouchE" -> "_ZN7outerNS8OuterCat7destroyERNS_5ThingE" 
+    "_ZN7outerNS8OuterCat7destroyERNS_5ThingE" -> "_ZN7outerNS8OuterCat5shredERNS_5ThingE" 
     "_ZN7outerNS5Thing10takeDamageEi"[label="outerNS::Thing::takeDamage"]
-    _ZN7outerNS8OuterCat5shredERNS_5ThingE -> _ZN7outerNS5Thing10takeDamageEi 
+    "_ZN7outerNS8OuterCat5shredERNS_5ThingE" -> "_ZN7outerNS5Thing10takeDamageEi" 
     "_ZN7outerNS9Superhero10takeDamageEi"[label="outerNS::Superhero::takeDamage"]
-    _ZN7outerNS9Superhero10takeDamageEi -> _ZN7outerNS5Thing10takeDamageEi 
-    _ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv -> _ZN7outerNS8OuterCat13isFriendlyCatEv 
+    "_ZN7outerNS9Superhero10takeDamageEi" -> "_ZN7outerNS5Thing10takeDamageEi" 
+    "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv" -> "_ZN7outerNS8OuterCat13isFriendlyCatEv" 
     "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv"[label="outerNS::OuterCat::isSecretlyUnfriendly"]
-    _ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv -> _ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv 
+    "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv" -> "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv" 
 }

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__json.snap
@@ -115,6 +115,10 @@ expression: sgc.to_json()
           "to": "_ZN7outerNS8OuterCat5shredERNS_5ThingE"
         },
         {
+          "from": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+          "to": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE"
+        },
+        {
           "from": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
           "to": "_ZN7outerNS5Thing10takeDamageEi"
         },

--- a/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
+++ b/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
@@ -1,0 +1,17 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(fm).unwrap()"
+---
+{
+  "file_matches": [
+    {
+      "path": "bug1446220_unicode.html"
+    },
+    {
+      "path": "mobile/androidTest/asserts/inputs.html"
+    },
+    {
+      "path": "test_DOMWindowCreated_chromeonly.html"
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/search-files/check_glob@anchored_fakewpt_doublestar_combi__json.snap
+++ b/tests/tests/checks/snapshots/search-files/check_glob@anchored_fakewpt_doublestar_combi__json.snap
@@ -1,0 +1,26 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(fm).unwrap()"
+---
+{
+  "file_matches": [
+    {
+      "path": "fake-wpt/meta/fake-standard/test_ima_disabled_wpt.js.ini"
+    },
+    {
+      "path": "fake-wpt/meta/fake-standard/test_ima_sad_subtests_wpt.js.ini"
+    },
+    {
+      "path": "fake-wpt/meta/fake-standard/test_ima_weird_meta_wpt.js.ini"
+    },
+    {
+      "path": "fake-wpt/tests/fake-standard/test_ima_disabled_wpt.js"
+    },
+    {
+      "path": "fake-wpt/tests/fake-standard/test_ima_sad_subtests_wpt.js"
+    },
+    {
+      "path": "fake-wpt/tests/fake-standard/test_ima_weird_meta_wpt.js"
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/search-files/check_glob@anchored_star_html__json.snap
+++ b/tests/tests/checks/snapshots/search-files/check_glob@anchored_star_html__json.snap
@@ -1,0 +1,14 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(fm).unwrap()"
+---
+{
+  "file_matches": [
+    {
+      "path": "bug1446220_unicode.html"
+    },
+    {
+      "path": "test_DOMWindowCreated_chromeonly.html"
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__context4__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__context4__json.snap
@@ -1,0 +1,69 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(frb).unwrap()"
+---
+{
+  "path_kind_results": [
+    {
+      "path_kind": "Normal",
+      "file_names": [],
+      "kind_groups": [
+        {
+          "kind": "Definitions",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 9,
+                  "line_range": [
+                    5,
+                    13
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-5\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"5\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n<div class=\"nesting-container nesting-depth-0\" data-nesting-sym=\"T_DoubleBase\">\n<div role=\"row\" id=\"line-6\" class=\"source-line-with-number nesting-sticky-line\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"6\"></div>\n  <code role=\"cell\" class=\"source-line\"><span class=\"syn_reserved\" >class</span> <span class=\"syn_def syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"0\" >DoubleBase</span> {\n</code>\n</div>\n\n<div role=\"row\" id=\"line-7\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"7\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >public</span>:\n</code>\n</div>\n\n<div role=\"row\" id=\"line-8\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"8\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-9\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"9\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >virtual</span> <span class=\"syn_reserved\" >void</span> <span class=\"syn_def\" data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"1\" >doublePure</span>() = 0;\n</code>\n</div>\n</div>\n<div role=\"row\" id=\"line-10\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"10\"></div>\n  <code role=\"cell\" class=\"source-line\">};\n</code>\n</div>\n\n<div role=\"row\" id=\"line-11\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"11\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n<div class=\"nesting-container nesting-depth-0\" data-nesting-sym=\"T_DoubleSubOne\">\n<div role=\"row\" id=\"line-12\" class=\"source-line-with-number nesting-sticky-line\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"12\"></div>\n  <code role=\"cell\" class=\"source-line\"><span class=\"syn_reserved\" >class</span> <span class=\"syn_def syn_type\" data-symbols=\"T_DoubleSubOne\" data-i=\"2\" >DoubleSubOne</span> : <span class=\"syn_reserved\" >public</span> <span class=\"syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"3\" >DoubleBase</span> {\n</code>\n</div>\n\n<div role=\"row\" id=\"line-13\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"13\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >public</span>:\n</code>\n</div>\n",
+                  "context": "DoubleBase",
+                  "contextsym": "T_DoubleBase"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Uses",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 64,
+                  "line_range": [
+                    60,
+                    64
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-60\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"60\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"22\" >DoubleBase</span> *<span data-symbols=\"V_a1642fb0fb5c5192_94aac9c1356\" >subTwo</span> = <span class=\"syn_reserved\" >new</span> <span class=\"syn_type\" data-symbols=\"_ZN12DoubleSubTwoC1Ev,T_DoubleSubTwo\" data-i=\"23\" >DoubleSubTwo</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-61\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"61\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleSubOne\" data-i=\"24\" >DoubleSubOne</span> <span data-symbols=\"V_c72d2fb0fb5c5192_94a37619f041780c,_ZN12DoubleSubOneC1Ev\" data-i=\"25\" >explicitOne</span>;\n</code>\n</div>\n\n<div role=\"row\" id=\"line-62\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"62\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleSubTwo\" data-i=\"26\" >DoubleSubTwo</span> <span data-symbols=\"V_dde53fb0fb5c5192_1c057619f041780c,_ZN12DoubleSubTwoC1Ev\" data-i=\"27\" >explicitTwo</span>;\n</code>\n</div>\n\n<div role=\"row\" id=\"line-63\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"63\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-64\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"64\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_20d15eb0fb5c5192_1d39c9c1356\" >subOne</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"28\" >doublePure</span>();\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                },
+                {
+                  "key_line": 65,
+                  "line_range": [
+                    65,
+                    69
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-65\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"65\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_a1642fb0fb5c5192_94aac9c1356\" >subTwo</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"29\" >doublePure</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-66\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"66\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-67\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"67\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_c72d2fb0fb5c5192_94a37619f041780c\" >explicitOne</span>.<span data-symbols=\"_ZN12DoubleSubOne10doublePureEv\" data-i=\"30\" >doublePure</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-68\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"68\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_dde53fb0fb5c5192_1c057619f041780c\" >explicitTwo</span>.<span data-symbols=\"_ZN12DoubleSubTwo10doublePureEv\" data-i=\"31\" >doublePure</span>();\n</code>\n</div>\n</div>\n<div role=\"row\" id=\"line-69\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"69\"></div>\n  <code role=\"cell\" class=\"source-line\">}\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "content_type": "text/html"
+}

--- a/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__context_alias4__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__context_alias4__json.snap
@@ -1,0 +1,69 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(frb).unwrap()"
+---
+{
+  "path_kind_results": [
+    {
+      "path_kind": "Normal",
+      "file_names": [],
+      "kind_groups": [
+        {
+          "kind": "Definitions",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 9,
+                  "line_range": [
+                    5,
+                    13
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-5\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"5\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n<div class=\"nesting-container nesting-depth-0\" data-nesting-sym=\"T_DoubleBase\">\n<div role=\"row\" id=\"line-6\" class=\"source-line-with-number nesting-sticky-line\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"6\"></div>\n  <code role=\"cell\" class=\"source-line\"><span class=\"syn_reserved\" >class</span> <span class=\"syn_def syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"0\" >DoubleBase</span> {\n</code>\n</div>\n\n<div role=\"row\" id=\"line-7\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"7\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >public</span>:\n</code>\n</div>\n\n<div role=\"row\" id=\"line-8\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"8\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-9\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"9\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >virtual</span> <span class=\"syn_reserved\" >void</span> <span class=\"syn_def\" data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"1\" >doublePure</span>() = 0;\n</code>\n</div>\n</div>\n<div role=\"row\" id=\"line-10\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"10\"></div>\n  <code role=\"cell\" class=\"source-line\">};\n</code>\n</div>\n\n<div role=\"row\" id=\"line-11\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"11\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n<div class=\"nesting-container nesting-depth-0\" data-nesting-sym=\"T_DoubleSubOne\">\n<div role=\"row\" id=\"line-12\" class=\"source-line-with-number nesting-sticky-line\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"12\"></div>\n  <code role=\"cell\" class=\"source-line\"><span class=\"syn_reserved\" >class</span> <span class=\"syn_def syn_type\" data-symbols=\"T_DoubleSubOne\" data-i=\"2\" >DoubleSubOne</span> : <span class=\"syn_reserved\" >public</span> <span class=\"syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"3\" >DoubleBase</span> {\n</code>\n</div>\n\n<div role=\"row\" id=\"line-13\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"13\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >public</span>:\n</code>\n</div>\n",
+                  "context": "DoubleBase",
+                  "contextsym": "T_DoubleBase"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Uses",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 64,
+                  "line_range": [
+                    60,
+                    64
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-60\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"60\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleBase\" data-i=\"22\" >DoubleBase</span> *<span data-symbols=\"V_a1642fb0fb5c5192_94aac9c1356\" >subTwo</span> = <span class=\"syn_reserved\" >new</span> <span class=\"syn_type\" data-symbols=\"_ZN12DoubleSubTwoC1Ev,T_DoubleSubTwo\" data-i=\"23\" >DoubleSubTwo</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-61\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"61\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleSubOne\" data-i=\"24\" >DoubleSubOne</span> <span data-symbols=\"V_c72d2fb0fb5c5192_94a37619f041780c,_ZN12DoubleSubOneC1Ev\" data-i=\"25\" >explicitOne</span>;\n</code>\n</div>\n\n<div role=\"row\" id=\"line-62\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"62\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_type\" data-symbols=\"T_DoubleSubTwo\" data-i=\"26\" >DoubleSubTwo</span> <span data-symbols=\"V_dde53fb0fb5c5192_1c057619f041780c,_ZN12DoubleSubTwoC1Ev\" data-i=\"27\" >explicitTwo</span>;\n</code>\n</div>\n\n<div role=\"row\" id=\"line-63\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"63\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-64\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"64\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_20d15eb0fb5c5192_1d39c9c1356\" >subOne</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"28\" >doublePure</span>();\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                },
+                {
+                  "key_line": 65,
+                  "line_range": [
+                    65,
+                    69
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-65\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"65\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_a1642fb0fb5c5192_94aac9c1356\" >subTwo</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"29\" >doublePure</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-66\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"66\"></div>\n  <code role=\"cell\" class=\"source-line\">\n</code>\n</div>\n\n<div role=\"row\" id=\"line-67\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"67\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_c72d2fb0fb5c5192_94a37619f041780c\" >explicitOne</span>.<span data-symbols=\"_ZN12DoubleSubOne10doublePureEv\" data-i=\"30\" >doublePure</span>();\n</code>\n</div>\n\n<div role=\"row\" id=\"line-68\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"68\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_dde53fb0fb5c5192_1c057619f041780c\" >explicitTwo</span>.<span data-symbols=\"_ZN12DoubleSubTwo10doublePureEv\" data-i=\"31\" >doublePure</span>();\n</code>\n</div>\n</div>\n<div role=\"row\" id=\"line-69\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"69\"></div>\n  <code role=\"cell\" class=\"source-line\">}\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "content_type": "text/html"
+}

--- a/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/overs.cpp/check_glob@query__doublePure__json.snap
@@ -1,0 +1,69 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(frb).unwrap()"
+---
+{
+  "path_kind_results": [
+    {
+      "path_kind": "Normal",
+      "file_names": [],
+      "kind_groups": [
+        {
+          "kind": "Definitions",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 9,
+                  "line_range": [
+                    9,
+                    9
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-9\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"9\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span class=\"syn_reserved\" >virtual</span> <span class=\"syn_reserved\" >void</span> <span class=\"syn_def\" data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"1\" >doublePure</span>() = 0;\n</code>\n</div>\n</div>",
+                  "context": "DoubleBase",
+                  "contextsym": "T_DoubleBase"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "Uses",
+          "pretty": "DoubleBase::doublePure",
+          "facets": [],
+          "by_file": [
+            {
+              "file": "overs.cpp",
+              "line_spans": [
+                {
+                  "key_line": 64,
+                  "line_range": [
+                    64,
+                    64
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-64\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"64\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_20d15eb0fb5c5192_1d39c9c1356\" >subOne</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"28\" >doublePure</span>();\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                },
+                {
+                  "key_line": 65,
+                  "line_range": [
+                    65,
+                    65
+                  ],
+                  "contents": "<div role=\"row\" id=\"line-65\" class=\"source-line-with-number\">\n  <div role=\"cell\"><div class=\"cov-strip cov-no-data\"></div></div>\n  <div role=\"cell\"><div class=\"blame-strip\"></div></div>\n  <div role=\"cell\" class=\"line-number\" data-line-number=\"65\"></div>\n  <code role=\"cell\" class=\"source-line\">  <span data-symbols=\"V_a1642fb0fb5c5192_94aac9c1356\" >subTwo</span>-><span data-symbols=\"_ZN10DoubleBase10doublePureEv\" data-i=\"29\" >doublePure</span>();\n</code>\n</div>\n",
+                  "context": "generateDoubleUses",
+                  "contextsym": "_Z18generateDoubleUsesv"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "content_type": "text/html"
+}

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
@@ -4,7 +4,19 @@ expression: "&jv.value"
 ---
 {
   "groups": {
+    "display": {
+      "input": "compiled",
+      "segments": [
+        {
+          "command": "show-html",
+          "args": []
+        }
+      ],
+      "output": "result",
+      "depth": 0
+    },
     "file-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-files",
@@ -12,9 +24,12 @@ expression: "&jv.value"
             "foo.bar+hats()"
           ]
         }
-      ]
+      ],
+      "output": "file-search",
+      "depth": 0
     },
     "semantic-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-identifiers",
@@ -22,9 +37,12 @@ expression: "&jv.value"
             "foo.bar+hats()"
           ]
         }
-      ]
+      ],
+      "output": "semantic-search",
+      "depth": 0
     },
     "text-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-text",
@@ -32,7 +50,24 @@ expression: "&jv.value"
             "--re='foo\\.bar\\+hats\\(\\)'"
           ]
         }
-      ]
+      ],
+      "output": "text-search",
+      "depth": 0
+    }
+  },
+  "junctions": {
+    "compile": {
+      "inputs": [
+        "file-search",
+        "semantic-search",
+        "text-search"
+      ],
+      "command": {
+        "command": "compile-results",
+        "args": []
+      },
+      "output": "compiled",
+      "depth": 0
     }
   }
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
@@ -8,7 +8,7 @@ expression: "&jv.value"
       "input": "compiled",
       "segments": [
         {
-          "command": "show-html",
+          "command": "augment-results",
           "args": []
         }
       ],
@@ -36,6 +36,14 @@ expression: "&jv.value"
           "args": [
             "foo.bar+hats()"
           ]
+        },
+        {
+          "command": "crossref-lookup",
+          "args": []
+        },
+        {
+          "command": "crossref-expand",
+          "args": []
         }
       ],
       "output": "semantic-search",

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__needs_regexp_escape__json.snap
@@ -69,5 +69,31 @@ expression: "&jv.value"
       "output": "compiled",
       "depth": 0
     }
-  }
+  },
+  "phases": [
+    {
+      "groups": [
+        [
+          "file-search"
+        ],
+        [
+          "semantic-search"
+        ],
+        [
+          "text-search"
+        ]
+      ],
+      "junctions": [
+        "compile"
+      ]
+    },
+    {
+      "groups": [
+        [
+          "display"
+        ]
+      ],
+      "junctions": []
+    }
+  ]
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__quoted_phrase__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__quoted_phrase__json.snap
@@ -4,7 +4,19 @@ expression: "&jv.value"
 ---
 {
   "groups": {
+    "display": {
+      "input": "compiled",
+      "segments": [
+        {
+          "command": "show-html",
+          "args": []
+        }
+      ],
+      "output": "result",
+      "depth": 0
+    },
     "file-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-files",
@@ -12,9 +24,12 @@ expression: "&jv.value"
             "foo bar"
           ]
         }
-      ]
+      ],
+      "output": "file-search",
+      "depth": 0
     },
     "semantic-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-identifiers",
@@ -22,9 +37,12 @@ expression: "&jv.value"
             "foo bar"
           ]
         }
-      ]
+      ],
+      "output": "semantic-search",
+      "depth": 0
     },
     "text-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-text",
@@ -32,7 +50,24 @@ expression: "&jv.value"
             "--re='foo bar'"
           ]
         }
-      ]
+      ],
+      "output": "text-search",
+      "depth": 0
+    }
+  },
+  "junctions": {
+    "compile": {
+      "inputs": [
+        "file-search",
+        "semantic-search",
+        "text-search"
+      ],
+      "command": {
+        "command": "compile-results",
+        "args": []
+      },
+      "output": "compiled",
+      "depth": 0
     }
   }
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__quoted_phrase__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__quoted_phrase__json.snap
@@ -69,5 +69,31 @@ expression: "&jv.value"
       "output": "compiled",
       "depth": 0
     }
-  }
+  },
+  "phases": [
+    {
+      "groups": [
+        [
+          "file-search"
+        ],
+        [
+          "semantic-search"
+        ],
+        [
+          "text-search"
+        ]
+      ],
+      "junctions": [
+        "compile"
+      ]
+    },
+    {
+      "groups": [
+        [
+          "display"
+        ]
+      ],
+      "junctions": []
+    }
+  ]
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
@@ -8,7 +8,7 @@ expression: "&jv.value"
       "input": "compiled",
       "segments": [
         {
-          "command": "show-html",
+          "command": "augment-results",
           "args": []
         }
       ],
@@ -36,6 +36,14 @@ expression: "&jv.value"
           "args": [
             "foo"
           ]
+        },
+        {
+          "command": "crossref-lookup",
+          "args": []
+        },
+        {
+          "command": "crossref-expand",
+          "args": []
         }
       ],
       "output": "semantic-search",

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
@@ -4,7 +4,19 @@ expression: "&jv.value"
 ---
 {
   "groups": {
+    "display": {
+      "input": "compiled",
+      "segments": [
+        {
+          "command": "show-html",
+          "args": []
+        }
+      ],
+      "output": "result",
+      "depth": 0
+    },
     "file-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-files",
@@ -12,9 +24,12 @@ expression: "&jv.value"
             "foo"
           ]
         }
-      ]
+      ],
+      "output": "file-search",
+      "depth": 0
     },
     "semantic-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-identifiers",
@@ -22,9 +37,12 @@ expression: "&jv.value"
             "foo"
           ]
         }
-      ]
+      ],
+      "output": "semantic-search",
+      "depth": 0
     },
     "text-search": {
+      "input": null,
       "segments": [
         {
           "command": "search-text",
@@ -32,7 +50,24 @@ expression: "&jv.value"
             "--re=foo"
           ]
         }
-      ]
+      ],
+      "output": "text-search",
+      "depth": 0
+    }
+  },
+  "junctions": {
+    "compile": {
+      "inputs": [
+        "file-search",
+        "semantic-search",
+        "text-search"
+      ],
+      "command": {
+        "command": "compile-results",
+        "args": []
+      },
+      "output": "compiled",
+      "depth": 0
     }
   }
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/check_glob@default__unquoted_word__json.snap
@@ -69,5 +69,31 @@ expression: "&jv.value"
       "output": "compiled",
       "depth": 0
     }
-  }
+  },
+  "phases": [
+    {
+      "groups": [
+        [
+          "file-search"
+        ],
+        [
+          "semantic-search"
+        ],
+        [
+          "text-search"
+        ]
+      ],
+      "junctions": [
+        "compile"
+      ]
+    },
+    {
+      "groups": [
+        [
+          "display"
+        ]
+      ],
+      "junctions": []
+    }
+  ]
 }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/overs.cpp/check_glob@query__parse__doublePure__context4__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/overs.cpp/check_glob@query__parse__doublePure__context4__json.snap
@@ -9,7 +9,10 @@ expression: "&jv.value"
       "segments": [
         {
           "command": "augment-results",
-          "args": []
+          "args": [
+            "--after=4",
+            "--before=4"
+          ]
         }
       ],
       "output": "result",
@@ -21,7 +24,7 @@ expression: "&jv.value"
         {
           "command": "search-files",
           "args": [
-            "foo bar"
+            "DoubleBase::doublePure"
           ]
         }
       ],
@@ -34,7 +37,7 @@ expression: "&jv.value"
         {
           "command": "search-identifiers",
           "args": [
-            "foo bar"
+            "DoubleBase::doublePure"
           ]
         },
         {
@@ -55,7 +58,7 @@ expression: "&jv.value"
         {
           "command": "search-text",
           "args": [
-            "--re='foo bar'"
+            "--re=DoubleBase::doublePure"
           ]
         }
       ],

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/overs.cpp/check_glob@query__parse__doublePure__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/overs.cpp/check_glob@query__parse__doublePure__json.snap
@@ -21,7 +21,7 @@ expression: "&jv.value"
         {
           "command": "search-files",
           "args": [
-            "foo bar"
+            "DoubleBase::doublePure"
           ]
         }
       ],
@@ -34,7 +34,7 @@ expression: "&jv.value"
         {
           "command": "search-identifiers",
           "args": [
-            "foo bar"
+            "DoubleBase::doublePure"
           ]
         },
         {
@@ -55,7 +55,7 @@ expression: "&jv.value"
         {
           "command": "search-text",
           "args": [
-            "--re='foo bar'"
+            "--re=DoubleBase::doublePure"
           ]
         }
       ],

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -43,7 +43,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -107,7 +107,7 @@ checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
  "hermit-abi",
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -321,7 +321,7 @@ dependencies = [
  "libc",
  "once_cell",
  "terminal_size",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -451,7 +451,7 @@ checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
 dependencies = [
  "libc",
  "redox_users",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -603,16 +603,6 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding 2.1.0",
-]
-
-[[package]]
-name = "fs2"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
-dependencies = [
- "libc",
- "winapi 0.3.9",
 ]
 
 [[package]]
@@ -1151,16 +1141,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-dependencies = [
- "winapi 0.2.8",
- "winapi-build",
-]
-
-[[package]]
 name = "kstring"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,15 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
-name = "memmap"
-version = "0.5.2"
+name = "memmap2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f3c7359028b31999287dae4e5047ddfe90a23b7dca2282ce759b491080c99b"
+checksum = "057a3db23999c867821a7a59feb06a578fcb03685e983dff90daf9e7d24ac08f"
 dependencies = [
- "fs2",
- "kernel32-sys",
  "libc",
- "winapi 0.2.8",
 ]
 
 [[package]]
@@ -1490,7 +1467,7 @@ dependencies = [
  "log 0.4.14",
  "miow",
  "ntapi",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1499,7 +1476,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1544,7 +1521,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -1674,7 +1651,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2175,7 +2152,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2298,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
  "lazy_static",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2491,7 +2468,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2589,7 +2566,7 @@ dependencies = [
  "rand 0.8.4",
  "redox_syscall",
  "remove_dir_all",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2600,7 +2577,7 @@ checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
 dependencies = [
  "dirs-next",
  "rustversion",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2619,7 +2596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2682,7 +2659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2740,7 +2717,7 @@ dependencies = [
  "num_cpus",
  "pin-project-lite",
  "tokio-macros",
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -2912,7 +2889,7 @@ dependencies = [
  "lol_html",
  "malloc_size_of",
  "malloc_size_of_derive",
- "memmap",
+ "memmap2",
  "num_cpus",
  "petgraph 0.6.0",
  "prost",
@@ -3233,7 +3210,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
 dependencies = [
  "same-file",
- "winapi 0.3.9",
+ "winapi",
  "winapi-util",
 ]
 
@@ -3348,12 +3325,6 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-
-[[package]]
-name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
@@ -3361,12 +3332,6 @@ dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",
 ]
-
-[[package]]
-name = "winapi-build"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 
 [[package]]
 name = "winapi-i686-pc-windows-gnu"
@@ -3380,7 +3345,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]
@@ -3395,7 +3360,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
 dependencies = [
- "winapi 0.3.9",
+ "winapi",
 ]
 
 [[package]]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -40,7 +40,7 @@ log = "0.4.0"
 lol_html = { git = "https://github.com/cloudflare/lol-html", rev = "8860fa455db627a5c227d014e1cecbe1832eb0ed" }
 malloc_size_of = { path = "./malloc_size_of" }
 malloc_size_of_derive = "0.1"
-memmap = "0.5.0"
+memmap = { package = "memmap2", version = "0.5.3" }
 num_cpus = "1"
 petgraph = "0.6.0"
 prost = "0.10.1"

--- a/tools/src/abstract_server/mod.rs
+++ b/tools/src/abstract_server/mod.rs
@@ -2,7 +2,7 @@ mod local_index;
 mod remote_server;
 mod server_interface;
 
-pub use local_index::make_local_server;
+pub use local_index::{make_all_local_servers, make_local_server};
 pub use remote_server::make_remote_server;
 pub use server_interface::{
     AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError, TextMatches, TextMatchesByFile,

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -117,6 +117,11 @@ impl AbstractServer for RemoteServer {
         Err(ServerError::Unsupported)
     }
 
+    async fn search_files(&self, _pathre: &str, _limit: usize) -> Result<Vec<String>> {
+        // Not yet; see interface comment.
+        Err(ServerError::Unsupported)
+    }
+
     async fn search_identifiers(&self, _needle: &str, _exact_match: bool, _ignore_case: bool, _match_limit: usize) -> Result<Vec<(String, String)>> {
         // Same rationale as crossref_lookup.
         Err(ServerError::Unsupported)

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -27,7 +27,7 @@ impl From<ParseError> for ServerError {
 }
 
 #[allow(dead_code)]
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 struct RemoteServer {
     server_base_url: Url,
     tree_base_url: Url,
@@ -84,6 +84,10 @@ async fn get_json(url: Url) -> Result<reqwest::Response> {
 
 #[async_trait]
 impl AbstractServer for RemoteServer {
+    fn clonify(&self) -> Box<dyn AbstractServer + Send + Sync> {
+        Box::new(self.clone())
+    }
+
     fn translate_analysis_path(&self, _sf_path: &str) -> Result<String> {
         // Remote servers don't have local filesystem paths.
         Err(ServerError::Unsupported)

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -36,6 +36,9 @@ pub enum ErrorLayer {
     /// (Our "insta" checks of course help avoid such problems becoming serious
     /// silent errors, as they would/should not be quieted.)
     BadInput,
+    /// The problem seems to involve configuration data, for example in the
+    /// query to pipeline mappings.
+    ConfigLayer,
     /// The error seems to involve server logic, so it may or may not be an issue
     /// with the underlying data.
     ServerLayer,

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use axum::response::{IntoResponse, Response};
+use axum::http::StatusCode;
 use futures_core::stream::BoxStream;
 use serde::Serialize;
 use serde_json::Value;
@@ -34,6 +36,13 @@ impl From<tokio::task::JoinError> for ServerError {
             layer: ErrorLayer::RuntimeInvariantViolation,
             message: format!("task panicked?: {}", err.to_string())
         })
+    }
+}
+
+impl IntoResponse for ServerError {
+    fn into_response(self) -> Response {
+        let body = format!("Error: {:#?}", self);
+        (StatusCode::INTERNAL_SERVER_ERROR, body).into_response()
     }
 }
 

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -28,6 +28,15 @@ impl From<regex::Error> for ServerError {
     }
 }
 
+impl From<tokio::task::JoinError> for ServerError {
+    fn from(err: tokio::task::JoinError) -> ServerError {
+        ServerError::StickyProblem(ErrorDetails {
+            layer: ErrorLayer::RuntimeInvariantViolation,
+            message: format!("task panicked?: {}", err.to_string())
+        })
+    }
+}
+
 /// Express whether the error seems to be happening in the server or the data.
 #[derive(Debug)]
 pub enum ErrorLayer {
@@ -160,6 +169,8 @@ pub struct TextMatches {
 ///
 #[async_trait]
 pub trait AbstractServer {
+    fn clonify(&self) -> Box<dyn AbstractServer + Send + Sync>;
+
     /// Convert a searchfox tree-local path into an absolute analysis path on
     /// disk.  This fundamentally only works for local indices.
     fn translate_analysis_path(&self, sf_path: &str) -> Result<String>;

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -9,42 +9,21 @@ use std::io::Write;
 
 extern crate env_logger;
 
-use serde::Serialize;
 use serde_json::{json, Map};
 extern crate tools;
-use tools::config;
-use tools::file_format::analysis::LineRange;
-use tools::file_format::analysis::{read_analysis, read_structured, read_target, AnalysisKind};
-use tools::find_source_file;
-use ustr::{ustr, Ustr};
+use tools::{
+    config,
+    file_format::analysis::{
+        read_analysis, read_structured, read_target, AnalysisKind, SearchResult,
+    },
+    find_source_file,
+};
+use ustr::ustr;
 
 /// The size for a payload line (inclusive of leading indicating character and
 /// newline) at which we store it externally in `crossref-extra` instead of
 /// inline in the `crossref` file itself.
 const EXTERNAL_STORAGE_THRESHOLD: usize = 1024 * 3;
-
-#[derive(Clone, Debug, Serialize)]
-struct SearchResult {
-    #[serde(rename = "lno")]
-    lineno: u32,
-    bounds: (u32, u32),
-    line: Ustr,
-    context: Ustr,
-    contextsym: Ustr,
-    // We use to build up "peekLines" which we excerpted from the file here, but
-    // this was never surfaced to users.  The plan at the time had been to try
-    // and store specific file offsets that could be directly mapped/seeked, but
-    // between effective caching of dynamic search results and good experiences
-    // with lol_html, it seems like we will soon be able to just excerpt the
-    // statically produced HTML efficiently enough through dynamic HTML
-    // filtering.
-    #[serde(
-        rename = "peekRange",
-        default,
-        skip_serializing_if = "LineRange::is_empty"
-    )]
-    peek_range: LineRange,
-}
 
 fn split_scopes(id: &str) -> Vec<String> {
     let mut result = Vec::new();

--- a/tools/src/bin/pipeline-server.rs
+++ b/tools/src/bin/pipeline-server.rs
@@ -1,12 +1,50 @@
-use axum::{routing::get, Router};
+use std::{sync::Arc, env, collections::{BTreeMap, HashMap}};
 
-//async fn handle_pipeline()
+use axum::{http::StatusCode, extract::{Path, Query}, routing::get, Router, Extension, Json, response::{IntoResponse, Response}};
+use tools::{abstract_server::{AbstractServer, make_all_local_servers, ServerError}, query::chew_query::chew_query, cmd_pipeline::builder::build_pipeline_graph};
+
+
+async fn handle_query(
+    local_servers: Extension<Arc<BTreeMap<String, Box<dyn AbstractServer + Send + Sync>>>>,
+    Path((tree, preset)): Path<(String, String)>,
+    Query(params): Query<HashMap<String, String>>
+) -> Result<Response, ServerError> {
+    let server = match local_servers.get(&tree) {
+        Some(s) => s,
+        None => {
+            return Ok((StatusCode::NOT_FOUND, format!("No such tree: {}", tree)).into_response());
+        }
+    };
+
+    if preset.as_str() != "default" {
+        return Ok((StatusCode::NOT_FOUND, format!("No such preset: {}", preset)).into_response());
+    }
+
+    let query = match params.get("q") {
+        Some(q) => q,
+        None => {
+            return Ok((StatusCode::BAD_REQUEST, "No 'q' parameter, no results!").into_response());
+
+        }
+    };
+
+    let pipeline_plan = chew_query(query)?;
+
+    let graph = build_pipeline_graph(server.clonify(), pipeline_plan)?;
+
+    let result = graph.run(true).await?;
+
+    Ok(Json(result).into_response())
+}
 
 #[tokio::main]
 async fn main() {
+    let local_servers = Arc::new(make_all_local_servers(&env::args().nth(1).unwrap()).unwrap());
+
     // build our application with a single route
     let app = Router::new()
-        .route("/:tree/query/:preset", get(|| async { "Hello, World!" }));
+        .route("/:tree/query/:preset", get(handle_query))
+        .layer(Extension(local_servers));
 
     axum::Server::bind(&"0.0.0.0:8002".parse().unwrap())
         .serve(app.into_make_service())

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -139,6 +139,10 @@ async fn main() {
             emit_json(&jv.value);
             0
         }
+        Ok(PipelineValues::FileMatches(fm)) => {
+            emit_json(&to_value(fm).unwrap());
+            0
+        }
         Ok(PipelineValues::TextMatches(tm)) => {
             emit_json(&to_value(tm).unwrap());
             0

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -82,18 +82,7 @@ async fn main() {
             0
         }
         Ok(PipelineValues::SymbolList(sl)) => {
-            match sl.from_identifiers {
-                Some(identifiers) => {
-                    for (sym, ident) in sl.symbols.iter().zip(identifiers.iter()) {
-                        println!("{} from {}", sym, ident);
-                    }
-                }
-                None => {
-                    for sym in sl.symbols {
-                        println!("{}", sym);
-                    }
-                }
-            }
+            emit_json(&to_value(sl).unwrap());
             0
         }
         Ok(PipelineValues::SymbolCrossrefInfoList(sl)) => {

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -95,10 +95,6 @@ async fn main() {
             emit_json(&sgc.to_json());
             0
         }
-        Ok(PipelineValues::StructuredResultsBundle(srb)) => {
-            emit_json(&to_value(srb).unwrap());
-            0
-        }
         Ok(PipelineValues::FlattenedResultsBundle(frb)) => {
             emit_json(&to_value(frb).unwrap());
             0

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -243,9 +243,12 @@ fn handle(
         }
 
         "complete" => {
-            let ids = ident_map.get(&tree_name.to_string()).unwrap();
-            let json = ids.lookup_json(&path[2], false, false, 6);
-            WebResponse::json(json)
+            if let Some(ids) = ident_map.get(&tree_name.to_string()) {
+                let json = ids.lookup_json(&path[2], false, false, 6);
+                WebResponse::json(json)
+            } else {
+                return WebResponse::not_found();
+            }
         }
 
         _ => WebResponse::not_found(),

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -3,7 +3,6 @@ use crate::{
         cmd_prod_filter::ProductionFilterCommand, cmd_query::QueryCommand,
         cmd_search_text::SearchTextCommand, PipelineCommand,
     },
-    query::chew_query::QueryPipelineGroupBuilder,
     structopt::StructOpt,
 };
 use tracing::{trace, trace_span};
@@ -22,7 +21,7 @@ use super::cmd_traverse::TraverseCommand;
 use super::{
     cmd_crossref_lookup::CrossrefLookupCommand, cmd_filter_analysis::FilterAnalysisCommand,
     cmd_graph::GraphCommand, cmd_merge_analyses::MergeAnalysesCommand,
-    cmd_search_identifiers::SearchIdentifiersCommand, interface::ServerPipelineGraph,
+    cmd_search_identifiers::SearchIdentifiersCommand,
 };
 
 use super::interface::ServerPipeline;

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -16,7 +16,7 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_search::SearchCommand, cmd_search_files::SearchFilesCommand};
+use super::{cmd_search::SearchCommand, cmd_search_files::SearchFilesCommand, cmd_crossref_expand::CrossrefExpandCommand};
 use super::cmd_show_html::ShowHtmlCommand;
 use super::cmd_traverse::TraverseCommand;
 use super::{
@@ -29,6 +29,8 @@ use super::interface::ServerPipeline;
 
 pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand>> {
     match opts.cmd {
+        Command::CrossrefExpand(ce) => Ok(Box::new(CrossrefExpandCommand { args: ce })),
+
         Command::CrossrefLookup(cl) => Ok(Box::new(CrossrefLookupCommand { args: cl })),
 
         Command::FilterAnalysis(fa) => Ok(Box::new(FilterAnalysisCommand { args: fa })),

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -1,8 +1,10 @@
 use crate::{
+    abstract_server::AbstractServer,
     cmd_pipeline::{
         cmd_prod_filter::ProductionFilterCommand, cmd_query::QueryCommand,
-        cmd_search_text::SearchTextCommand, PipelineCommand,
+        cmd_search_text::SearchTextCommand, interface::JunctionInvocation, PipelineCommand,
     },
+    query::chew_query::QueryPipelineGroupBuilder,
     structopt::StructOpt,
 };
 use tracing::{trace, trace_span};
@@ -15,19 +17,28 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_search::SearchCommand, cmd_search_files::SearchFilesCommand, cmd_crossref_expand::CrossrefExpandCommand};
-use super::cmd_show_html::ShowHtmlCommand;
-use super::cmd_traverse::TraverseCommand;
+use super::{cmd_augment_results::AugmentResultsCommand, cmd_traverse::TraverseCommand};
+use super::{
+    cmd_compile_results::CompileResultsCommand,
+    cmd_crossref_expand::CrossrefExpandCommand,
+    cmd_search::SearchCommand,
+    cmd_search_files::SearchFilesCommand,
+    interface::{NamedPipeline, PipelineJunctionCommand, ServerPipelineGraph},
+    parser::{JunctionCommand, JunctionOpts},
+};
 use super::{
     cmd_crossref_lookup::CrossrefLookupCommand, cmd_filter_analysis::FilterAnalysisCommand,
     cmd_graph::GraphCommand, cmd_merge_analyses::MergeAnalysesCommand,
     cmd_search_identifiers::SearchIdentifiersCommand,
 };
+use super::{cmd_show_html::ShowHtmlCommand, interface::ParallelPipelines};
 
 use super::interface::ServerPipeline;
 
-pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand>> {
+pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand + Send + Sync>> {
     match opts.cmd {
+        Command::AugmentResults(ar) => Ok(Box::new(AugmentResultsCommand { args: ar })),
+
         Command::CrossrefExpand(ce) => Ok(Box::new(CrossrefExpandCommand { args: ce })),
 
         Command::CrossrefLookup(cl) => Ok(Box::new(CrossrefLookupCommand { args: cl })),
@@ -53,6 +64,14 @@ pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand>>
         Command::ShowHtml(sh) => Ok(Box::new(ShowHtmlCommand { args: sh })),
 
         Command::Traverse(t) => Ok(Box::new(TraverseCommand { args: t })),
+    }
+}
+
+pub fn fab_junction_from_opts(
+    opts: JunctionOpts,
+) -> Result<Box<dyn PipelineJunctionCommand + Send + Sync>> {
+    match opts.cmd {
+        JunctionCommand::CompileResults(cr) => Ok(Box::new(CompileResultsCommand { args: cr })),
     }
 }
 
@@ -82,7 +101,7 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
     let mut output_format = None;
     let mut first_time = true;
 
-    let mut commands: Vec<Box<dyn PipelineCommand>> = vec![];
+    let mut commands: Vec<Box<dyn PipelineCommand + Send + Sync>> = vec![];
 
     for arg_slices in all_args.split(|v| v == "|") {
         let mut fake_args = vec![bin_name.to_string()];
@@ -122,8 +141,127 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
     ))
 }
 
-/*
-pub fn build_pipeline_graph(query: QueryPipelineGroupBuilder) -> ServerPipelineGraph {
+pub fn build_pipeline_graph(
+    server: Box<dyn AbstractServer + Send + Sync>,
+    query: QueryPipelineGroupBuilder,
+) -> Result<ServerPipelineGraph> {
+    let mut pipelines = vec![];
+    for phase in query.phases {
+        let mut phase_pipelines = vec![];
+        for groups_in_pipeline in phase.groups {
+            let mut commands = vec![];
+            let mut first = true;
+            let mut input_name = None;
+            let mut output_name = "".to_string();
+            for group_name in groups_in_pipeline {
+                let group_info = query.groups.get(&group_name).ok_or_else(|| {
+                    // This really shouldn't happen.
+                    ServerError::StickyProblem(ErrorDetails {
+                        layer: ErrorLayer::RuntimeInvariantViolation,
+                        message: format!("bad group name somehow: {}", group_name),
+                    })
+                })?;
+                if first {
+                    first = false;
+                    input_name = group_info.input.clone();
+                }
 
+                for segment in &group_info.segments {
+                    // The args needs to include a fake binary name, then the
+                    // command, then the args.
+                    let full_args: Vec<String> =
+                        vec!["searchfox-tool".to_string(), segment.command.clone()]
+                            .iter()
+                            .chain(&segment.args)
+                            .cloned()
+                            .collect();
+                    let opts = match ToolOpts::from_iter_safe(full_args) {
+                        Ok(opts) => opts,
+                        Err(err) => {
+                            return Err(ServerError::StickyProblem(ErrorDetails {
+                                layer: ErrorLayer::BadInput,
+                                message: err.to_string(),
+                            }));
+                        }
+                    };
+
+                    trace!(cmd = ?opts.cmd);
+                    commands.push(fab_command_from_opts(opts)?);
+                }
+
+                output_name = group_info
+                    .output
+                    .as_ref()
+                    .ok_or_else(|| {
+                        // This really shouldn't happen.
+                        ServerError::StickyProblem(ErrorDetails {
+                            layer: ErrorLayer::RuntimeInvariantViolation,
+                            message: format!("pipeline lacking output: {}", group_name),
+                        })
+                    })?
+                    .clone();
+            }
+            phase_pipelines.push(NamedPipeline {
+                input_name,
+                output_name,
+                commands,
+            });
+        }
+
+        let mut phase_junctions = vec![];
+        for junction_name in phase.junctions {
+            let junction_info = query.junctions.get(&junction_name).ok_or_else(|| {
+                // This really shouldn't happen.
+                ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::RuntimeInvariantViolation,
+                    message: format!("bad junction name somehow: {}", junction_name),
+                })
+            })?;
+
+            let full_args: Vec<String> = vec![
+                "searchfox-tool".to_string(),
+                junction_info.command.command.clone(),
+            ]
+            .iter()
+            .chain(&junction_info.command.args)
+            .cloned()
+            .collect();
+            let opts = match JunctionOpts::from_iter_safe(full_args) {
+                Ok(opts) => opts,
+                Err(err) => {
+                    return Err(ServerError::StickyProblem(ErrorDetails {
+                        layer: ErrorLayer::BadInput,
+                        message: err.to_string(),
+                    }));
+                }
+            };
+
+            trace!(cmd = ?opts.cmd);
+            let command = fab_junction_from_opts(opts)?;
+
+            let invoc = JunctionInvocation {
+                input_names: junction_info.inputs.clone(),
+                output_name: junction_info
+                    .output
+                    .as_ref()
+                    .ok_or_else(|| {
+                        // This really shouldn't happen.
+                        ServerError::StickyProblem(ErrorDetails {
+                            layer: ErrorLayer::RuntimeInvariantViolation,
+                            message: format!("junction lacking output: {}", junction_name),
+                        })
+                    })?
+                    .clone(),
+                command,
+            };
+            phase_junctions.push(invoc);
+        }
+
+        pipelines.push(ParallelPipelines {
+            pipelines: phase_pipelines,
+            junctions: phase_junctions,
+        });
+    }
+
+    Ok(ServerPipelineGraph { server, pipelines })
 }
-*/

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -1,4 +1,11 @@
-use crate::{cmd_pipeline::{PipelineCommand, cmd_prod_filter::ProductionFilterCommand, cmd_query::QueryCommand, cmd_search_text::SearchTextCommand}, structopt::StructOpt, query::chew_query::QueryPipelineGroupBuilder};
+use crate::{
+    cmd_pipeline::{
+        cmd_prod_filter::ProductionFilterCommand, cmd_query::QueryCommand,
+        cmd_search_text::SearchTextCommand, PipelineCommand,
+    },
+    query::chew_query::QueryPipelineGroupBuilder,
+    structopt::StructOpt,
+};
 use tracing::{trace, trace_span};
 use url::Url;
 
@@ -9,61 +16,44 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_filter_analysis::FilterAnalysisCommand, cmd_merge_analyses::MergeAnalysesCommand, cmd_crossref_lookup::CrossrefLookupCommand, cmd_search_identifiers::SearchIdentifiersCommand, cmd_graph::GraphCommand, interface::ServerPipelineGraph};
-use super::cmd_search::SearchCommand;
+use super::{cmd_search::SearchCommand, cmd_search_files::SearchFilesCommand};
 use super::cmd_show_html::ShowHtmlCommand;
 use super::cmd_traverse::TraverseCommand;
+use super::{
+    cmd_crossref_lookup::CrossrefLookupCommand, cmd_filter_analysis::FilterAnalysisCommand,
+    cmd_graph::GraphCommand, cmd_merge_analyses::MergeAnalysesCommand,
+    cmd_search_identifiers::SearchIdentifiersCommand, interface::ServerPipelineGraph,
+};
 
 use super::interface::ServerPipeline;
 
 pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand>> {
     match opts.cmd {
-        Command::CrossrefLookup(cl) => {
-            Ok(Box::new(CrossrefLookupCommand { args: cl }))
-        }
+        Command::CrossrefLookup(cl) => Ok(Box::new(CrossrefLookupCommand { args: cl })),
 
-        Command::FilterAnalysis(fa) => {
-            Ok(Box::new(FilterAnalysisCommand { args: fa }))
-        }
+        Command::FilterAnalysis(fa) => Ok(Box::new(FilterAnalysisCommand { args: fa })),
 
-        Command::Graph(g) => {
-            Ok(Box::new(GraphCommand { args: g }))
-        }
+        Command::Graph(g) => Ok(Box::new(GraphCommand { args: g })),
 
-        Command::MergeAnalyses(ma) => {
-            Ok(Box::new(MergeAnalysesCommand{ args: ma }))
-        }
+        Command::MergeAnalyses(ma) => Ok(Box::new(MergeAnalysesCommand { args: ma })),
 
-        Command::ProductionFilter(pf) => {
-            Ok(Box::new(ProductionFilterCommand { args: pf }))
-        }
+        Command::ProductionFilter(pf) => Ok(Box::new(ProductionFilterCommand { args: pf })),
 
-        Command::Query(q) => {
-            Ok(Box::new(QueryCommand { args: q }))
-        }
+        Command::Query(q) => Ok(Box::new(QueryCommand { args: q })),
 
-        Command::Search(q) => {
-            Ok(Box::new(SearchCommand { args: q }))
-        }
+        Command::Search(q) => Ok(Box::new(SearchCommand { args: q })),
 
-        Command::SearchIdentifiers(si) => {
-            Ok(Box::new(SearchIdentifiersCommand { args: si }))
-        },
+        Command::SearchFiles(sf) => Ok(Box::new(SearchFilesCommand { args: sf })),
 
-        Command::SearchText(st) => {
-            Ok(Box::new(SearchTextCommand { args: st }))
-        }
+        Command::SearchIdentifiers(si) => Ok(Box::new(SearchIdentifiersCommand { args: si })),
 
-        Command::ShowHtml(sh) => {
-            Ok(Box::new(ShowHtmlCommand { args: sh }))
-        }
+        Command::SearchText(st) => Ok(Box::new(SearchTextCommand { args: st })),
 
-        Command::Traverse(t) => {
-            Ok(Box::new(TraverseCommand { args: t }))
-        }
+        Command::ShowHtml(sh) => Ok(Box::new(ShowHtmlCommand { args: sh })),
+
+        Command::Traverse(t) => Ok(Box::new(TraverseCommand { args: t })),
     }
 }
-
 
 /// Build a command pipeline from a shell-y string where we use pipe boundaries
 /// to delineate the separate pipeline steps.
@@ -120,7 +110,6 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
         trace!(cmd = ?opts.cmd);
         commands.push(fab_command_from_opts(opts)?);
     }
-
 
     Ok((
         ServerPipeline {

--- a/tools/src/cmd_pipeline/cmd_augment_results.rs
+++ b/tools/src/cmd_pipeline/cmd_augment_results.rs
@@ -1,0 +1,181 @@
+use std::{cell::Cell, collections::HashMap};
+
+use async_trait::async_trait;
+use lol_html::{element, HtmlRewriter, Settings};
+use structopt::StructOpt;
+
+use super::interface::{PipelineCommand, PipelineValues};
+use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+/// Augment a FlattenedResultsBundle by scraping the rendered HTML output files
+/// for lines of interest plus any context, plus applying any predicates that
+/// run against data baked into the output file (like coverage data or history
+/// data).
+///
+/// It's possible the performance for this will be horrible, although it may be
+/// possible to throw some of the following at this model:
+/// - Having the HTML line extraction run as multiple parallel tasks.
+/// - Increasing VM RAM to allow for more caching.
+/// - Switching to a VM with local SSD for better I/O.
+/// - Pre-computing line offsets (in the uncompresed HTML, noting that we do
+///   gzip the HTML and probably still want to seek through that) so that we can
+///   reduce the amount of HTML parsing required (even if we still have to seek
+///   through a lot).
+/// - Create some alternate on-disk representation for the rendered HTML files
+///   that's intentionally distinct from the pre-gzipped files.  This could be
+///   a different compression format and/or sharded files (maybe with duplicate
+///   data at the start/end so we never have to span shards normally).
+///
+/// Alternately, we might:
+/// - Run a post-file-rendering phase and effectively re-compute the crossref
+///   database with HTML baked in and some number of extra lines of context?
+/// - Have the crossref database include some extra context and have tokenizer
+///   state included at the first line point so the tokenizer can do a bare
+///   bones syntax highlighting.
+#[derive(Debug, StructOpt)]
+pub struct AugmentResults {
+    /// Lines of context before a hit.
+    #[structopt(short, long, default_value = "0")]
+    before: u32,
+
+    /// Lines of context after a hit.
+    #[structopt(short, long, default_value = "0")]
+    after: u32,
+}
+
+#[derive(Debug)]
+pub struct AugmentResultsCommand {
+    pub args: AugmentResults,
+}
+
+#[async_trait]
+impl PipelineCommand for AugmentResultsCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let mut results = match input {
+            PipelineValues::FlattenedResultsBundle(frb) => frb,
+            _ => {
+                return Err(ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::ConfigLayer,
+                    message: "augment-resultst needs a FlattenedResultsBundle".to_string(),
+                }));
+            }
+        };
+
+        // ### Build up map of HTML lines
+        //
+        // This bit could potentially run in parallel.  We're not going to yet
+        // because:
+        // - Wanna see how bad it is.
+        // - Don't wanna have this experimental thing steal all the resources
+        //   from the non-experimental router.py and web-server.rs yet!
+
+        let mut path_line_contents: HashMap<String, HashMap<u32, String>> = HashMap::new();
+
+        for (path, lines_to_show) in
+            results.compute_path_line_sets(self.args.before, self.args.after)
+        {
+            // XXX Doing this as a single string received in a lump is fine for
+            // our testing use-case, but this may need to be reconsidered in
+            // production.  Or maybe production really wants the performance?
+            // Production certainly should have the RAM for our known worst
+            // case scenarios.
+            let html_str = server.fetch_html(&path).await?;
+
+            let file_lines = path_line_contents
+                .entry(path.clone())
+                .or_insert_with(|| HashMap::new());
+
+            // ### HTML Extraction: What We Want
+            //
+            // We want the full line container which looks like:
+            // - div id="line-N" class="source-line-with-number" role="row"
+            //   - div role="cell"
+            //     - div class="cov-strip cov-uncovered cov-known"
+            //   - div role="cell"
+            //     - div class="blame-strip c2" data-blame="..."
+            //   - div role="cell" class="line-number" data-line-number="N"
+            //   - code role="cell" class="source-line"
+            //     - ex: span class="sync_comment"
+            //     - ex: span class="syn_def syn_type" data-symbols="..." data-i
+            //
+            // ### HTML Extraction Low Level Details
+            //
+            // Until https://github.com/cloudflare/lol-html/issues/40 or
+            // the spin-off https://github.com/cloudflare/lol-html/issues/78
+            // are implemented, lol_html doesn't explicitly provide a way to
+            // derive the value of an element.
+            //
+            // So we attempt a hack where we use a custom output sink that is
+            // kept aware of where we are in the file.  The good news is that
+            // since lol_html is oriented around minimal memory allocation, we
+            // can generally control when flushes happen.
+
+            let mut writing_line: u32 = 0;
+            let cur_line = Cell::new(0u32);
+            let want_cur_line = Cell::new(false);
+
+            let mut buf = vec![];
+
+            let mut rewrite = HtmlRewriter::new(
+                Settings {
+                    element_content_handlers: vec![element!(
+                        r#"div.source-line-with-number"#,
+                        |el| {
+                            if let Some(id_str) = el.get_attribute("id") {
+                                let id_parts: Vec<&str> = id_str.split("-").collect();
+                                if id_parts.len() == 2 && id_parts[0] == "line" {
+                                    let lno = id_parts[1].parse().unwrap_or(0);
+                                    cur_line.set(lno);
+                                    want_cur_line.set(lines_to_show.contains(&lno));
+                                }
+                            }
+
+                            Ok(())
+                        }
+                    )],
+                    ..Settings::default()
+                },
+                |c: &[u8]| {
+                    // We were actively writing and potentially have some
+                    // buffer.
+                    if writing_line > 0 {
+                        // We're done writing; flush!
+                        if cur_line.get() != writing_line {
+                            file_lines
+                                .insert(writing_line, String::from_utf8_lossy(&buf).to_string());
+                            writing_line = 0;
+                            buf.clear();
+                        }
+                        // We're still writing!
+                        else {
+                            // Write into the buffer and then leave, because we
+                            // don't need to consider switching into writing, as
+                            // we're still here.
+                            buf.extend_from_slice(c);
+                            return;
+                        }
+                    }
+                    // We either closed out writing or weren't writing.  But now
+                    // we need to see if we should be writing!
+                    if cur_line.get() > 0 && want_cur_line.get() {
+                        writing_line = cur_line.get();
+                        buf.extend_from_slice(c);
+                    }
+                    // Otherwise, this wasn't interesting.
+                },
+            );
+
+            rewrite.write(html_str.as_bytes()).unwrap();
+            rewrite.end().unwrap();
+        }
+
+        // ## Ingest the new lines.
+        results.ingest_html_lines(&path_line_contents, self.args.before, self.args.after);
+
+        Ok(PipelineValues::FlattenedResultsBundle(results))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_compile_results.rs
+++ b/tools/src/cmd_pipeline/cmd_compile_results.rs
@@ -1,0 +1,38 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::{interface::{PipelineJunctionCommand, PipelineValues, FlattenedResultsBundle}, transforms::path_glob_transform};
+
+use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+/*
+
+ */
+
+#[derive(Debug, StructOpt)]
+pub struct CompileResults {
+    #[structopt(short, long, default_value = "0")]
+    limit: usize,
+}
+
+#[derive(Debug)]
+pub struct CompileResultsCommand {
+    pub args: CompileResults,
+}
+
+#[async_trait]
+impl PipelineJunctionCommand for CompileResultsCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: Vec<PipelineValues>,
+    ) -> Result<PipelineValues> {
+
+        let mut path_kind_results = vec![];
+
+        Ok(PipelineValues::FlattenedResultsBundle(FlattenedResultsBundle {
+            path_kind_results,
+            content_type: "text/plain".to_string(),
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -1,0 +1,313 @@
+use std::collections::{HashSet, VecDeque};
+
+use async_trait::async_trait;
+use serde_json::Value;
+use structopt::StructOpt;
+use tracing::{trace};
+
+use super::interface::{
+    OverloadInfo, OverloadKind, PipelineCommand, PipelineValues, SymbolCrossrefInfo,
+    SymbolCrossrefInfoList, SymbolRelation,
+};
+
+use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+/// Given a set of symbol crossref data, expand the set via relevant semantic
+/// relationships like override set membership.  This is fundamentally entwined
+/// with what information we want to present in search results and how we want
+/// to present it.
+#[derive(Debug, StructOpt)]
+pub struct CrossrefExpand {
+    #[structopt(long, default_value = "100")]
+    pub subclass_local_limit: u32,
+    #[structopt(long, default_value = "400")]
+    pub subclass_global_limit: u32,
+
+    #[structopt(long, default_value = "100")]
+    pub override_local_limit: u32,
+    #[structopt(long, default_value = "400")]
+    pub override_global_limit: u32,
+}
+
+/// Crosseref expansion exists to help us:
+/// 1. Provide relevant context to symbol results, like class hierarchies.
+/// 2. Let us unify results that could be said to be conceptually equivalent but
+///    which logistically involve distinct symbols.
+///
+/// Before the introduction of "structured" records, we unified results by
+/// leveraging the ability to associate multiple symbols with a single
+/// identifier.  Clever langage-specific analyses could do things like tie the
+/// JS symbol and C++ getter and setter symbols to the identifier for an IDL
+/// file, or associate all C++ overrides with every layer of their C++ class
+/// ancestry.  This was generally amazing with the one downside that if you
+/// searched for a specific sub-class's override by identifier that in turn was
+/// overridden by its own sub-classes, you would also get its cousins' overrides
+/// with no way in the UI to ignore the cousins.  One would have to arrive at
+/// a symbol search that listed the unified list of symbols as would be produced
+/// by the "search" context menu option and remove the symbols that were not of
+/// interest.
+///
+/// Post-structured refactoring, an intentional decision has been made to have
+/// mozsearch understand the semantic relationships explicitly so that analyses
+/// don't have to do hacky things which destroy information and potentially
+/// require other layers to have to undo or work-around cleverness, especially
+/// since it doesn't scale across multiple langauge analyzers trying to be
+/// clever in their own ways.  (These changes also allow for other meaningful
+/// optimizations like replacing the jumps/searches ANALYSIS_DATA table with
+/// crossref data and massively eliminating data duplication.)
+///
+/// Currently we still exist in a hybrid scenario, where overrides must be
+/// manually traversed but IPC/IDL edges currently still involve the identifiers
+/// lookup mechanism unifying things.  Our initial focus in this implementation
+/// will be on the override set because this is where we've regressed some use
+/// cases and we have tentative plans for faceting and diagramming.
+#[derive(Debug)]
+pub struct CrossrefExpandCommand {
+    pub args: CrossrefExpand,
+}
+
+struct LimitGroup {
+    kind: OverloadKind,
+    local_limit: u32,
+    // Hitting the global limit is a multi-step process, so we have to keep a
+    // running tally.
+    global_count: u32,
+    global_limit: u32,
+}
+
+#[async_trait]
+impl PipelineCommand for CrossrefExpandCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let source_crossrefs = match input {
+            PipelineValues::SymbolCrossrefInfoList(scil) => scil,
+            _ => {
+                return Err(ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::ConfigLayer,
+                    message: "crossref-expand needs a CrossrefInfoList".to_string(),
+                }));
+            }
+        };
+
+        // Our approach here is derived from that of `traverse` because of the
+        // inherent conceptual overlap and the implementation necessity to
+        // ensure we only process a given symbol at most once.  Things are
+        // simpler here, though, because we're just dealing with set membership
+        // here, not edges (which can be erroneously elided if naively
+        // supressing vertices without being aware of the tupling).
+        //
+        // That said, when our input set involves multiple symbols that exist
+        // within the same connected groups but have different identifiers, we
+        // will likely run into problems with the single `SymbolRelation` we use
+        // to label each symbol.  We do take care to list distances in the enum,
+        // but even a min() heuristic is potentially going to look weird.
+
+        let mut to_traverse = VecDeque::new();
+        let mut considered = HashSet::new();
+
+        for info in source_crossrefs.symbol_crossref_infos {
+            considered.insert(info.symbol.clone());
+            to_traverse.push_back((
+                info.symbol.clone(),
+                info.relation.clone(),
+                info.quality.clone(),
+                Some(info),
+            ));
+        }
+
+        let mut expanded = vec![];
+
+        // Running tallies for our limits.
+        let mut override_limits = LimitGroup {
+            kind: OverloadKind::Overrides,
+            local_limit: self.args.override_local_limit,
+            global_count: 0,
+            global_limit: self.args.override_global_limit,
+        };
+        let mut subclass_limits = LimitGroup {
+            kind: OverloadKind::Subclasses,
+            local_limit: self.args.subclass_local_limit,
+            global_count: 0,
+            global_limit: self.args.subclass_global_limit,
+        };
+
+        while let Some((symbol, relation, quality, maybe_info)) = to_traverse.pop_front() {
+            let mut info = match maybe_info {
+                Some(existing) => existing,
+                None => {
+                    let fresh_info = server.crossref_lookup(&symbol).await?;
+                    SymbolCrossrefInfo {
+                        symbol: symbol.clone(),
+                        crossref_info: fresh_info,
+                        relation: relation.clone(),
+                        quality,
+                        overloads_hit: vec![],
+                    }
+                }
+            };
+
+            let mut proc_ptr =
+                |ptr: &str,
+                 xfunc: &dyn Fn(&Value) -> &Value,
+                 use_relation: SymbolRelation,
+                 use_limits: Option<&mut LimitGroup>| {
+                    if let Some(Value::Array(arr)) = info.crossref_info.pointer(ptr) {
+                        if let Some(limits) = use_limits {
+                            if limits.local_limit > 0 && arr.len() as u32 > limits.local_limit {
+                                info.overloads_hit.push(OverloadInfo {
+                                    kind: limits.kind.clone(),
+                                    exist: arr.len() as u32,
+                                    included: 0,
+                                    local_limit: limits.local_limit,
+                                    global_limit: 0,
+                                });
+                                return;
+                            }
+                            if limits.global_limit > 0
+                                && limits.global_count + arr.len() as u32 > limits.global_limit
+                            {
+                                info.overloads_hit.push(OverloadInfo {
+                                    kind: limits.kind.clone(),
+                                    exist: arr.len() as u32,
+                                    included: 0,
+                                    local_limit: 0,
+                                    global_limit: limits.global_limit,
+                                });
+                                return;
+                            }
+                            limits.global_count += arr.len() as u32;
+                        }
+                        trace!(edge=ptr, count=arr.len(), "considering");
+                        for wrapped in arr.iter() {
+                            if let Value::String(sym) = xfunc(wrapped) {
+                                if considered.insert(sym.clone()) {
+                                    to_traverse.push_back((
+                                        sym.clone(),
+                                        use_relation.clone(),
+                                        info.quality.clone(),
+                                        None,
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                };
+
+            // Build up our traversal lists based on the relation for the node
+            // we're processing.  Our general approach is:
+            // - `Queried` nodes are the roots of our search and all edges are
+            //   possible.
+            // - As we move down into descendant nodes we only continue to move
+            //   in this direction because upward movement would be
+            //   backtracking.
+            // - As we move upward into ancestor nodes, there are new downward
+            //   edges to consider, and we do consider these and label them
+            //   cousins.  We rely on `considered` to avoid creating loops.
+            // - We apply local and global (within this command) limits to avoid
+            //   performing traversals of edge sets that are too large.  This is
+            //   primarily about not trying to show all the subclasses of
+            //   nsISupports or all the overrides of nsISupports::AddRef
+            //   automatically without the user explicitly indicating that's
+            //   what they want.
+            match &relation {
+                SymbolRelation::Queried => {
+                    proc_ptr(
+                        "/meta/overridenBy",
+                        &|x| &x,
+                        SymbolRelation::OverrideOf(symbol.clone(), 1),
+                        Some(&mut override_limits),
+                    );
+                    proc_ptr(
+                        "/meta/overrides",
+                        &|x| &x["sym"],
+                        SymbolRelation::OverriddenBy(symbol.clone(), 1),
+                        None,
+                    );
+                    proc_ptr(
+                        "/meta/subclasses",
+                        &|x| &x,
+                        SymbolRelation::SubclassOf(symbol.clone(), 1),
+                        Some(&mut subclass_limits),
+                    );
+                    proc_ptr(
+                        "/meta/supers",
+                        &|x| &x["sym"],
+                        SymbolRelation::SuperclassOf(symbol.clone(), 1),
+                        None,
+                    );
+                }
+                SymbolRelation::OverriddenBy(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/overrides",
+                        &|x| &x["sym"],
+                        SymbolRelation::OverriddenBy(root_sym.clone(), dist + 1),
+                        None,
+                    );
+                    proc_ptr(
+                        "/meta/overridenBy",
+                        &|x| &x,
+                        SymbolRelation::CousinOverrideOf(root_sym.clone(), dist + 1),
+                        Some(&mut override_limits),
+                    );
+                }
+                SymbolRelation::OverrideOf(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/overridenBy",
+                        &|x| &x,
+                        SymbolRelation::OverrideOf(root_sym.clone(), dist + 1),
+                        Some(&mut override_limits),
+                    );
+                }
+                SymbolRelation::CousinOverrideOf(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/overridenBy",
+                        &|x| &x,
+                        SymbolRelation::CousinOverrideOf(root_sym.clone(), dist + 1),
+                        Some(&mut override_limits),
+                    );
+                }
+                SymbolRelation::SubclassOf(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/subclasses",
+                        &|x| &x,
+                        SymbolRelation::SubclassOf(root_sym.clone(), dist + 1),
+                        Some(&mut subclass_limits),
+                    );
+                }
+                SymbolRelation::SuperclassOf(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/supers",
+                        &|x| &x["sym"],
+                        SymbolRelation::SuperclassOf(root_sym.clone(), dist + 1),
+                        None,
+                    );
+                    proc_ptr(
+                        "/meta/subclasses",
+                        &|x| &x,
+                        SymbolRelation::CousinClassOf(root_sym.clone(), dist + 1),
+                        Some(&mut subclass_limits),
+                    );
+                }
+                SymbolRelation::CousinClassOf(root_sym, dist) => {
+                    proc_ptr(
+                        "/meta/subclasses",
+                        &|x| &x,
+                        SymbolRelation::CousinClassOf(root_sym.clone(), dist + 1),
+                        Some(&mut subclass_limits),
+                    );
+                }
+            }
+
+            expanded.push(info);
+        }
+
+        Ok(PipelineValues::SymbolCrossrefInfoList(
+            SymbolCrossrefInfoList {
+                symbol_crossref_infos: expanded,
+            },
+        ))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -35,6 +35,11 @@ impl PipelineCommand for QueryCommand {
     ) -> Result<PipelineValues> {
         let pipeline_plan = chew_query(&self.args.query)?;
 
+        if self.args.dump_pipeline {
+            return Ok(PipelineValues::JsonValue(JsonValue { value: to_value(pipeline_plan)? }));
+        }
+
+        // XXX same as dump_pipeline for now...
         Ok(PipelineValues::JsonValue(JsonValue { value: to_value(pipeline_plan)? }))
     }
 }

--- a/tools/src/cmd_pipeline/cmd_search_files.rs
+++ b/tools/src/cmd_pipeline/cmd_search_files.rs
@@ -1,0 +1,58 @@
+use async_trait::async_trait;
+use structopt::StructOpt;
+
+use super::{
+    interface::{PipelineCommand, PipelineValues, FileMatches, FileMatch},
+    transforms::path_glob_transform,
+};
+
+use crate::abstract_server::{AbstractServer, Result};
+
+/// Perform a fulltext search against our livegrep/codesearch server over gRPC.
+/// This is local-only at this time.
+#[derive(Debug, StructOpt)]
+pub struct SearchFiles {
+    /// Path to search for; this will be searchfox glob-transformed.
+    path: Option<String>,
+
+    /// Constrain matching path patterns with a regexp.
+    #[structopt(long)]
+    pathre: Option<String>,
+
+    #[structopt(short, long, default_value = "1000")]
+    limit: usize,
+}
+
+#[derive(Debug)]
+pub struct SearchFilesCommand {
+    pub args: SearchFiles,
+}
+
+#[async_trait]
+impl PipelineCommand for SearchFilesCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        _input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let pathre_pattern = if let Some(pathre) = &self.args.pathre {
+            pathre.clone()
+        } else if let Some(path) = &self.args.path {
+            path_glob_transform(path)
+        } else {
+            "".to_string()
+        };
+
+        let matches = server
+            .search_files(&pathre_pattern, self.args.limit)
+            .await?;
+
+        Ok(PipelineValues::FileMatches(FileMatches {
+            file_matches: matches.into_iter().map(|path| {
+                FileMatch {
+                    path
+                }
+            }).collect()
+        }))
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_search_text.rs
+++ b/tools/src/cmd_pipeline/cmd_search_text.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use structopt::StructOpt;
 
-use super::interface::{PipelineCommand, PipelineValues};
+use super::{interface::{PipelineCommand, PipelineValues}, transforms::path_glob_transform};
 
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
 
@@ -59,7 +59,7 @@ impl PipelineCommand for SearchTextCommand {
         let pathre_pattern = if let Some(pathre) = &self.args.pathre {
             pathre.clone()
         } else if let Some(path) = &self.args.path {
-            regex::escape(path)
+            path_glob_transform(path)
         } else {
             "".to_string()
         };

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -56,10 +56,11 @@ impl PipelineCommand for TraverseCommand {
         let max_depth = self.args.max_depth;
         let cil = match input {
             PipelineValues::SymbolCrossrefInfoList(cil) => cil,
-            // TODO: Figure out a better way to handle a nonsensical pipeline
-            // configuration / usage.
             _ => {
-                return Ok(PipelineValues::Void);
+                return Err(ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::ConfigLayer,
+                    message: "traverse needs a CrossrefInfoList".to_string(),
+                }));
             }
         };
 

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -40,6 +40,7 @@ pub enum PipelineValues {
     SymbolGraphCollection(SymbolGraphCollection),
     JsonValue(JsonValue),
     JsonRecords(JsonRecords),
+    FileMatches(FileMatches),
     TextMatches(TextMatches),
     HtmlExcerpts(HtmlExcerpts),
     StructuredResultsBundle(StructuredResultsBundle),
@@ -126,6 +127,23 @@ pub struct FlattenedResultsByFile {
 pub struct FlattenedLineSpan {
     pub line_range: (u32, u32),
     pub contents: String,
+}
+
+/// This currently boring struct exists so that we have a place to put metadata
+/// about files that can ride-along with the name.  However, it could end up
+/// that we want to just treat files as a special type of symbol, in which case
+/// maybe we don't put that info here and let later stages look it up
+/// themselves?  Optionally, maybe this ends up being an optional serde_json
+/// Value (where Some(null) means it had no data and None means we haven't
+/// looked).
+#[derive(Serialize)]
+pub struct FileMatch {
+    pub path: String,
+}
+
+#[derive(Serialize)]
+pub struct FileMatches {
+    pub file_matches: Vec<FileMatch>,
 }
 
 /// JSON records are raw analysis records from a single file (for now)

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -216,6 +216,10 @@ pub struct ServerPipeline {
     pub commands: Vec<Box<dyn PipelineCommand>>,
 }
 
+/// A linear pipeline sequence that potentially runs in parallel with other
+/// named pipelines in a `ParallelPipelines` node which can be one in a sequence
+/// of `ParallelPipelines` in a `ServerpipelineGraph`.  Inputs and outputs are
+/// consumed from and added to a global dictionary.
 pub struct NamedPipeline {
     /// Previous pipeline's output to consume.
     pub input_name: Option<String>,
@@ -223,6 +227,10 @@ pub struct NamedPipeline {
     pub commands: Vec<Box<dyn PipelineCommand>>,
 }
 
+/// Consumes one or more inputs from the `NamedPipeline`s that ran prior to it
+/// in the same `ParallelPipelines` node or possibly an earlier
+/// `ParallelPipelines` node, producting a new output.  Inputs and outputs are
+/// consumed from and added to a global dictionary.
 pub struct JunctionInvocation {
     pub input_names: Vec<String>,
     pub output_name: String,

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -5,6 +5,7 @@ pub mod builder;
 pub mod interface;
 pub mod parser;
 pub mod symbol_graph;
+pub mod transforms;
 
 mod cmd_crossref_lookup;
 mod cmd_filter_analysis;
@@ -13,6 +14,7 @@ mod cmd_merge_analyses;
 mod cmd_prod_filter;
 mod cmd_query;
 mod cmd_search;
+mod cmd_search_files;
 mod cmd_search_identifiers;
 mod cmd_search_text;
 mod cmd_show_html;

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -7,6 +7,7 @@ pub mod parser;
 pub mod symbol_graph;
 pub mod transforms;
 
+mod cmd_augment_results;
 mod cmd_compile_results;
 mod cmd_crossref_expand;
 mod cmd_crossref_lookup;

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -7,6 +7,8 @@ pub mod parser;
 pub mod symbol_graph;
 pub mod transforms;
 
+mod cmd_compile_results;
+mod cmd_crossref_expand;
 mod cmd_crossref_lookup;
 mod cmd_filter_analysis;
 mod cmd_graph;

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -8,6 +8,7 @@ use super::cmd_merge_analyses::MergeAnalyses;
 use super::cmd_prod_filter::ProductionFilter;
 use super::cmd_query::Query;
 use super::cmd_search::Search;
+use super::cmd_search_files::SearchFiles;
 use super::cmd_search_identifiers::SearchIdentifiers;
 use super::cmd_search_text::SearchText;
 use super::cmd_show_html::ShowHtml;
@@ -54,6 +55,7 @@ pub enum Command {
     ProductionFilter(ProductionFilter),
     Query(Query),
     Search(Search),
+    SearchFiles(SearchFiles),
     SearchIdentifiers(SearchIdentifiers),
     SearchText(SearchText),
     ShowHtml(ShowHtml),

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -1,6 +1,7 @@
 use clap::arg_enum;
 use structopt::StructOpt;
 
+use super::cmd_crossref_expand::CrossrefExpand;
 use super::cmd_crossref_lookup::CrossrefLookup;
 use super::cmd_filter_analysis::FilterAnalysis;
 use super::cmd_graph::Graph;
@@ -48,6 +49,7 @@ pub struct ToolOpts {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
+    CrossrefExpand(CrossrefExpand),
     CrossrefLookup(CrossrefLookup),
     FilterAnalysis(FilterAnalysis),
     Graph(Graph),

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -1,6 +1,8 @@
 use clap::arg_enum;
 use structopt::StructOpt;
 
+use super::cmd_augment_results::AugmentResults;
+use super::cmd_compile_results::CompileResults;
 use super::cmd_crossref_expand::CrossrefExpand;
 use super::cmd_crossref_lookup::CrossrefLookup;
 use super::cmd_filter_analysis::FilterAnalysis;
@@ -49,6 +51,7 @@ pub struct ToolOpts {
 
 #[derive(Debug, StructOpt)]
 pub enum Command {
+    AugmentResults(AugmentResults),
     CrossrefExpand(CrossrefExpand),
     CrossrefLookup(CrossrefLookup),
     FilterAnalysis(FilterAnalysis),
@@ -62,4 +65,15 @@ pub enum Command {
     SearchText(SearchText),
     ShowHtml(ShowHtml),
     Traverse(Traverse),
+}
+
+#[derive(Debug, StructOpt)]
+pub struct JunctionOpts {
+    #[structopt(subcommand)]
+    pub cmd: JunctionCommand,
+}
+
+#[derive(Debug, StructOpt)]
+pub enum JunctionCommand {
+    CompileResults(CompileResults),
 }

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -14,7 +14,7 @@ use super::cmd_show_html::ShowHtml;
 use super::cmd_traverse::Traverse;
 
 arg_enum! {
-    #[derive(Debug, PartialEq)]
+    #[derive(Clone, Debug, PartialEq)]
     pub enum OutputFormat {
         // Pretty-printed JSON.
         Pretty,

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -133,6 +133,10 @@ impl Serialize for SymbolGraphCollection {
     }
 }
 
+fn escaped_node_id(id: &str) -> NodeId {
+    NodeId(Id::Escaped(format!("\"{}\"", id)), None)
+}
+
 impl SymbolGraphCollection {
     /// Return a sorted Object mapping from symbol identifiers to their meta, if
     /// available.  We sort the symbols for stability for testing purposes and
@@ -212,7 +216,12 @@ impl SymbolGraphCollection {
                 ));
             }
 
-            dot_graph.add_stmt(stmt!(edge!(node_id!(&source_sym) => node_id!(&target_sym))));
+            // node_id!'s macro_rules currently can't handle an `esc` prefix, so
+            // we create the structs via a hand-rolled `escaped_node_id` that
+            // replicates what the equivalent macros would do.
+            dot_graph.add_stmt(stmt!(
+                edge!(escaped_node_id(&source_sym) => escaped_node_id(&target_sym))
+            ));
         }
 
         dot_graph

--- a/tools/src/cmd_pipeline/transforms.rs
+++ b/tools/src/cmd_pipeline/transforms.rs
@@ -1,0 +1,38 @@
+use regex::{Regex, Captures};
+
+/// Apply the searchfox path glob transformation ported from `router.py`.
+pub fn path_glob_transform(s: &str) -> String {
+  lazy_static! {
+    static ref RE_TO_ESCAPE: Regex = Regex::new("[()|.]").unwrap();
+    static ref RE_STARS: Regex = Regex::new(r"\*\*?").unwrap();
+    static ref RE_BRACES: Regex = Regex::new(r"\{([^}]*)\}").unwrap();
+  }
+  let backslashed = RE_TO_ESCAPE.replace_all(s, r"\$0");
+  let starred = RE_STARS.replace_all(&backslashed, |caps: &Captures| {
+    if caps.get(0).unwrap().as_str().len() == 1 {
+      "[^/]*"
+    } else {
+      ".*"
+    }
+  });
+  let questioned = str::replace(&starred, "?", ".");
+  let braced = RE_BRACES.replace_all(&questioned, |caps: &Captures| {
+    let inside_braces = caps.get(1).unwrap().as_str();
+    format!("({})", str::replace(inside_braces, ",", "|"))
+  });
+  braced.to_string()
+}
+
+#[test]
+fn test_path_glob_transform() {
+  // Test coverage for the cases we documented on the help page.
+  assert_eq!(path_glob_transform("test"), "test");
+  assert_eq!(path_glob_transform("^js/src"), "^js/src");
+
+  assert_eq!(path_glob_transform("*.cpp"), "[^/]*\\.cpp");
+  assert_eq!(path_glob_transform("*.cpp$"), "[^/]*\\.cpp$");
+
+  assert_eq!(path_glob_transform("^js/src/*.cpp$"), "^js/src/[^/]*\\.cpp$");
+  assert_eq!(path_glob_transform("^js/src/**.cpp$"), "^js/src/.*\\.cpp$");
+  assert_eq!(path_glob_transform("^js/src/**.{cpp,h}$"), "^js/src/.*\\.(cpp|h)$");
+}

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -201,7 +201,7 @@ pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>) -> C
     }
 
     Config {
-        trees: trees,
+        trees,
         mozsearch_path: mozsearch.to_owned(),
     }
 }

--- a/tools/src/config.rs
+++ b/tools/src/config.rs
@@ -12,7 +12,7 @@ use malloc_size_of::{MallocSizeOf, MallocSizeOfOps};
 
 use git2::{Oid, Repository};
 
-#[derive(Debug, MallocSizeOf, Serialize, Deserialize)]
+#[derive(Clone, Debug, MallocSizeOf, Serialize, Deserialize)]
 pub struct TreeConfigPaths {
     pub index_path: String,
     pub files_path: String,

--- a/tools/src/query/chew_query.rs
+++ b/tools/src/query/chew_query.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, VecDeque};
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    iter::FromIterator,
+};
 
 use query_parser::{parse, TermValue};
 use serde::{Deserialize, Serialize};
@@ -7,13 +10,51 @@ use toml::value::Table;
 use crate::abstract_server::{ErrorDetails, ErrorLayer, Result, ServerError};
 
 /*
-  Queries are translated into pipelines by building individiual pipelines on
-  a per-group basis.
+  Queries are translated into pipelines in the following steps:
+
+  1. We parse the query string with the `query-parser` crate which provides us
+     with a list of terms and values from `term:value` with a special case for
+     bare values where there is no term.
+  2. We look up each term (including "default" for bare values) which contain
+     some combination of:
+     - Term aliases: We just re-process the term as if the aliased term had been
+       used.  This is intended for short-hands like "C" for "context" where we
+       want our UI to act like "context" had been used when "C" is observed so
+       that we can explain to the user what is going on without being cryptic.
+     - Term expansions: We re-process the term as one or more other terms,
+       potentially transforming the value associated with the term.  Allowing
+       expansion to multiple terms lets us have a single query run against
+       multiple data sources.  For example, our default term expands to
+       "file" for filename/path search, "idprefix" for identifier lookup by
+       prefix, and "text" for full-text search.  These will result in parallel
+       execution pipelines which are stitched back together later via the
+       "group" and "junction" config dictionaries.
+     - Pipeline command invocations placed in a specific group.  Command
+       invocations will create a command with the given name if it does not
+       already exist, or reuse an existing command if one already exists
+       (searching from the most recently added command).  Arguments are then
+       contributed to the command.  This allows terms to add additional
+       constraints or settings to a single pipeline command.
+     - Maybe in the future: The ability to set some kind of global variable so
+       that a single term can influence multiple pipeline commands that may or
+       may not exist (and without bringing them into existence)?
+  3. After the terms have produced the starting groups, we consult the "group"
+     and "junction" nodes that have not yet been processed.  For each group /
+     junction, we look up its config settings and:
+     - For each group, we set its "output" and if there is a "next" group or a
+       "junction" that should process its output, we create the group /
+       junction if it does not exist and add/set the group's "output" as the/a
+       input to the group/junction.  We populate the new group with a "command"
+       and any "args" if they were provided.  We add the group/junction to the
+       to-do list.
+    - For each junction we similarly look at its "output" and any "next" group.
 */
 
 #[derive(Deserialize)]
 pub struct QueryConfig {
     pub term: BTreeMap<String, TermConfig>,
+    pub group: BTreeMap<String, GroupConfig>,
+    pub junction: BTreeMap<String, JunctionConfig>,
 }
 
 #[derive(Deserialize)]
@@ -37,7 +78,26 @@ pub struct TermExpansion {
 #[derive(Deserialize)]
 pub struct PipelineUse {
     pub command: String,
+    #[serde(default)]
     pub args: Table,
+}
+
+#[derive(Deserialize)]
+pub struct GroupConfig {
+    pub output: String,
+    #[serde(default)]
+    pub commands: Vec<PipelineUse>,
+    pub junction: Option<String>,
+    pub next: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub struct JunctionConfig {
+    pub command: String,
+    #[serde(default)]
+    pub args: Table,
+    pub output: String,
+    pub next: Option<String>,
 }
 
 lazy_static! {
@@ -47,10 +107,11 @@ lazy_static! {
 #[derive(Default, Serialize)]
 pub struct QueryPipelineGroupBuilder {
     pub groups: BTreeMap<String, PipelineGroup>,
+    pub junctions: BTreeMap<String, JunctionNode>,
 }
 
 fn apply_transforms(user_val: String, transforms: &Vec<String>) -> String {
-	let mut val = user_val;
+    let mut val = user_val;
     for transform in transforms.iter() {
         val = match transform.as_str() {
             "regexp_escape" => regex::escape(&val),
@@ -144,12 +205,23 @@ impl QueryPipelineGroupBuilder {
         }
 
         Ok(())
-	}
+    }
 }
 
 #[derive(Default, Serialize)]
 pub struct PipelineGroup {
+    pub input: Option<String>,
     pub segments: Vec<PipelineSegment>,
+    pub output: Option<String>,
+    pub depth: u32,
+}
+
+#[derive(Default, Serialize)]
+pub struct JunctionNode {
+    pub inputs: Vec<String>,
+    pub command: PipelineSegment,
+    pub output: Option<String>,
+    pub depth: u32,
 }
 
 #[derive(Default, Serialize)]
@@ -168,6 +240,99 @@ pub fn chew_query(full_arg_str: &str) -> Result<QueryPipelineGroupBuilder> {
                     builder.ingest_term(&key, &value)?;
                 } else {
                     builder.ingest_term("default", &value)?;
+                }
+            }
+        }
+    }
+
+    let mut unprocessed_groups: VecDeque<String> = builder.groups.keys().cloned().collect();
+    let mut unprocessed_junctions: VecDeque<String> = VecDeque::new();
+    // The set of groups without an input which means they should go in the
+    // first `ParallelPipelines` instance.  We remove groups from this set as we
+    // determine that they are actually depdendent on some earlier pipeline.
+    let mut root_groups = BTreeSet::from_iter(unprocessed_groups.iter().cloned());
+
+    while !unprocessed_groups.is_empty() || !unprocessed_junctions.is_empty() {
+        let mut next_group: Option<String> = None;
+        let mut next_junction: Option<String> = None;
+        let mut use_input: Option<String> = None;
+
+        // We process groups first because junctions must have inputs and they
+        // should probably already exist as groups, so our life is probably
+        // easier if we process them first.
+        if let Some(group_name) = unprocessed_groups.pop_front() {
+            if let (Some(group_config), Some(group)) = (
+                QUERY_CORE.group.get(&group_name),
+                builder.groups.get_mut(&group_name),
+            ) {
+                group.output = Some(group_config.output.clone());
+                use_input = group.output.clone();
+                if let Some(next_group_name) = &group_config.next {
+                    next_group = Some(next_group_name.clone());
+                } else if let Some(next_junction_name) = &group_config.junction {
+                    next_junction = Some(next_junction_name.clone());
+                }
+            }
+        } else if let Some(junction_name) = unprocessed_junctions.pop_front() {
+            if let (Some(junction_config), Some(junction)) = (
+                QUERY_CORE.junction.get(&junction_name),
+                builder.junctions.get_mut(&junction_name),
+            ) {
+                junction.output = Some(junction_config.output.clone());
+                use_input = junction.output.clone();
+                if let Some(next_group_name) = &junction_config.next {
+                    next_group = Some(next_group_name.clone());
+                }
+            }
+        }
+
+        // Make the requested thing.
+        if let Some(group_name) = next_group {
+            if let (Some(group_config), group) = (
+                QUERY_CORE.group.get(&group_name),
+                builder
+                    .groups
+                    .entry(group_name.clone())
+                    .or_insert_with(|| PipelineGroup::default()),
+            ) {
+                group.input = use_input;
+                if group.input.is_some() {
+                    root_groups.remove(&group_name);
+                }
+                // group.output will be set and next/junction will be processed
+                // in the 1st phase of the loop above; we're just ensuring the
+                // group exists, establishing the "input" link, and adding any
+                // commands/args listed.
+                unprocessed_groups.push_back(group_name);
+
+                for cmd in &group_config.commands {
+                    let flattened_args = flatten_args("", &cmd.args);
+                    group.segments.push(PipelineSegment {
+                        command: cmd.command.clone(),
+                        args: flattened_args,
+                    });
+                }
+            }
+        } else if let Some(junction_name) = next_junction {
+            if let (Some(junction_config), junction, Some(input)) = (
+                QUERY_CORE.junction.get(&junction_name),
+                builder
+                    .junctions
+                    .entry(junction_name.clone())
+                    .or_insert_with(|| JunctionNode::default()),
+                use_input,
+            ) {
+                junction.inputs.push(input);
+                // junction.output will be set and next will be processed in the
+                // 1st phase of the loop above; we're just ensuring the junction
+                // exists and adding the "input" to the list.
+                //
+                // Logic to run only the first time we're processing the
+                // junction:
+                if junction.command.command.is_empty() {
+                    junction.command.command = junction_config.command.clone();
+                    junction.command.args = flatten_args("", &junction_config.args);
+                    unprocessed_junctions.push_back(junction_name);
                 }
             }
         }

--- a/tools/src/query/chew_query.rs
+++ b/tools/src/query/chew_query.rs
@@ -7,7 +7,7 @@ use query_parser::{parse, TermValue};
 use serde::{Deserialize, Serialize};
 use toml::value::Table;
 
-use crate::abstract_server::{ErrorDetails, ErrorLayer, Result, ServerError};
+use crate::{abstract_server::{ErrorDetails, ErrorLayer, Result, ServerError}, cmd_pipeline::transforms::path_glob_transform};
 
 /*
   Queries are translated into pipelines in the following steps:
@@ -122,6 +122,7 @@ fn apply_transforms(user_val: String, transforms: &Vec<String>) -> String {
     for transform in transforms.iter() {
         val = match transform.as_str() {
             "regexp_escape" => regex::escape(&val),
+            "path_glob" => path_glob_transform(&val),
             _ => val,
         }
     }

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -38,6 +38,9 @@ args.exact_match = false
 
 
 [term.pathre]
+[[term.pathre.group.file-search]]
+command = "search-files"
+args.pathre = "$0"
 [[term.pathre.group.semantic-search]]
 command = "filter-crossref"
 args.pathre = "$0"
@@ -51,7 +54,7 @@ alias = "path"
 [term.path]
 [[term.path.expand]]
 term = "pathre"
-transforms = ["regexp_escape"]
+transforms = ["path_glob"]
 
 [term.re]
 [[term.re.group.text-search]]

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -3,8 +3,9 @@ alias = "context"
 
 [term.context]
 [[term.context.group.display]]
-command = "show-html"
-args.context = "$0"
+command = "augment-results"
+args.before = "$0"
+args.after = "$0"
 
 # The default term is what gets applied to things without a term.  It can also
 # be explicitly referenced by other terms.
@@ -29,21 +30,32 @@ conflicts = ["idprefix"]
 command = "search-identifiers"
 args.positional = "$0"
 args.exact_match = true
+[[term.id.group.semantic-search]]
+command = "crossref-lookup"
+[[term.id.group.semantic-search]]
+command = "crossref-expand"
 
 [term.idprefix]
 [[term.idprefix.group.semantic-search]]
 command = "search-identifiers"
 args.positional = "$0"
 args.exact_match = false
-
+[[term.idprefix.group.semantic-search]]
+command = "crossref-lookup"
+[[term.idprefix.group.semantic-search]]
+command = "crossref-expand"
 
 [term.pathre]
 [[term.pathre.group.file-search]]
 command = "search-files"
 args.pathre = "$0"
-[[term.pathre.group.semantic-search]]
-command = "filter-crossref"
-args.pathre = "$0"
+## TODO: Implement filtering crossref output by path
+## does this really want to be its own stage, or just part of crossref-lookup?
+## I guess this may need to come after crossref-expand, so then it would want
+## to be its own command.
+#[[term.pathre.group.semantic-search]]
+#command = "filter-crossref"
+#args.pathre = "$0"
 [[term.pathre.group.text-search]]
 command = "search-text"
 args.pathre = "$0"
@@ -68,6 +80,10 @@ alias = "symbol"
 [[term.symbol.group.semantic-search]]
 command = "search-identifiers"
 args.add_sym = "$0"
+[[term.symbol.group.semantic-search]]
+command = "crossref-lookup"
+[[term.symbol.group.semantic-search]]
+command = "crossref-expand"
 
 [term.text]
 [[term.text.expand]]
@@ -94,4 +110,4 @@ next = "display"
 [group.display]
 output = "result"
 [[group.display.commands]]
-command = "show-html"
+command = "augment-results"

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -70,3 +70,25 @@ args.add_sym = "$0"
 [[term.text.expand]]
 term = "re"
 transforms = ["regexp_escape"]
+
+[group.file-search]
+output = "file-search"
+junction = "compile"
+
+[group.semantic-search]
+output = "semantic-search"
+junction = "compile"
+
+[group.text-search]
+output = "text-search"
+junction = "compile"
+
+[junction.compile]
+command = "compile-results"
+output = "compiled"
+next = "display"
+
+[group.display]
+output = "result"
+[[group.display.commands]]
+command = "show-html"

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -173,9 +173,6 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         Ok(PipelineValues::SymbolGraphCollection(sgc)) => {
                             insta::assert_json_snapshot!(sgc.to_json());
                         }
-                        Ok(PipelineValues::StructuredResultsBundle(srb)) => {
-                            insta::assert_json_snapshot!(&to_value(srb).unwrap());
-                        }
                         Ok(PipelineValues::FlattenedResultsBundle(frb)) => {
                             insta::assert_json_snapshot!(&to_value(frb).unwrap());
                         }

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -161,28 +161,14 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         Ok(PipelineValues::IdentifierList(il)) => {
                             insta::assert_json_snapshot!(json!(il.identifiers));
                         }
-                        Ok(PipelineValues::SymbolList(sl)) => match sl.from_identifiers {
-                            Some(identifiers) => {
-                                let mut pairs = vec![];
-                                for (sym, ident) in sl.symbols.iter().zip(identifiers.iter()) {
-                                    pairs.push(json!({
-                                        "sym": sym,
-                                        "id": ident,
-                                    }));
-                                }
-                                insta::assert_json_snapshot!(json!(pairs));
-                            }
-                            None => {
-                                insta::assert_json_snapshot!(json!(sl.symbols));
-                            }
-                        },
-                        Ok(PipelineValues::SymbolCrossrefInfoList(sl)) => {
-                            let crossref_json = json!(sl
-                                .symbol_crossref_infos
-                                .into_iter()
-                                .map(|sci| sci.crossref_info)
-                                .collect::<Value>());
-                            insta::assert_json_snapshot!(crossref_json);
+                        Ok(PipelineValues::SymbolList(sl)) => {
+                            insta::assert_json_snapshot!(&to_value(sl).unwrap());
+                        }
+                        Ok(PipelineValues::SymbolCrossrefInfoList(scil)) => {
+                            // We used to previously just turn this into a list of
+                            // just the crossref values, but we now have important
+                            // metadata.
+                            insta::assert_json_snapshot!(&to_value(scil).unwrap());
                         }
                         Ok(PipelineValues::SymbolGraphCollection(sgc)) => {
                             insta::assert_json_snapshot!(sgc.to_json());

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -216,6 +216,9 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         Ok(PipelineValues::JsonValue(jv)) => {
                             insta::assert_json_snapshot!(&jv.value);
                         }
+                        Ok(PipelineValues::FileMatches(fm)) => {
+                            insta::assert_json_snapshot!(&to_value(fm).unwrap());
+                        }
                         Ok(PipelineValues::TextMatches(tm)) => {
                             insta::assert_json_snapshot!(&to_value(tm).unwrap());
                         }


### PR DESCRIPTION
This stack:
- Provides the MVP classic searchfox search via the new "query" mechanism which translates query-parser style syntax into a pipeline graph consisting of 3 parallel searches (file search, semantic search via crossref lookup and results expansion via crossref-expand, fulltext search via livegrep/codesearch), a junction in "compile-results" that takes any of those, plus lookup of lines from the generated HTML files with user-configurable context including overlap compensation.
  - Parallelism is leveraged by spawning a tokio task for each parallel pipeline.  Currently all our memory map lookups are treated as non-blocking but that may need to be revisited.
- Exposes "query" internally for the searchfox-tool for testing.
- Makes the pipeline-server a thing that seems to work.  If you run the VM and add a keyword bookmark for `http://localhost:16995/tests/query/default?q=%s` you can issue queries and get JSON back that looks convincingly like reasonable search results, although probably with some bugs here and there.
  - Specifically I've noticed a "pretty" symbol that was still mangled, but that may be a pre-existing data bug that router.py may side-step because it likes to overzealously demangle everything whereas I've tried to leverage that we now should have structured "meta" info for most C++ types.
  - Note that I'd previously talked about hardening the abstract servers against misuse, but the query mechanism doesn't actually provide a way for web requests to manipulate the pipeline in a way to generate paths; only filter them.  And there's no way to arbitrarily use other pipeline commands or provide them with arbitrary arguments.  Everything is just fill-in-the-blanks.

This landing won't actually provide any useful functionality to anyone yet, but it's pretty close.  The key next step is to bind the search results from the above into a UI along the lines of the existing "search" UI.  The only deviation right now is the introduction of automatic faceting of qual-kind group results so that we can potentially provide some checkboxes that allow turning off sets of related symbols for overrides, or turning off groups of paths.  This data is provided as a sort-of sidecar that can also just be ignored.

My tentative plan is to use the liquid templating support I've already added for the test "explanation" mechanism (which is still a WIP to be useful) so that we can translate the results directly into semantic HTML rather than continuing to use our ad hoc JS HTML templating in `populateResults` in `search.js` that we then poke into innerHTML.  That said, note that I explicitly chose liquid because there's also a JS version of it too, so we could also potentially use the same templating logic on both the client and server if desired, etc. etc.