### PR TITLE
Bug 1801960 - Widen the context-menu word regexp to include #.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -259,7 +259,13 @@ function getTargetWord() {
 
   function isWordChar(character) {
     // TODO: this could be more non-ascii friendly.
-    return /[A-Z0-9_]/i.test(character);
+    //
+    // Notable Changes:
+    // - We have added "#" to deal with JS private symbols.  This will widen
+    //   C preprocessor directives to include the leading #, which makes sense.
+    //   This will also impact use of the "stringizing operator" for macros,
+    //   where it won't be what we want.
+    return /[#A-Z0-9_]/i.test(character);
   }
 
   if (offset < string.length && !isWordChar(string[offset])) {


### PR DESCRIPTION
As :saschanaz pointed out, the context-menu's "search for the substring" option is excluding the leading "#" for private symbols still, which is weird.

This fix naively just widens the regex.  I imagine there could be regressions for this and it could make sense for this JS to instead understand the difference between:
- The user clicking on a symbol for which we can know the exact symbol string to use.
- The user clicking on random text which is not marked up as a symbol and for which we should use a regex heuristic.
- The user selecting a region of text and then clicking on it with the intent to potentially provide our context menu to search for that string, but where we will currently erase the user's own selection.