### PR TITLE
Bug 1787667 - Avoid getting confused by removed submodules that are now dirs

### DIFF
--- a/tools/src/bin/build-blame.rs
+++ b/tools/src/bin/build-blame.rs
@@ -484,7 +484,13 @@ fn build_blame_tree(
                         None => None,
                         Some(tree) => tree
                             .get_name(entry_name)
-                            .map(|e| e.to_object(git_repo).unwrap())
+                            // In the case where a git submodule has been removed
+                            // and replaced by a regular file/directory in the
+                            // same commit, we expect to_object to fail, and in
+                            // that case we just want to treat it as None, so
+                            // we use ok() instead of unwrap() which we
+                            // previously used.
+                            .and_then(|e| e.to_object(git_repo).ok())
                             .and_then(|o| o.into_tree().ok()),
                     };
                     parent_subtrees.push(parent_subtree);


### PR DESCRIPTION
This is @staktrace's proposed fix of using ok() with the added type consistency change of converting `map` to `and_then` since the type for the closure on `map` is `T -> U` but the type on [and_then](https://doc.rust-lang.org/nightly/core/option/enum.Option.html#method.and_then) is `T -> Option<U>` and we don't want `Option<Option<Object>>`.

This successfully ran on the dev channel.