### PR TITLE
Process mjs files as modules

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -292,7 +292,8 @@ let Analyzer = {
   parse(text, filename, line) {
     let ast;
     try {
-      ast = Reflect.parse(text, {loc: true, source: filename, line});
+      let target = filename.endsWith(".mjs") ? "module" : "script";
+      ast = Reflect.parse(text, {loc: true, source: filename, line, target});
 
       let parsedLines = text.split('\n');
 


### PR DESCRIPTION
Use the .mjs extension to opt in to module parsing.