### PR TITLE
Bug 1801960 - Tokenize JS private symbols, add checks.

### DIFF
--- a/tests/tests/checks/inputs/analysis/js/some_javascript.js/all__priv_field_num__html
+++ b/tests/tests/checks/inputs/analysis/js/some_javascript.js/all__priv_field_num__html
@@ -1,0 +1,1 @@
+filter-analysis some_javascript.js -i '#priv_field_num' | show-html

--- a/tests/tests/checks/inputs/analysis/js/some_javascript.js/all__priv_field_num__json
+++ b/tests/tests/checks/inputs/analysis/js/some_javascript.js/all__priv_field_num__json
@@ -1,0 +1,1 @@
+filter-analysis some_javascript.js -i '#priv_field_num'

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
@@ -1,0 +1,19 @@
+---
+source: tests/test_check_insta.rs
+expression: "&aggr_str"
+---
+<div role="row" id="line-33" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="33"></div>
+  <code role="cell" class="source-line">  <span class="syn_def syn_def" data-symbols="##priv_field_num,ClassWithProperties##priv_field_num" data-i="11" >#priv_field_num</span> = 10;
+</code>
+</div>
+<div role="row" id="line-76" class="source-line-with-number">
+  <div role="cell"><div class="cov-strip cov-no-data"></div></div>
+  <div role="cell"><div class="blame-strip"></div></div>
+  <div role="cell" class="line-number" data-line-number="76"></div>
+  <code role="cell" class="source-line">    <span class="syn_reserved" >return</span> <span class="syn_reserved" >this</span>.<span data-symbols="##priv_field_num" data-i="18" >#priv_field_num</span>;
+</code>
+</div>
+

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
@@ -1,0 +1,36 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "33:2-17",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property #priv_field_num",
+    "sym": "##priv_field_num"
+  },
+  {
+    "loc": "33:2-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "#priv_field_num",
+    "sym": "##priv_field_num",
+    "context": "ClassWithProperties"
+  },
+  {
+    "loc": "76:16-31",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property #priv_field_num",
+    "sym": "##priv_field_num"
+  },
+  {
+    "loc": "76:16-31",
+    "target": 1,
+    "kind": "use",
+    "pretty": "#priv_field_num",
+    "sym": "##priv_field_num",
+    "context": "ClassWithProperties.consumes_priv_field_num"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -385,14 +385,8 @@ expression: "&fb.contents"
 
         <tr>
           <td><a href="/tests/source/some_javascript.js" class="icon icon-js">some_javascript.js</a></td>
-          <td class="description"><a href="/tests/source/some_javascript.js" title="#priv_field_undefined;
-
-  #priv_field_num = 10;
-  ">#priv_field_undefined;
-
-  #priv_field_num = 10;
-  </td>
-          <td><a href="/tests/source/some_javascript.js">1898</a></td>
+          <td class="description"><a href="/tests/source/some_javascript.js" title=""></td>
+          <td><a href="/tests/source/some_javascript.js">2555</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/some_javascript.js
+++ b/tests/tests/files/some_javascript.js
@@ -28,34 +28,53 @@ class ClassWithProperties {
 
   // PRIVATE FIELDS AREN'T SUPPORTED YET.
   // These next 2 simply won't emit anything in the AST right now.
-  /*
   #priv_field_undefined;
 
   #priv_field_num = 10;
-  */
 
   // This generates a syntax error even if I wrap the object initializer in
   // parens.  The spec is very dry and I'm having trouble figuring out if this
   // is actually legal or not.
-  /*
   #priv_field_dict = {
     sub_prop: 12
   };
-  */
+
+  #priv_method() {
+    // Let's have a few lines so we can verify position: sticky.
+
+    // BEEP BEEP BEEP BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP BEEP BEEP BEEP
+    return this.#priv_field_undefined;
+  }
 
   // This also doesn't work.
-  /*
   #priv_field_func = b => {
+    // Let's have a few lines so we can verify position: sticky.
+
+    // BEEP BEEP BEEP BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP           BEEP
+    // BEEP BEEP BEEP BEEP
     return b * 2;
   };
-  */
 
-  // Disabled by bug 1559269 for now.
-  /*
   consumes_priv_field_num() {
     return this.#priv_field_num;
   }
-  */
 }
 
 class ClassWithStaticMethods {

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -5,6 +5,8 @@ use std::path::Path;
 pub struct LanguageSpec {
     pub reserved_words: HashMap<String, String>,
     pub hash_comment: bool,
+    // In JS, private symbols are now a thing.
+    pub hash_identifier: bool,
     pub c_style_comments: bool,
     pub backtick_strings: bool,
     pub regexp_literals: bool,
@@ -566,6 +568,7 @@ static RESERVED_WORDS_KOTLIN: &'static [&'static str] = &[
 lazy_static! {
     static ref JS_SPEC : LanguageSpec = LanguageSpec {
         reserved_words: make_reserved(&*RESERVED_WORDS_JS),
+        hash_identifier: true,
         c_style_comments: true,
         backtick_strings: true,
         regexp_literals: true,

--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -168,9 +168,9 @@ pub fn tokenize_plain(string: &str) -> Vec<Token> {
 }
 
 pub fn tokenize_c_like(string: &str, spec: &LanguageSpec) -> Vec<Token> {
-    fn is_ident(ch: char) -> bool {
-        (ch == '_') || ch.is_alphabetic() || ch.is_digit(10)
-    }
+    let is_ident = |ch: char| -> bool {
+        (ch == '_') || ch.is_alphabetic() || ch.is_digit(10) || (ch == '#' && spec.hash_identifier)
+    };
 
     let mut tokens = Vec::new();
 


### PR DESCRIPTION
We were analyzing private symbols acceptably, but the tokenizer did not recognize them as valid identifier symbols, which meant we would just output them as plain text.