### PR TITLE
Bug 1782375 - Upload fix, `handle_tree_error` gets a better message

### DIFF
--- a/infrastructure/indexer-upload.sh
+++ b/infrastructure/indexer-upload.sh
@@ -26,7 +26,7 @@ do
     # If the setup script failed, indexer-setup.sh will have used the
     # `inhibit_upload` function exported by `load-vars.sh` to create an
     # `INHIBIT_UPLOAD` marker at the root of the tree.
-    if [ -f $CONFIG_REPO/$TREE_NAME/upload && ! -f $INDEX_ROOT/INHIBIT_UPLOAD ]
+    if [[ -f $CONFIG_REPO/$TREE_NAME/upload && ! -f $INDEX_ROOT/INHIBIT_UPLOAD ]]
     then
         $CONFIG_REPO/$TREE_NAME/upload || handle_tree_error "tree upload script"
     fi

--- a/scripts/load-vars.sh
+++ b/scripts/load-vars.sh
@@ -32,7 +32,7 @@ export -f inhibit_upload
 
 handle_tree_error() {
     local msg=$1
-    echo "warning: Tree error: $msg"
+    echo "warning: Tree '$TREE_NAME' error: $msg"
     if [[ $TREE_ON_ERROR == "continue" ]]; then
         return 0
     fi


### PR DESCRIPTION
The additional conditional in the upgrade logic was using `[` instead
of `[[` which is required.  This resulted in a nicely interesting
cascade failure for config4 when config1 failed to update (as inspected
via logs for the ongoing config4).