### PR TITLE
Bug 1771805 - make sure the home directory can be accessed via nginx

### DIFF
--- a/infrastructure/aws/indexer-provision.sh
+++ b/infrastructure/aws/indexer-provision.sh
@@ -6,6 +6,9 @@ set -o pipefail # Check all commands in a pipeline
 
 date
 
+# as of Ubuntu 22.04 /home/ubuntu is no longer o+rx so we need to manually do it.
+chmod a+rx ~
+
 # ## Script Ordering
 #
 # This script now gets run before the non-AWS provisioner so that we can

--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -6,6 +6,9 @@ set -o pipefail # Check all commands in a pipeline
 
 date
 
+# as of Ubuntu 22.04 /home/ubuntu is no longer o+rx so we need to manually do it.
+chmod a+rx ~
+
 # ## Script Ordering
 #
 # This script now gets run before the non-AWS provisioner so that we can


### PR DESCRIPTION
All of the indexers failed to pivot their web-servers into place as
they ended up hung waiting to be able to load `status.txt`.  This
revealed that trigger-web-server.py's prints don't seem to be getting
into the `index-log` which is not what I was expecting and led me to
initially assume this was something else.

This was the same thing I saw inside the vagrant VM before but I'd
assumed that was only a change in the vagrant based VM.  Whoops!
Very humbling.