### PR TITLE
Bug 1783761 - Upgrade to clap v3 from clap v2/structopt

### DIFF
--- a/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__outercat_meet__dot
+++ b/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__outercat_meet__dot
@@ -1,1 +1,1 @@
-search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse | graph --format=rawdot
+search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse | graph --format=raw-dot

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -289,17 +289,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "8e538f9ee5aa3b3963f09a997035f883677966ed50fce0292611927ce6f6d8c6"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f98063cac4652f23ccda556b8d04347a7fc4b2cff1f7577cc8c6546e0d8078"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -787,15 +811,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
 dependencies = [
  "ahash",
-]
-
-[[package]]
-name = "heck"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1637,6 +1652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1938,7 +1959,7 @@ dependencies = [
  "bytes 1.1.0",
  "cfg-if",
  "cmake",
- "heck 0.4.0",
+ "heck",
  "itertools 0.10.3",
  "lazy_static",
  "log 0.4.14",
@@ -2499,33 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -2602,12 +2599,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thin-slice"
@@ -2903,7 +2897,6 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "shell-words",
- "structopt",
  "tokio",
  "tokio-stream",
  "toml",
@@ -3184,12 +3177,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -12,7 +12,7 @@ async-stream = "0.3.2"
 async-trait = "0.1.50"
 axum = "0.5.3"
 chrono = "0.2"
-clap = "2"
+clap = { version = "3.0", features = ["cargo", "derive", "env"] }
 dot-generator = "0.2.0"
 dot-structures = "0.1.0"
 env_logger = "0.7.1"
@@ -55,7 +55,6 @@ shell-words = "1.0.0"
 serde = { version = "1.0.130", features = ["derive", "rc", "std"] }
 serde_json = { version = "1.0.67", features = ["preserve_order"] }
 serde_repr = "0.1"
-structopt = "0.3"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util"] }
 tokio-stream = "0.1.8"
 toml = "0.5.9"

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -1,3 +1,5 @@
+use clap::Parser;
+
 use crate::{
     abstract_server::AbstractServer,
     cmd_pipeline::{
@@ -5,7 +7,6 @@ use crate::{
         cmd_search_text::SearchTextCommand, interface::JunctionInvocation, PipelineCommand,
     },
     query::chew_query::QueryPipelineGroupBuilder,
-    structopt::StructOpt,
 };
 use tracing::{trace, trace_span};
 use url::Url;
@@ -110,7 +111,7 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
         let mut fake_args = vec![bin_name.to_string()];
         fake_args.extend(arg_slices.iter().cloned());
 
-        let opts = match ToolOpts::from_iter_safe(fake_args) {
+        let opts = match ToolOpts::try_parse_from(fake_args) {
             Ok(opts) => opts,
             Err(err) => {
                 return Err(ServerError::StickyProblem(ErrorDetails {
@@ -178,7 +179,7 @@ pub fn build_pipeline_graph(
                             .chain(&segment.args)
                             .cloned()
                             .collect();
-                    let opts = match ToolOpts::from_iter_safe(full_args) {
+                    let opts = match ToolOpts::try_parse_from(full_args) {
                         Ok(opts) => opts,
                         Err(err) => {
                             return Err(ServerError::StickyProblem(ErrorDetails {
@@ -229,7 +230,7 @@ pub fn build_pipeline_graph(
             .chain(&junction_info.command.args)
             .cloned()
             .collect();
-            let opts = match JunctionOpts::from_iter_safe(full_args) {
+            let opts = match JunctionOpts::try_parse_from(full_args) {
                 Ok(opts) => opts,
                 Err(err) => {
                     return Err(ServerError::StickyProblem(ErrorDetails {

--- a/tools/src/cmd_pipeline/cmd_augment_results.rs
+++ b/tools/src/cmd_pipeline/cmd_augment_results.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, collections::HashMap, rc::Rc};
 
 use async_trait::async_trait;
 use lol_html::{element, HtmlRewriter, Settings};
-use structopt::StructOpt;
+use clap::StructOpt;
 
 use super::interface::{PipelineCommand, PipelineValues};
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError, HtmlFileRoot};
@@ -35,11 +35,11 @@ use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, S
 #[derive(Debug, StructOpt)]
 pub struct AugmentResults {
     /// Lines of context before a hit.
-    #[structopt(short, long, default_value = "0")]
+    #[structopt(short, long, value_parser, default_value = "0")]
     before: u32,
 
     /// Lines of context after a hit.
-    #[structopt(short, long, default_value = "0")]
+    #[structopt(short, long, value_parser, default_value = "0")]
     after: u32,
 }
 

--- a/tools/src/cmd_pipeline/cmd_batch_render.rs
+++ b/tools/src/cmd_pipeline/cmd_batch_render.rs
@@ -1,13 +1,13 @@
 use async_trait::async_trait;
 use serde_json::{to_value};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::{interface::{JsonValue, PipelineCommand, PipelineValues}, builder::build_pipeline_graph};
 use crate::{
     abstract_server::{AbstractServer, Result}, query::chew_query::chew_query,
 };
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct BatchRender {
     /// Preconfigured rendering task.  This could be an enum or sub-command, but
     /// for now we're just going for strings.

--- a/tools/src/cmd_pipeline/cmd_cat_html.rs
+++ b/tools/src/cmd_pipeline/cmd_cat_html.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use lol_html::{element, rewrite_str, RewriteStrSettings, html_content::ContentType};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{PipelineCommand, PipelineValues, TextFile};
 use crate::{
@@ -24,17 +24,18 @@ use crate::{
 ///
 /// Differs from show-html which is about excerpting source lines and which has
 /// a separate "prod-filter" helper for production "checks".
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CatHtml {
     /// Tree-relative source file path or directory.
+    #[clap(value_parser)]
     file: String,
 
     /// Is this a directory's HTML we want (instead of a source file)?
-    #[structopt(short, long)]
+    #[clap(short, long, action)]
     dir: bool,
 
     /// Is this a template's HTML we want?
-    #[structopt(short, long)]
+    #[clap(short, long, action)]
     template: bool,
 }
 

--- a/tools/src/cmd_pipeline/cmd_compile_results.rs
+++ b/tools/src/cmd_pipeline/cmd_compile_results.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use async_trait::async_trait;
 use regex::Regex;
 use serde_json::{from_value, Value};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{
     FileMatch, FlattenedKindGroupResults, FlattenedLineSpan, FlattenedPathKindGroupResults,
@@ -25,15 +25,15 @@ use crate::{
 /// by key/kind precedence (files, IDL, defs, override stuff, super/subclass
 /// stuff, assignments, uses, declarations, text matches), noting that
 /// precedences will likely change.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CompileResults {
     /// Maximum number of file results to list, truncating at the limit.
-    #[structopt(short, long, default_value = "2000")]
+    #[clap(short, long, value_parser, default_value = "2000")]
     file_limit: usize,
 
     /// Maximum number of result lines to limit, truncating at the limit.
     /// Context lines don't impact this limit.
-    #[structopt(short, long, default_value = "2000")]
+    #[clap(short, long, value_parser, default_value = "2000")]
     line_limit: usize,
 }
 

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -2,7 +2,7 @@ use std::collections::{HashSet, VecDeque};
 
 use async_trait::async_trait;
 use serde_json::Value;
-use structopt::StructOpt;
+use clap::Args;
 use tracing::{trace};
 
 use super::interface::{
@@ -16,16 +16,16 @@ use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, S
 /// relationships like override set membership.  This is fundamentally entwined
 /// with what information we want to present in search results and how we want
 /// to present it.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CrossrefExpand {
-    #[structopt(long, default_value = "100")]
+    #[clap(long, value_parser, default_value = "100")]
     pub subclass_local_limit: u32,
-    #[structopt(long, default_value = "400")]
+    #[clap(long, value_parser, default_value = "400")]
     pub subclass_global_limit: u32,
 
-    #[structopt(long, default_value = "100")]
+    #[clap(long, value_parser, default_value = "100")]
     pub override_local_limit: u32,
-    #[structopt(long, default_value = "400")]
+    #[clap(long, value_parser, default_value = "400")]
     pub override_global_limit: u32,
 }
 

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{
     PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolList, SymbolWithContext, SymbolQuality, SymbolRelation,
@@ -9,16 +9,17 @@ use crate::abstract_server::{AbstractServer, Result, ServerError, ErrorDetails, 
 
 /// Return the crossref data for one or more symbols received via pipeline or as
 /// explicit arguments.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CrossrefLookup {
     /// Explicit symbols to lookup.
+    #[clap(value_parser)]
     symbols: Vec<String>,
     // TODO: It might make sense to provide a way to filter the looked up data
     // by kind, although that could of course be its own command too.
 
     /// If the looked up symbol turns out to be a class with methods, instead of
     /// adding the class to the set, add its methods.
-    #[structopt(long)]
+    #[clap(long, action)]
     methods: bool,
 }
 

--- a/tools/src/cmd_pipeline/cmd_filter_analysis.rs
+++ b/tools/src/cmd_pipeline/cmd_filter_analysis.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Args;
 use tokio_stream::StreamExt;
 
 use super::interface::{
@@ -11,18 +11,19 @@ use crate::{
 };
 
 /// Filter the contents of a single analysis file.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct FilterAnalysis {
     /// Tree-relative analysis file path
+    #[clap(value_parser)]
     file: String,
 
-    #[structopt(long, short, possible_values = &RecordType::variants(), case_insensitive = true)]
+    #[clap(long, short, value_parser, value_enum)]
     record_type: Option<Vec<RecordType>>,
 
-    #[structopt(long, short)]
+    #[clap(long, short, value_parser)]
     kind: Option<String>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     query_opts: SymbolicQueryOpts,
 }
 
@@ -51,7 +52,7 @@ impl PipelineCommand for FilterAnalysisCommand {
                 // "source", "target", or "structured" so check for the
                 // stringified version of the enum value.
                 for rt in record_types {
-                    if val.get(rt.to_string().to_lowercase()).is_some() {
+                    if val.get(rt.name()).is_some() {
                         return true;
                     }
                 }

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde_json::{from_str, Value};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{
     JsonRecords, PipelineCommand, PipelineValues,
@@ -12,13 +12,14 @@ use crate::{
 };
 
 /// Merge analysis files from different build configs into one analysis file.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct MergeAnalyses {
     /// Tree-relative analysis file paths
+    #[clap(value_parser)]
     files: Vec<String>,
 
     /// The list of platforms to claim the files came from.
-    #[structopt(long, short)]
+    #[clap(long, short, value_parser)]
     platforms: Vec<String>,
 }
 

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -5,7 +5,7 @@ use lol_html::{
 };
 use regex::Regex;
 use serde_json::Value;
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{
     JsonRecords, JsonRecordsByFile, JsonValue, PipelineCommand, PipelineValues,
@@ -18,7 +18,7 @@ use crate::{
 /// Normalize HTML or JSON records for production environment checks so that
 /// details like line numbers or `data-i` indexes that are subject to churn
 /// due to changes elsewhere in the file are normalized to "NORM".
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct ProductionFilter {}
 
 #[derive(Debug)]

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use serde_json::{to_value};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::{interface::{JsonValue, PipelineCommand, PipelineValues}, builder::build_pipeline_graph};
 use crate::{
@@ -10,13 +10,14 @@ use crate::{
 /// Run a new-style `query-parser` `term:value` query parse against the local
 /// index.  Remote server is currently a no-op, but when supported the entire
 /// query will be run on the server (because we want to test the server).
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Query {
     /// Query string
+    #[clap(value_parser)]
     query: String,
 
     /// Output the constructed pipeline instead of running the pipeline.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     dump_pipeline: bool,
 }
 

--- a/tools/src/cmd_pipeline/cmd_search.rs
+++ b/tools/src/cmd_pipeline/cmd_search.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use json_structural_diff::JsonDiff;
 use serde_json::{json, Map, Value};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{JsonValue, PipelineCommand, PipelineValues};
 use crate::abstract_server::{AbstractServer, Result};
@@ -9,26 +9,27 @@ use crate::abstract_server::{AbstractServer, Result};
 /// Run a traditional searchfox search against the web server.  This will turn
 /// into a no-op when run against a local index at this time, but in the future
 /// may be able to spin up the necessary pieces.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Search {
     /// Query string
+    #[clap(value_parser)]
     query: String,
 
     /// Diff the results of this query against the previous command's output,
     /// producing diff output.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     diff: bool,
 
     /// Normalize "bounds" out of existence because they can differ when using
     /// different query strings.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     normalize: bool,
 
     /// Convert arrays of "path"-keyed objects to a dict whose keys are the "path"
     /// values and the value is still the same value, including "path".  This is
     /// meant to make the diff option more friendly in cases where ordering is not
     /// a concern.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     dictify: bool,
 }
 

--- a/tools/src/cmd_pipeline/cmd_search_files.rs
+++ b/tools/src/cmd_pipeline/cmd_search_files.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Args;
 
 use super::{
     interface::{PipelineCommand, PipelineValues, FileMatches, FileMatch},
@@ -10,16 +10,17 @@ use crate::abstract_server::{AbstractServer, Result};
 
 /// Perform a fulltext search against our livegrep/codesearch server over gRPC.
 /// This is local-only at this time.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct SearchFiles {
     /// Path to search for; this will be searchfox glob-transformed.
+    #[clap(value_parser)]
     path: Option<String>,
 
     /// Constrain matching path patterns with a regexp.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pathre: Option<String>,
 
-    #[structopt(short, long, default_value = "1000")]
+    #[clap(short, long, value_parser, default_value = "1000")]
     limit: usize,
 }
 

--- a/tools/src/cmd_pipeline/cmd_search_identifiers.rs
+++ b/tools/src/cmd_pipeline/cmd_search_identifiers.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{
     IdentifierList, PipelineCommand, PipelineValues, SymbolList, SymbolQuality, SymbolWithContext,
@@ -9,26 +9,27 @@ use crate::abstract_server::{AbstractServer, Result};
 
 /// Return the crossref data for one or more symbols received via pipeline or as
 /// explicit arguments.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct SearchIdentifiers {
     /// Explicit identifiers to search.
+    #[clap(value_parser)]
     identifiers: Vec<String>,
 
     /// Should this be an exact-match?  By default we do a prefix search.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     exact_match: bool,
 
     /// Should this be case-sensitive?  By default we are case-insensitive.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     case_sensitive: bool,
 
     /// Minimum identifier length to search for.  The default of 3 is derived
     /// from router.py's `is_trivial_search` heuristic requiring a length of 3,
     /// although it was only required along one axis.
-    #[structopt(long, default_value = "3")]
+    #[clap(long, value_parser, default_value = "3")]
     min_length: usize,
 
-    #[structopt(short, long, default_value = "1000")]
+    #[clap(short, long, value_parser, default_value = "1000")]
     limit: usize,
 }
 

--- a/tools/src/cmd_pipeline/cmd_search_text.rs
+++ b/tools/src/cmd_pipeline/cmd_search_text.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use structopt::StructOpt;
+use clap::Args;
 
 use super::{interface::{PipelineCommand, PipelineValues}, transforms::path_glob_transform};
 
@@ -7,29 +7,30 @@ use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, S
 
 /// Perform a fulltext search against our livegrep/codesearch server over gRPC.
 /// This is local-only at this time.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct SearchText {
     /// Text to search for; this will be regexp escaped.
+    #[clap(value_parser)]
     text: Option<String>,
 
     /// Search for a regular expression.  This can't be used if `text` is used.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     re: Option<String>,
 
     /// Constrain matching path patterns with a non-regexp path constraint that
     /// will be escaped into a regexp.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     path: Option<String>,
 
     /// Constrain matching path patterns with a regexp.
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     pathre: Option<String>,
 
     /// Should this be case-sensitive?  By default we are case-insensitive.
-    #[structopt(short, long)]
+    #[clap(short, long, value_parser)]
     case_sensitive: bool,
 
-    #[structopt(short, long, default_value = "0")]
+    #[clap(short, long, value_parser, default_value = "0")]
     limit: usize,
 }
 

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -2,7 +2,7 @@ use std::{cell::Cell, rc::Rc};
 
 use async_trait::async_trait;
 use lol_html::{element, HtmlRewriter, Settings};
-use structopt::StructOpt;
+use clap::Args;
 
 use super::interface::{JsonRecords, PipelineCommand, PipelineValues};
 use crate::{
@@ -20,7 +20,7 @@ use crate::{
 /// be driven by command-line use-cases; in particular, the experience of
 /// evolving a more targeted query.  Having to modify a command up-stream should
 /// be considered undesirable.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct ShowHtml {}
 
 #[derive(Debug)]

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use itertools::Itertools;
 use serde_json::Value;
-use structopt::StructOpt;
+use clap::Args;
 use tracing::trace;
 
 use super::{
@@ -18,7 +18,7 @@ use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, S
 /// Processes piped-in crossref symbol data, recursively traversing the given
 /// edges, building up a graph that also holds onto the crossref data for all
 /// traversed symbols.
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Traverse {
     /// The edge to traverse, currently "uses" or "callees".
     ///
@@ -35,12 +35,12 @@ pub struct Traverse {
     ///
     /// The fancy prototype previously did but we don't do yet:
     /// - Ignores edges to nodes that are 'boring' as determined by hardcoded
-    #[structopt(long, short, default_value = "callees")]
+    #[clap(long, short, value_parser, default_value = "callees")]
     edge: String,
 
     /// Maximum traversal depth.  Traversal will also be constrained by the
     /// applicable node-limit, but is effectively breadth-first.
-    #[structopt(long, short, default_value = "8")]
+    #[clap(long, short, value_parser, default_value = "8")]
     max_depth: u32,
 
     /// When enabled, the traversal will be performed with the higher
@@ -48,17 +48,17 @@ pub struct Traverse {
     /// traversal will be used as pair-wise inputs to the all_simple_paths
     /// petgraph algorithm to derive a new graph which will be constrained to
     /// the normal "node-limit".
-    #[structopt(long)]
+    #[clap(long, value_parser)]
     paths_between: bool,
 
     /// Maximum number of nodes in a resulting graph.  When paths are involved,
     /// we may opt to add the entirety of the path that puts the graph over the
     /// node limit rather than omitting it.
-    #[structopt(long, default_value = "256")]
+    #[clap(long, value_parser, default_value = "256")]
     pub node_limit: u32,
     /// Maximum number of nodes in a graph being built to be processed by
     /// paths-between.
-    #[structopt(long, default_value = "8192")]
+    #[clap(long, value_parser, default_value = "8192")]
     pub paths_between_node_limit: u32,
 
     /// If we see "uses" with this many paths with hits, do not process any of
@@ -68,7 +68,7 @@ pub struct Traverse {
     /// TODO: Probably have the meta capture the total number of uses so we can
     /// just perform a look-up without this hack.  But this hack works for
     /// experimenting.
-    #[structopt(long, default_value = "16")]
+    #[clap(long, value_parser, default_value = "16")]
     pub skip_uses_at_path_count: u32,
 }
 

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use clap::arg_enum;
+use clap::{Args, ValueEnum};
 use serde::Serialize;
 use serde_json::{to_string_pretty, Value};
 use std::{
@@ -7,7 +7,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     fmt::Debug,
 };
-use structopt::StructOpt;
 use tracing::{trace, trace_span};
 
 use crate::abstract_server::TextMatches;
@@ -15,23 +14,31 @@ pub use crate::abstract_server::{AbstractServer, Result};
 
 use super::symbol_graph::SymbolGraphCollection;
 
-arg_enum! {
-  #[derive(Debug, PartialEq)]
-  pub enum RecordType {
-      Source,
-      Target,
-      Structured,
-  }
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
+pub enum RecordType {
+    Source,
+    Target,
+    Structured,
 }
 
-#[derive(Debug, StructOpt)]
+impl RecordType {
+    pub fn name(&self) -> &'static str {
+        match self {
+            RecordType::Source => "source",
+            RecordType::Target => "target",
+            RecordType::Structured => "structured",
+        }
+    }
+}
+
+#[derive(Debug, Args)]
 pub struct SymbolicQueryOpts {
     /// Exact symbol match
-    #[structopt(short)]
+    #[clap(short, value_parser)]
     pub symbol: Option<String>,
 
     /// Exact identifier match
-    #[structopt(short)]
+    #[clap(short, value_parser)]
     pub identifier: Option<String>,
 }
 

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -1,5 +1,4 @@
 extern crate clap;
-extern crate structopt;
 
 pub mod builder;
 pub mod interface;

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -1,5 +1,4 @@
-use clap::arg_enum;
-use structopt::StructOpt;
+use clap::{Parser, Subcommand, ValueEnum};
 
 use super::cmd_augment_results::AugmentResults;
 use super::cmd_cat_html::CatHtml;
@@ -18,39 +17,49 @@ use super::cmd_search_text::SearchText;
 use super::cmd_show_html::ShowHtml;
 use super::cmd_traverse::Traverse;
 
-arg_enum! {
-    #[derive(Clone, Debug, PartialEq)]
-    pub enum OutputFormat {
-        // Pretty-printed JSON.
-        Pretty,
-        // Un-pretty-printed JSON.
-        Concise,
-    }
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
+pub enum OutputFormat {
+    // Pretty-printed JSON.
+    Pretty,
+    // Un-pretty-printed JSON.
+    Concise,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct ToolOpts {
     /// URL of the server to query or the path to the root of the index tree if
     /// using local data.
-    #[structopt(
+    #[clap(
         long,
+        value_parser,
         default_value = "https://searchfox.org/",
         env = "SEARCHFOX_SERVER"
     )]
     pub server: String,
 
     /// The name of the indexed tree to use.
-    #[structopt(long, default_value = "mozilla-central", env = "SEARCHFOX_TREE")]
+    #[clap(
+        long,
+        value_parser,
+        default_value = "mozilla-central",
+        env = "SEARCHFOX_TREE"
+    )]
     pub tree: String,
 
-    #[structopt(long, short, possible_values = &OutputFormat::variants(), case_insensitive = true, default_value = "concise")]
+    #[clap(
+        long,
+        short,
+        value_parser,
+        value_enum,
+        default_value = "concise"
+    )]
     pub output_format: OutputFormat,
 
-    #[structopt(subcommand)]
+    #[clap(subcommand)]
     pub cmd: Command,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum Command {
     AugmentResults(AugmentResults),
     CatHtml(CatHtml),
@@ -69,13 +78,13 @@ pub enum Command {
     Traverse(Traverse),
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct JunctionOpts {
     #[structopt(subcommand)]
     pub cmd: JunctionCommand,
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 pub enum JunctionCommand {
     CompileResults(CompileResults),
 }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -18,7 +18,6 @@ extern crate malloc_size_of;
 extern crate query_parser;
 extern crate serde;
 extern crate serde_json;
-extern crate structopt;
 #[macro_use]
 extern crate tracing;
 extern crate tracing_subscriber;


### PR DESCRIPTION
We were slow enough in this upgrade that the migration ended up being
slightly more involved to make the deprecation warnings go away.  This
mainly entailed adding "value_parser" to everything.

This requires a re-provisioning because of our cargo deps policy that
we want the VM to already have cached the crates locally.