### PR TITLE
panel: Fix deindent with leading line with no whitespace.

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -233,7 +233,9 @@ var Panel = new (class Panel {
         return existingPrefix;
       }
 
-      let min = existingPrefix
+      // NOTE: existingPrefix === null means it's first call.
+      //       existingPrefix === "" means there's no leading whitespace.
+      let min = existingPrefix !== null
         ? Math.min(existingPrefix.length, lineText.length)
         : lineText.length;
       let count = 0;


### PR DESCRIPTION
This fixes the case that the first line has no whitespace.
the current code ignores that line and always deindent removing the first line's characters