### PR TITLE
Bug 1806771 - Adjust searchfox plugin to clang upstream changes.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -180,7 +180,9 @@ public:
                                   StringRef FileName,
                                   bool IsAngled,
                                   CharSourceRange FileNameRange,
-#if CLANG_VERSION_MAJOR >= 15
+#if CLANG_VERSION_MAJOR >= 16
+                                  OptionalFileEntryRef File,
+#elif CLANG_VERSION_MAJOR >= 15
                                   Optional<FileEntryRef> File,
 #else
                                   const FileEntry *File,
@@ -2088,7 +2090,9 @@ void PreprocessorHook::InclusionDirective(SourceLocation HashLoc,
                                           StringRef FileName,
                                           bool IsAngled,
                                           CharSourceRange FileNameRange,
-#if CLANG_VERSION_MAJOR >= 15
+#if CLANG_VERSION_MAJOR >= 16
+                                          OptionalFileEntryRef File,
+#elif CLANG_VERSION_MAJOR >= 15
                                           Optional<FileEntryRef> File,
 #else
                                           const FileEntry *File,


### PR DESCRIPTION
This is a manual import of https://phabricator.services.mozilla.com/D165266 as landed at https://hg.mozilla.org/mozilla-central/rev/1931d3d21dc9 applied via patch -p4 directly against the file.