### PR TITLE
Move from using virtualenv to venv, motivated by glean builds failing.

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -85,8 +85,10 @@ not work properly in a headless VM, but if you do that flow outside the VM and
 copy the resulting credentials into the VM that might work.
 
 To start, you'll need to create some AWS configuration files in your
-home directory, and set up a python3 virtual environment with some AWS-related
-packages:
+home directory, and set up a python3 venv environment with some AWS-related
+packages.  See https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/
+for more on installing venv, but on ubuntu you should be able to run
+`apt install python3-venv`.
 
 ```
 # RUN THESE COMMANDS OUTSIDE THE VM!
@@ -98,7 +100,7 @@ cat > ~/.aws/config <<"THEEND"
 region = us-west-2
 THEEND
 
-virtualenv --python=python3 env
+python3 -m venv env
 source env/bin/activate
 pip install boto3 awscli rich mozilla-aws-cli-mozilla
 # Make sure that we have an up-to-date version of certifi for certificate
@@ -544,6 +546,6 @@ by running
 infrastructure/aws/terminate-indexer.py <instance-id>
 infrastructure/aws/delete-volume.py <volume-id>
 ```
-from within your local searchfox virtualenv (see the above section
+from within your local searchfox venv (see the above section
 on setting up AWS locally). The terminate-indexer.py script or the
 web console will let you know the volume ID of the volume to delete.

--- a/infrastructure/aws/build-lambda-indexer-start.sh
+++ b/infrastructure/aws/build-lambda-indexer-start.sh
@@ -38,8 +38,11 @@ def start(event, context):
 EOF
 
 pushd /tmp/lambda
-virtualenv --python=python3 env
+python3 -m venv env
 env/bin/pip install boto3
+# Note: The below comment may no longer apply since we've migrated from
+# virtualenv to venv, but it seems like it can't hurt, so I'm leaving it around.
+#
 # Because our virtualenv doesn't specify --no-seed/--without-pip, it may pull
 # packages from your machine into the virtualenv which can include a potentially
 # out-of-date version of certifi.  For example, on asuth's Ubuntu 20.04 machine,

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -53,7 +53,7 @@ sudo apt-get remove -y unattended-upgrades
 sudo apt-get install -y gdb python3-dbg
 
 # Other
-sudo apt-get install -y parallel unzip python3-pip python3-virtualenv lz4
+sudo apt-get install -y parallel unzip python3-pip python3-venv lz4
 
 # and we want to be able to extract stuff from json and yaml
 sudo apt-get install -y jq


### PR DESCRIPTION
Glean indexing run builds on config4 have been failing with:
```
   Compiling sample v0.1.0 (/mnt/index-scratch/glean/git/samples/rust)
    Checking ordered-float v3.0.0
    Checking url v2.2.2
    Checking lmdb-rkv v0.14.0
error: failed to run custom build command for `sample v0.1.0 (/mnt/index-scratch/glean/git/samples/rust)`

Caused by:
  process didn't exit successfully: `/mnt/index-scratch/glean/objdir/debug/build/sample-46862ee66fd1b733/build-script-build` (exit status: 101)
  --- stdout
  Python 3.10.4
  The virtual environment was not created successfully because ensurepip is not
  available.  On Debian/Ubuntu systems, you need to install the python3-venv
  package using the following command.

      apt install python3.10-venv

  You may need to use sudo with that command.  After installing the python3-venv
  package, recreate your virtual environment.

  Failing command: ['/mnt/index-scratch/glean/objdir/debug/venv-py3-glean_parser/bin/python3', '-Im', 'ensurepip', '--upgrade', '--default-pip']


  --- stderr
  $ python3 --version
  $ python3 -m venv /mnt/index-scratch/glean/objdir/debug/venv-py3-glean_parser
  thread 'main' panicked at 'Error generating Glean Rust bindings: command exited with non-zero code `python3 -m venv /mnt/index-scratch/glean/objdir/debug/venv-py3-glean_parser`: 1', sample
s/rust/build.rs:8:10
```

Before this patch, we currently install `python3-virtualenv` for our AWS scripts outside the VM and for the lambda script generation inside the VM.  I'm changing our docs and automation here to use `python3-venv` instead to be consistent with best practices which will also help the glean build.