### PR TITLE
Bug 1786216 - Further fix permalink current revision opt

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -203,6 +203,8 @@ for repo in config['trees']:
             f'types {{ {binary_types_str} }}',
             'default_type text/html;',
             'add_header Cache-Control "must-revalidate";',
+            'gzip_static always;',
+            'gunzip on;',
         ])
 
     # Handled by router/router.py


### PR DESCRIPTION
The permalink optimization may actually have been broken even longer
than expected as by fixing the route, I revealed that we hadn't
compensated for the gzip optimization I'd done a long, long, long time
ago and so we were serving the 0-length files.  This implies the
format string might actually have had the same behavior for the byte
string and that this was broken since the change to python3.