### PR TITLE
Bug 1797153 - patch traitobject to use destructure_traitobject

### DIFF
--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3045,8 +3045,7 @@ dependencies = [
 [[package]]
 name = "traitobject"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
+source = "git+https://github.com/philip-peterson/destructure_traitobject?rev=d49b0af9087b3b7848d19d5baae43948ebc7fb9d#d49b0af9087b3b7848d19d5baae43948ebc7fb9d"
 
 [[package]]
 name = "try-lock"

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -65,6 +65,20 @@ url = "2.2.2"
 ustr = { version = "0.9.0", features = ["serialization"] }
 walkdir = "2.3.2"
 
+[patch.crates-io]
+# Our very old version of hyper depends on traitobject but rustc does not like
+# a formulation it uses.  We are able to use the patch mechanism documented at
+# https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html to
+# replace the version hyper sees.  Honestly we would be fine with just using the
+# crates.io version of https://github.com/philip-peterson/destructure_traitobject
+# but my immediate attempts to alias that did not work out.
+#
+# We use revision
+# https://github.com/philip-peterson/destructure_traitobject/commit/d49b0af9087b3b7848d19d5baae43948ebc7fb9d
+# because that's the last revision before Cargo.toml updated the package's name
+# which causes problems.
+traitobject = { git = "https://github.com/philip-peterson/destructure_traitobject", rev = "d49b0af9087b3b7848d19d5baae43948ebc7fb9d" }
+
 # Build release mode with line number info for easier debugging when
 # we hit panics in production
 [profile.release]


### PR DESCRIPTION
We're using the mechanism documented at
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html to reference destructure_traitobject when its Cargo.toml still claimed to be traitobject.