### PR TITLE
Revert "Process mjs files as modules"

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -292,8 +292,7 @@ let Analyzer = {
   parse(text, filename, line) {
     let ast;
     try {
-      let target = filename.endsWith(".mjs") ? "module" : "script";
-      ast = Reflect.parse(text, {loc: true, source: filename, line, target});
+      ast = Reflect.parse(text, {loc: true, source: filename, line});
 
       let parsedLines = text.split('\n');
 


### PR DESCRIPTION
Reverts mozsearch/mozsearch#568

js-analzye was not prepared for the additional new AST nodes it found in there:
```
/home/ubuntu/mozsearch/scripts/js-analyze.js:326:12 uncaught exception: Unexpected statement: ExportDeclaration
```