### PR TITLE
Warning fixes

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1,13 +1,36 @@
 let nextSymId = 0;
 let localFile, fileIndex, mozSearchRoot;
 
+const ERROR_INTERVENTIONS = [
+  {
+    includes: "expected expression, got '<':",
+    severity: "INFO",
+    prepend: "React detected, downgrading to info: ",
+  }
+];
+
 function logError(msg)
 {
-  // This gets to be a warning so the searchfox warning script will report it.
+  // We log "errors" as warnings so the searchfox warning script will report it.
+  let severity = "WARN";
+
+  // But we also have some heuristics defined above that let us downgrade
+  // expected problems to INFO.  Ideally these would be logged as diagnostic
+  // records as proposed at https://bugzilla.mozilla.org/show_bug.cgi?id=1789515
+  // but our expected migration to scip-typescript means it's probably not worth
+  // it at this time, or at least not until we have the rest of the
+  // diagnostic analysis record mechanism implemented.
+  for (const intervention of ERROR_INTERVENTIONS) {
+    if (msg.includes(intervention.includes)) {
+      severity = intervention.severity;
+      msg = intervention.prepend + msg;
+    }
+  }
+
   //
   // This means we may end up needing to add a bunch of tree-specific
   // exclusions, which is probably fine.
-  printErr("WARN " + msg + "\n");
+  printErr(`${severity} ${msg}\n`);
 }
 
 function SymbolTable()

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -302,7 +302,8 @@ let Analyzer = {
       } catch (ex) {
         // If we were trying to parse something as script and it had an import,
         // attempt to re-parse it as a module.
-        if (ex.message.includes("import declarations may only appear") &&
+        if ((ex.message.includes("import declarations may only appear") ||
+             ex.message.includes("export declarations may only appear")) &&
             target === "script") {
           target = "module";
           ast = Reflect.parse(text, { loc: true, source: filename, line, target });

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1127,7 +1127,7 @@ function preprocess(filename, comment)
       branches.pop();
     } else if (!branches[branches.length-1]) {
       preprocessedLines.push(comment(tline));
-    } else if (tline.startsWith("#include")) {
+    } else if (tline.startsWith("#include") || tline.startsWith("#includesubst")) {
       /*
       let match = tline.match(/#include "?([A-Za-z0-9_.-]+)"?/);
       if (!match) {
@@ -1140,11 +1140,15 @@ function preprocess(filename, comment)
     } else if (tline.startsWith("#filter substitution")) {
       preprocessedLines.push(comment(tline));
       substitution = true;
-    } else if (tline.startsWith("#filter")) {
+    } else if (tline.startsWith("#filter") || tline.startsWith("#unfilter")) {
       preprocessedLines.push(comment(tline));
     } else if (tline.startsWith("#expand")) {
       preprocessedLines.push(line.substring(String("#expand ").length));
-    } else if (tline.startsWith("#")) {
+    } else if (tline.startsWith("#literal")) {
+        preprocessedLines.push(line.substring(String("#literal ").length));
+    } else if (tline.startsWith("#define") ||
+               tline.startsWith("#undef") ||
+               tline.startsWith("#error")) {
       preprocessedLines.push(comment(tline));
     } else {
       preprocessedLines.push(line);

--- a/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "5:6-21",
+    "loc": "12:6-21",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property rootModuleConst",
     "sym": "#rootModuleConst"
   },
   {
-    "loc": "5:6-21",
+    "loc": "12:6-21",
     "target": 1,
     "kind": "def",
     "pretty": "rootModuleConst",

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -341,7 +341,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/root-module.mjs" class="icon " style="">root-module.mjs</a></td>
           <td class="description"><a href="/tests/source/root-module.mjs" title=""></td>
-          <td><a href="/tests/source/root-module.mjs">231</a></td>
+          <td><a href="/tests/source/root-module.mjs">371</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/root-module.mjs
+++ b/tests/tests/files/root-module.mjs
@@ -2,4 +2,11 @@ import { moduleConst, moduleFunc, ModuleClass } from "./imported-module.mjs";
 import { default as aliasedDefault } from "./imported-module.mjs";
 import * as importedModule from "./imported-module.mjs";
 
+function exportedAsDefaultAsReference() {
+    return 5;
+}
+
+// This should generate a failure.
+export default exportedAsDefaultAsReference;
+
 const rootModuleConst = 10;


### PR DESCRIPTION
This includes a bunch of mitigations, most of which are discussed on the bug.  In general the strategy is to downgrade things to INFO from WARN if it's complaining about:
- something that's explicitly intended to be an error in source code, like a syntax error test
- something that we cannot make searchfox handle on its own in the existing JS analyzer, like JSX or import assertions 
- something that do not want to make the existing JS analyzer support because it would be a ton of work that would be obsoleted by moving to scip-typescript.