### PR TITLE
Bug 1789329 - Add explicit mjs parsing, fallback module parsing, tests.

### DIFF
--- a/scripts/idl-analyze.py
+++ b/scripts/idl-analyze.py
@@ -318,13 +318,7 @@ for l in lines:
     linebreaks.append(cur)
 
 if analysis:
-    # compatibility before and after bug 1633156
-    import inspect
-    initMethod = [obj for (name, obj) in inspect.getmembers(xpidl.IDLParser) if name == '__init__'][0]
-    if 'outputdir' in inspect.getargspec(initMethod).args:
-        p = xpidl.IDLParser(outputdir='/tmp')
-    else:
-        p = xpidl.IDLParser()
+    p = xpidl.IDLParser()
 
     try:
         r = p.parse(text, filename=fname)

--- a/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_ModuleClass__json
+++ b/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_ModuleClass__json
@@ -1,0 +1,1 @@
+filter-analysis imported-module.mjs -k def -i ModuleClass

--- a/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_moduleConst__json
+++ b/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_moduleConst__json
@@ -1,0 +1,1 @@
+filter-analysis imported-module.mjs -k def -i moduleConst

--- a/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_moduleFunc__json
+++ b/tests/tests/checks/inputs/analysis/js/imported-module.mjs/def_moduleFunc__json
@@ -1,0 +1,1 @@
+filter-analysis imported-module.mjs -k def -i moduleFunc

--- a/tests/tests/checks/inputs/analysis/js/root-module.mjs/def_rootModuleConst__json
+++ b/tests/tests/checks/inputs/analysis/js/root-module.mjs/def_rootModuleConst__json
@@ -1,0 +1,1 @@
+filter-analysis root-module.mjs -k def -i rootModuleConst

--- a/tests/tests/checks/inputs/analysis/js/secret-madjewel.js/def_secretMadjewelConst__json
+++ b/tests/tests/checks/inputs/analysis/js/secret-madjewel.js/def_secretMadjewelConst__json
@@ -1,0 +1,1 @@
+filter-analysis secret-madjewel.js -k def -i secretMadjewelConst

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "11:13-24",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property ModuleClass",
+    "sym": "#ModuleClass",
+    "nestingRange": "11:25-15:0"
+  },
+  {
+    "loc": "11:13-24",
+    "target": 1,
+    "kind": "def",
+    "pretty": "ModuleClass",
+    "sym": "#ModuleClass",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "5:13-24",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property moduleConst",
+    "sym": "#moduleConst"
+  },
+  {
+    "loc": "5:13-24",
+    "target": 1,
+    "kind": "def",
+    "pretty": "moduleConst",
+    "sym": "#moduleConst",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
@@ -1,0 +1,22 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "7:16-26",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property moduleFunc",
+    "sym": "#moduleFunc",
+    "nestingRange": "7:43-9:0"
+  },
+  {
+    "loc": "7:16-26",
+    "target": 1,
+    "kind": "def",
+    "pretty": "moduleFunc",
+    "sym": "#moduleFunc",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "5:6-21",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property rootModuleConst",
+    "sym": "#rootModuleConst"
+  },
+  {
+    "loc": "5:6-21",
+    "target": 1,
+    "kind": "def",
+    "pretty": "rootModuleConst",
+    "sym": "#rootModuleConst",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "8:6-25",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property secretMadjewelConst",
+    "sym": "#secretMadjewelConst"
+  },
+  {
+    "loc": "8:6-25",
+    "target": 1,
+    "kind": "def",
+    "pretty": "secretMadjewelConst",
+    "sym": "#secretMadjewelConst",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -249,6 +249,12 @@ expression: "&fb.contents"
         </tr>
 
         <tr>
+          <td><a href="/tests/source/imported-module.mjs" class="icon " style="">imported-module.mjs</a></td>
+          <td class="description"><a href="/tests/source/imported-module.mjs" title=""></td>
+          <td><a href="/tests/source/imported-module.mjs">318</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/invalid-files" class="icon folder" style="">invalid-files</a></td>
           <td class="description"><a href="/tests/source/invalid-files" title=""></td>
           <td><a href="/tests/source/invalid-files">1</a></td>
@@ -330,6 +336,18 @@ expression: "&fb.contents"
           <td><a href="/tests/source/README.md" class="icon " style="">README.md</a></td>
           <td class="description"><a href="/tests/source/README.md" title="This is a README">This is a README</td>
           <td><a href="/tests/source/README.md">342</a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/root-module.mjs" class="icon " style="">root-module.mjs</a></td>
+          <td class="description"><a href="/tests/source/root-module.mjs" title=""></td>
+          <td><a href="/tests/source/root-module.mjs">231</a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/secret-madjewel.js" class="icon js" style="">secret-madjewel.js</a></td>
+          <td class="description"><a href="/tests/source/secret-madjewel.js" title=""></td>
+          <td><a href="/tests/source/secret-madjewel.js">361</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/imported-module.mjs
+++ b/tests/tests/files/imported-module.mjs
@@ -1,0 +1,15 @@
+export default function moduleDefaultFunc() {
+    return "I'm the default!";
+}
+
+export const moduleConst = "I am a constant";
+
+export function moduleFunc(moduleFuncArg1) {
+    console.log("My argument was:", moduleFuncArg1);
+}
+
+export class ModuleClass {
+    constructor() {
+        this.moduleClassField = 1;
+    }
+}

--- a/tests/tests/files/root-module.mjs
+++ b/tests/tests/files/root-module.mjs
@@ -1,0 +1,5 @@
+import { moduleConst, moduleFunc, ModuleClass } from "./imported-module.mjs";
+import { default as aliasedDefault } from "./imported-module.mjs";
+import * as importedModule from "./imported-module.mjs";
+
+const rootModuleConst = 10;

--- a/tests/tests/files/secret-madjewel.js
+++ b/tests/tests/files/secret-madjewel.js
@@ -1,0 +1,8 @@
+// This file is secretly a mod-ule but with a name that is intended to defeat
+// any filename heuristics we might introduce.
+
+import { moduleConst, moduleFunc, moduleClass } from "./imported-module.mjs";
+import { default as aliasedDefault } from "./imported-module.mjs";
+import * as importedModule from "./imported-module.mjs";
+
+const secretMadjewelConst = 11;


### PR DESCRIPTION
For JS parsing:
- If the file ends in ".mjs" we treat it as a module only.
- If the file ends in ".js" we try parsing it as a script and fall back to also trying it as a module if it doesn't parse as a script because imports/exports are illegal.

For the analysis:
- We process ExportDeclaration nodes by recursively processing the declaration it wraps.
- We otherwise ignore everything having to do with modules because our SCIP support should let us do clever things soon so it's a bit of a waste to try and do something smart since it will all just get thrown away.

I add some very basic definition checks to ensure that we've parsed the modules and the export declarations.  I don't add any other pre-existing JS checks at this time.  This is largely because we haven't really seen regressions and also because we are 100% going to have to change the symbol mapping when we move to SCIP.