### PR TITLE
Bug 1779672 - log codesearch stats, prevent default submit

### DIFF
--- a/router/codesearch.py
+++ b/router/codesearch.py
@@ -55,7 +55,9 @@ def do_search(host, port, pattern, fold_case, file, context_lines):
     channel.close()
 
     matches = collateMatches(result.results)
-    log('  codesearch result with %d line matches across %d paths - %f', len(result.results), len(matches), time.time() - t)
+    log('  codesearch result with %d line matches across %d paths - %f : %s',
+        len(result.results), len(matches), time.time() - t,
+        repr(result.stats).replace('\n', ', '))
     return (matches, livegrep_pb2.SearchStats.ExitReason.Name(result.stats.exit_reason) == 'TIMEOUT')
 
 def daemonize(args):

--- a/scripts/output.js
+++ b/scripts/output.js
@@ -104,7 +104,10 @@ function generate(content, opt)
         </div>
       </div>
     </fieldset>
-    <input type="submit" value="Search" class="visually-hidden" />
+    <!-- We're marking this disabled in order to avoid the user pressing enter
+         triggering the default submit behavior and conflicting with our dynamic
+         logic. -->
+    <input type="submit" value="Search" disabled class="visually-hidden" />
   </form>
 </div>
 

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -175,7 +175,7 @@ pub fn generate_header(opt: &Options, writer: &mut dyn Write) -> Result<(), &'st
         F::S("</div>"),
         F::S(r#"<div id="path-section">"#),
         F::Indent(vec![
-            F::S(r#"<label for="query" class="query_label visually-hidden">Path</label>"#),
+            F::S(r#"<label for="path" class="query_label visually-hidden">Path</label>"#),
             F::S(
                 r#"<input type="text" name="path" value="" maxlength="2048" id="path" accesskey="p" title="Path" placeholder="Path filter (supports globbing and ^, $)" autocomplete="off" />"#,
             ),
@@ -206,7 +206,8 @@ pub fn generate_header(opt: &Options, writer: &mut dyn Write) -> Result<(), &'st
         F::S("<fieldset>"),
         F::Indent(fieldset),
         F::S("</fieldset>"),
-        F::S(r#"<input type="submit" value="Search" class="visually-hidden" />"#),
+        F::S("<!-- disabled to avoid enter-submits behavior that conflicts with JS search logic -->"),
+        F::S(r#"<input type="submit" value="Search" disabled class="visually-hidden" />"#),
         F::S(r#"<div id="revision">"#),
         F::Indent(revision),
         F::S("</div>"),

--- a/tools/templates/header_query.liquid
+++ b/tools/templates/header_query.liquid
@@ -24,6 +24,8 @@
             <section id="spinner"></section>
         </div>
     </fieldset>
+    <!-- We currently depend on the default submit behavior for Query so we do
+         not mark this disabled like we do for "search" -->
     <input type="submit" value="Search" class="visually-hidden" />
     </form>
 </div>

--- a/tools/templates/header_search.liquid
+++ b/tools/templates/header_search.liquid
@@ -40,6 +40,9 @@
         </div>
         </div>
     </fieldset>
-    <input type="submit" value="Search" class="visually-hidden" />
+    <!-- We're marking this disabled in order to avoid the user pressing enter
+         triggering the default submit behavior and conflicting with our dynamic
+         logic. -->
+    <input type="submit" value="Search" disabled class="visually-hidden" />
     </form>
 </div>


### PR DESCRIPTION
codesearch has stats we can log as well, noting that the repr will elide
zero values.

Potentially more notably, we inhibit the default submit behavior of the
search field in favor of our magic AJAX logic.  It would potentially be
better to explicitly handle the user pressing enter as an acceleration
of `startSearchSoon` via `startSearch` since startSearchSoon has a
300ms delay, but I'm going to have that be an enhancement since this
minimal fix is easier and an overall win for the user and the server.