### PR TITLE
Downgrade buggy kaios code warning:

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -54,6 +54,11 @@ const ERROR_INTERVENTIONS = [
     severity: "INFO",
     prepend: "(unsupported) import assertions can parse this way: "
   },
+  {
+    includes: "redeclaration of import",
+    severity: "INFO",
+    prepend: "Known buggy code pattern is not a problem: "
+  }
 ];
 
 // Note that once we can process .eslintignore most of these can go away because


### PR DESCRIPTION
For kaios we're seeing:
```
 WARN when parsing as 'module': Unable to parse JS file /mnt/index-scratch/kaios/git/dom/push/PushServiceWebSocket.sys.mjs:1 because SyntaxError: redeclaration of import XPCOMUtils: /mnt/index-scratch/kaios/git/dom/push/PushServiceWebSocket.sys.mjs:7
```

This is just buggy code we're processing, not a buggy searchfox understanding.