### PR TITLE
Bug 1771805 - Upgrade to 22.04 from 20.04.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu2004"
-  config.vm.box_version = "3.2.6"
+  config.vm.box = "generic/ubuntu2204"
+  config.vm.box_version = "4.0.0"
 
   config.vm.provision :shell, privileged: false, path: "infrastructure/vagrant/indexer-provision.sh"
   config.vm.provision :shell, privileged: false, path: "infrastructure/indexer-provision.sh"

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -115,10 +115,10 @@ aws ec2 terminate-instances --region $AWS_REGION --instance-ids $INSTANCE_ID
 # Performing lookup from https://cloud-images.ubuntu.com/locator/ec2/ by
 # searching on "20.04 us-west-2 amd64" we get:
 #
-# us-west-2	focal	20.04 LTS	amd64	hvm:ebs-ssd	20211129	ami-0892d3c7ee96c0bf7	hvm
+# us-west-2	jammy	22.04	amd64	hvm:ebs-ssd	20220506	ami-0437ae8a23be4e98b	hvm
 #
 # and then we copy the ami ID into here:
-image_id = 'ami-0892d3c7ee96c0bf7'
+image_id = 'ami-0437ae8a23be4e98b'
 
 launch_spec = {
     'ImageId': image_id,

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -12,7 +12,7 @@ set -o pipefail # Check all commands in a pipeline
 # Note that for the most recent LLVM/clang release (ex: right now v13), you
 # would actually want to leave this empty.  Check out https://apt.llvm.org/ for
 # the latest info in all cases.
-CLANG_SUFFIX=-11
+CLANG_SUFFIX=-14
 # Bumping the priority with each version upgrade lets running the provisioning
 # script on an already provisioned machine do the right thing alternative-wise.
 # Actually, we no longer support re-provisioning, but it's fun to increment
@@ -64,18 +64,18 @@ sudo pip3 install yq
 # dos2unix is used to normalize generated files from windows
 sudo apt-get install -y dos2unix
 
-# Livegrep (Bazel is needed for Livegrep builds, OpenJDK 8 required for bazel)
-sudo apt-get install -y unzip openjdk-8-jdk libssl-dev
-# Install Bazel 1.1.0
-if [ ! -d bazel ]; then
-  mkdir bazel
-  pushd bazel
-    # Note that bazel unzips itself so we can't just pipe it to sudo bash.
-    curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-installer-linux-x86_64.sh
-    chmod +x bazel-1.1.0-installer-linux-x86_64.sh
-    sudo ./bazel-1.1.0-installer-linux-x86_64.sh
+# Prior livegrep deps, now rust wants libssl-dev still
+sudo apt-get install -y unzip libssl-dev
+
+# Install Bazelisk to install bazel as needed.  bazezlisk is like nvm.
+if [ ! -d bazelisk ]; then
+  mkdir bazelisk
+  pushd bazelisk
+    curl -sSfL -O https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+    chmod +x bazelisk-linux-amd64
   popd
 fi
+BAZEL=~/bazelisk/bazelisk-linux-amd64
 
 # Clang
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -87,6 +87,7 @@ sudo apt-get install -y clang${CLANG_SUFFIX} libclang${CLANG_SUFFIX}-dev
 sudo update-alternatives --install /usr/bin/llvm-config llvm-config /usr/bin/llvm-config${CLANG_SUFFIX} ${CLANG_PRIORITY}
 sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang${CLANG_SUFFIX} ${CLANG_PRIORITY}
 sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++${CLANG_SUFFIX} ${CLANG_PRIORITY}
+sudo update-alternatives --install /usr/bin/llvm-symbolizer llvm-symbolizer /usr/bin/llvm-symbolizer${CLANG_SUFFIX} ${CLANG_PRIORITY}
 
 # Install zlib.h (needed for NSS build)
 sudo apt-get install -y zlib1g-dev
@@ -118,9 +119,9 @@ cargo install cargo-insta
 
 # Install codesearch.
 if [ ! -d livegrep ]; then
-  git clone -b mozsearch-version5 https://github.com/mozsearch/livegrep
+  git clone -b mozsearch-version6 https://github.com/mozsearch/livegrep
   pushd livegrep
-    bazel build //src/tools:codesearch
+    $BAZEL build //src/tools:codesearch
     sudo install bazel-bin/src/tools/codesearch /usr/local/bin
   popd
   # Remove ~2G of build artifacts that we don't need anymore

--- a/infrastructure/vagrant/indexer-provision.sh
+++ b/infrastructure/vagrant/indexer-provision.sh
@@ -11,13 +11,17 @@ if [ -f $HOME/.provisioned ]; then
     cat $HOME/.provisioned
     exit 1
 fi
-git -C /vagrant log -1 > $HOME/.provisioned
-
 # Bug 1766697:
 # Compensate for UID/GID mis-matches that freak out git after
 # https://github.blog/2022-04-12-git-security-vulnerability-announced/.
 # We could alternately fix the problem by involving vagrant-bindfs.
 git config --global --add safe.directory /vagrant
+
+git -C /vagrant log -1 > $HOME/.provisioned
+
+# /home/vagrant lost the o+rx at some point, so we put it back so that nginx's
+# www-data user can read the file contents.
+chmod a+rx /home/vagrant
 
 # Install SpiderMonkey.
 rm -rf jsshell-linux-x86_64.zip js

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -38,18 +38,18 @@ sudo apt-get install -y parallel unzip python3-pip
 sudo apt-get install -y jq
 sudo pip3 install yq
 
-# Livegrep (Bazel is needed for Livegrep builds, OpenJDK 8 required for bazel)
-sudo apt-get install -y unzip openjdk-8-jdk libssl-dev
-# Install Bazel 1.1.0
-if [ ! -d bazel ]; then
-  mkdir bazel
-  pushd bazel
-    # Note that bazel unzips itself so we can't just pipe it to sudo bash.
-    curl -sSfL -O https://github.com/bazelbuild/bazel/releases/download/1.1.0/bazel-1.1.0-installer-linux-x86_64.sh
-    chmod +x bazel-1.1.0-installer-linux-x86_64.sh
-    sudo ./bazel-1.1.0-installer-linux-x86_64.sh
+# Prior livegrep deps, now rust wants libssl-dev still
+sudo apt-get install -y unzip libssl-dev
+
+# Install Bazelisk to install bazel as needed.  bazezlisk is like nvm.
+if [ ! -d bazelisk ]; then
+  mkdir bazelisk
+  pushd bazelisk
+    curl -sSfL -O https://github.com/bazelbuild/bazelisk/releases/download/v1.11.0/bazelisk-linux-amd64
+    chmod +x bazelisk-linux-amd64
   popd
 fi
+BAZEL=~/bazelisk/bazelisk-linux-amd64
 
 # Nginx
 sudo apt-get install -y nginx
@@ -71,9 +71,9 @@ fi
 
 # Install codesearch.
 if [ ! -d livegrep ]; then
-  git clone -b mozsearch-version5 https://github.com/mozsearch/livegrep
+  git clone -b mozsearch-version6 https://github.com/mozsearch/livegrep
   pushd livegrep
-    bazel build //src/tools:codesearch
+    $BAZEL build //src/tools:codesearch
     sudo install bazel-bin/src/tools/codesearch /usr/local/bin
   popd
   # Remove ~2G of build artifacts that we don't need anymore

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -63,7 +63,7 @@ expression: "&json_results"
     "target": 1,
     "kind": "use",
     "pretty": "RAND_MAX",
-    "sym": "M_85a652bdd3e78849"
+    "sym": "M_99e652bdd3e78849"
   },
   {
     "loc": "00063:14-47",
@@ -1132,7 +1132,7 @@ expression: "&json_results"
     "syntax": "function,use",
     "pretty": "function rand",
     "sym": "rand",
-    "type": "int (void) throw()"
+    "type": "int (void) noexcept(true)"
   },
   {
     "loc": "00034:8-21",
@@ -1148,7 +1148,7 @@ expression: "&json_results"
     "source": 1,
     "syntax": "macro,use",
     "pretty": "macro RAND_MAX",
-    "sym": "M_85a652bdd3e78849"
+    "sym": "M_99e652bdd3e78849"
   },
   {
     "loc": "00036:8-12",


### PR DESCRIPTION
Likely appropriate steps for people to do locally:
- On linux, make sure you have a recent version of `vagrant-libvirt`.  Things
  work for me with `vagrant-libvirt` 0.7.0 on Ubuntu 22.04 as a host.
- Run `vagrant destroy`
- Run `vagrant up --no-destroy-on-error`.  If you experience any errors,
  check the logs which you can access via `vagrant ssh`.
- It will likely be necessary to manually `make clean` in `clang-plugin`
  before running `make build-test-repo` in `/vagrant` in the VM.