### PR TITLE
Bug 1703115 - address divergence in update functions in provisioning

### DIFF
--- a/infrastructure/common-provision-post.sh
+++ b/infrastructure/common-provision-post.sh
@@ -4,18 +4,3 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-# Run the update script for a side effect of downloading the crates.io
-# dependencies ahead of time since we're seeing intermittent network problems
-# downloading crates in https://bugzilla.mozilla.org/show_bug.cgi?id=1720037.
-#
-# Note that because the update script fully deletes the mozsearch directory,
-# this really is just:
-# - Validating the image can compile and use rust and clang correctly.
-# - Caching some crates in `~/.cargo`.
-./update.sh master https://github.com/mozsearch/mozsearch https://github.com/mozsearch/mozsearch-mozilla
-mv update-log provision-update-log-1
-
-# Run this a second time to make sure the script is actually idempotent, so we
-# don't have any surprises when the update script gets run when the VM spins up.
-./update.sh master https://github.com/mozsearch/mozsearch https://github.com/mozsearch/mozsearch-mozilla
-mv update-log provision-update-log-2

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -68,3 +68,19 @@ date
 THEEND
 
 chmod +x update.sh
+
+# Run the update script for a side effect of downloading the crates.io
+# dependencies ahead of time since we're seeing intermittent network problems
+# downloading crates in https://bugzilla.mozilla.org/show_bug.cgi?id=1720037.
+#
+# Note that because the update script fully deletes the mozsearch directory,
+# this really is just:
+# - Validating the image can compile and use rust and clang correctly.
+# - Caching some crates in `~/.cargo`.
+./update.sh master https://github.com/mozsearch/mozsearch https://github.com/mozsearch/mozsearch-mozilla
+mv update-log provision-update-log-1
+
+# Run this a second time to make sure the script is actually idempotent, so we
+# don't have any surprises when the update script gets run when the VM spins up.
+./update.sh master https://github.com/mozsearch/mozsearch https://github.com/mozsearch/mozsearch-mozilla
+mv update-log provision-update-log-2

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -61,3 +61,19 @@ date
 THEEND
 
 chmod +x update.sh
+
+# Run the update script for a side effect of downloading the crates.io
+# dependencies ahead of time since we're seeing intermittent network problems
+# downloading crates in https://bugzilla.mozilla.org/show_bug.cgi?id=1720037.
+#
+# Note that because the update script fully deletes the mozsearch directory,
+# this really is just:
+# - Validating the image can compile and use rust and clang correctly.
+# - Caching some crates in `~/.cargo`.
+./update.sh https://github.com/mozsearch/mozsearch master https://github.com/mozsearch/mozsearch-mozilla master
+mv update-log provision-update-log-1
+
+# Run this a second time to make sure the script is actually idempotent, so we
+# don't have any surprises when the update script gets run when the VM spins up.
+./update.sh https://github.com/mozsearch/mozsearch master https://github.com/mozsearch/mozsearch-mozilla master
+mv update-log provision-update-log-2


### PR DESCRIPTION
I'd moved the invocations of the update script into common provisioning
logic, but that is no longer appropriate now that the update scripts
differ in how they specify revisions.