### PR TITLE
Bug 1771805 - provision lz4

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -55,7 +55,7 @@ sudo apt-get remove -y unattended-upgrades
 sudo apt-get install -y gdb python3-dbg
 
 # Other
-sudo apt-get install -y parallel python3-virtualenv python3-pip
+sudo apt-get install -y parallel python3-virtualenv python3-pip lz4
 
 # we want to be able to extract stuff from json and yaml
 sudo apt-get install -y jq

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -32,7 +32,7 @@ sudo apt-get remove -y unattended-upgrades
 sudo apt-get install -y gdb python3-dbg
 
 # Other
-sudo apt-get install -y parallel unzip python3-pip
+sudo apt-get install -y parallel unzip python3-pip lz4
 
 # and we want to be able to extract stuff from json and yaml
 sudo apt-get install -y jq


### PR DESCRIPTION
lz4 was somehow already installed in the 20.04 instances, but that disappeared with 22.04... very much an "include what you use" sort of lesson, I'm sure.