### PR TITLE
Bug 1771620 - Pass paths to output-file over stdin

### DIFF
--- a/docs/index-directory-contents.md
+++ b/docs/index-directory-contents.md
@@ -59,6 +59,10 @@ Directories:
   `router.py` can inline the JSON search results from a query.
 
 Files:
+- `all-files`: `repo-files` and `objdir-files` concatenated together by
+  `find-objdir-files.sh` after deriving `objdir-files`.  This exists so that
+  `output.sh` can use `--pipe-part` which needs a real file on disk rather than
+  a pipe from dynamically `cat`-ing the source files.
 - `analysis-dirs-*.list`: `find -type d` for each per-platform analysis
   directory.  Produced by the per-platform `process-tc-artifacts.sh` script and
   concatenated into the unified list by `process-gecko-analysis.sh`.  The

--- a/scripts/find-objdir-files.sh
+++ b/scripts/find-objdir-files.sh
@@ -8,3 +8,5 @@ pushd ${INDEX_ROOT}/analysis/__GENERATED__
 find . -type f | sed -e 's#^./#__GENERATED__/#' > ${INDEX_ROOT}/objdir-files
 find . -mindepth 1 -type d | sed -e 's#^./#__GENERATED__/#' > ${INDEX_ROOT}/objdir-dirs
 popd
+
+cat ${INDEX_ROOT}/repo-files ${INDEX_ROOT}/objdir-files > ${INDEX_ROOT}/all-files

--- a/scripts/indexer-logs-analyze.sh
+++ b/scripts/indexer-logs-analyze.sh
@@ -7,7 +7,7 @@ PARSE_EXPR+=' as time, script, args'
 PARSE_EXPR+=' | parseDate(time) as time'
 PARSE_EXPR+=' | split(args) on " "'
 PARSE_EXPR+=' | if(script == "find-repo-files.py" or script == "build.sh" or script=="output.sh", args[2], "") as tree'
-PARSE_EXPR+=' | if(script == "js-analyze.sh" or script == "java-analyze.sh" or script == "idl-analyze.sh" or script == "ipdl-analyze.sh" or script == "crossref.sh" or script == "build-codesearch.py" or script == "check-index.sh", args[1], tree) as tree'
+PARSE_EXPR+=' | if(script == "js-analyze.sh" or script == "java-analyze.sh" or script == "idl-analyze.sh" or script == "ipdl-analyze.sh" or script == "crossref.sh" or script == "build-codesearch.py" or script == "check-index.sh" or script == "compress-outputs.sh" or script == "check-index.sh", args[1], tree) as tree'
 
 # - Grep the log in Perl mode looking for the pattern where a "date" invocation
 #   is followed by a script invocation from mozsearch/scripts.

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -72,8 +72,10 @@ $MOZSEARCH_PATH/scripts/build-codesearch.py $CONFIG_FILE $TREE_NAME
 
 date
 
-# this depends on INDEX_ROOT already being available
-$MOZSEARCH_PATH/scripts/compress-outputs.sh
+# This depends on INDEX_ROOT already being available.  The script doesn't
+# actually care about CONFIG_FILE or TREE_NAME, but it's helpful to
+# `indexer-logs-analyze.sh`.
+$MOZSEARCH_PATH/scripts/compress-outputs.sh $CONFIG_FILE $TREE_NAME
 
 date
 
@@ -81,6 +83,7 @@ date
 # 4th argument needs to be empty.  We now also need the livegrep server to be
 # available, so start that first.
 $MOZSEARCH_PATH/router/codesearch.py $CONFIG_FILE start $TREE_NAME
+date
 $MOZSEARCH_PATH/scripts/check-index.sh $CONFIG_FILE $TREE_NAME "filesystem" ""
 
 # And we want to stop it after.  It's possible if we errored above that it will


### PR DESCRIPTION
We can eliminate a massive amount of process startup overhead by having
output-file receive the list of files to process over stdin.  With
these changes we basically run one output-file instance per core.  The
main trade-off is that because we distribute the list of files up front
and don't do any dynamic scheduling, there's a potential for unequal
distribution of work.

Should this end up being a meaningful problem, we can:
- Randomize the contents of `all-files` to avoid clustering of larger
  files or ramifications of different path-lengths in the tree (since
  divvying is based on bytes, not lines).
- Ditch parallel in favor of just having output-file internally be
  multi-threaded and use a work-queue mechanism that can be aware of
  how much work each thread still has to do / does work-stealing / etc.