### PR TITLE
Bug 1703656 - Implement a settings page, minor context menu regression fix

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -21,6 +21,8 @@ import os.path
 import subprocess
 import six
 
+# The config file at the root of the WORKING directory; all paths should be
+# absolute paths.
 config_fname = sys.argv[1]
 # doc_root will usually be /home/ubuntu/docroot and will hold files like:
 # - status.txt: A file written by the web-servers that the web-server triggering
@@ -150,6 +152,8 @@ location('= /robots.txt', [
 # we're using could better cleaned up by use of "alias".  The exception is
 # "source" where the "try_files" is definitely absolutely necessary.
 for repo in config['trees']:
+    tree_config = config['trees'][repo]
+    index_path = tree_config['index_path']
     head_rev = None
     if 'git_path' in config['trees'][repo]:
         try:
@@ -160,6 +164,8 @@ for repo in config['trees']:
 
     # we use alias because the we don't want the "/{repo}" portion.
     location(f'/{repo}/static/', [f'alias {mozsearch_path}/static/;'])
+
+    location(f'/{repo}/pages/', [f'alias {index_path}/pages/;'])
 
     location(f'/{repo}/source', [
         f'root {doc_root};',

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -75,5 +75,10 @@ SEARCHFOX_SERVER=${CONFIG_FILE} \
     SEARCHFOX_TREE=${TREE_NAME} \
     $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
 
+TOOL_CMD="render settings"
+SEARCHFOX_SERVER=${CONFIG_FILE} \
+    SEARCHFOX_TREE=${TREE_NAME} \
+    $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
+
 #js $MOZSEARCH_PATH/scripts/output-template.js $FILES_ROOT $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME
 #js $MOZSEARCH_PATH/scripts/output-help.js $CONFIG_REPO/help.html $INDEX_ROOT $MOZSEARCH_PATH $TREE_NAME

--- a/static/css/icons.css
+++ b/static/css/icons.css
@@ -18,7 +18,7 @@
      this has the same precedence as the mimtype-icon-* values so this must
      be defined before the per-file icon selectors. */
      background-image: url(../icons/mimetypes/unknown.png);
-    }
+}
 
 .mimetype-floating-container {
   background-color: transparent;
@@ -36,6 +36,10 @@
   vertical-align: text-bottom;
   /* same rationale as for .mimetype-fixed-container */
   background-image: url(../icons/mimetypes/unknown.png);
+}
+
+.mimetype-no-icon {
+  background-image: none;
 }
 
 /* Previously the panel button rows were getting their padding from ".icon"

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -607,6 +607,9 @@ tr.after-context-line + tr.before-context-line {
   text-align: left;
   cursor: pointer;
 }
+#show-settings {
+  color: var(--panel-header-color);
+}
 .navpanel-icon {
   display: inline-block;
   margin-right: 0.5rem;
@@ -696,7 +699,7 @@ span[data-symbols].hovered {
 }
 
 /* Help screen */
-.intro {
+.intro, .settings-page {
   font: 14px/1.5 Arial, Helvetica, sans-serif;
   margin-left: 10%;
   margin-right: 10%;

--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -90,7 +90,7 @@ var BlamePopup = new (class BlamePopup {
     }
 
     // If no content was returned or the blame element has changed, bail.
-    if (!content || this.blameElement != elt) {
+    if (!content || this.blameElement != elt || !hoverRightOfElt) {
       return;
     }
 

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -27,9 +27,9 @@ var DocumentTitler = new (class DocumentTitler {
     // If we have a better title than the original title, use it, but making
     // sure to include the original filename because this is important for
     // finding the tab again in the awesomebar via its filename.
-    if (this.selectionTitle) {
+    if (Settings.pageTitle.lineSelection && this.selectionTitle) {
       bestTitle = `${this.selectionTitle} (${this.originalTitle})`;
-    } else if (this.stickyTitle) {
+    } else if (Settings.pageTitle.stickySymbol && this.stickyTitle) {
       bestTitle = `${this.stickyTitle} (${this.originalTitle})`;
     } else {
       bestTitle = this.originalTitle;

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -110,10 +110,30 @@ var ContextMenu = new (class ContextMenu {
       let li = document.createElement("li");
       let link = li.appendChild(document.createElement("a"));
       link.href = item.href;
-      link.classList.add("icon");
+      link.classList.add("mimetype-fixed-container");
+      // Cancel out the default "unknown" icon we get from the above so there's
+      // no icon displayed (by default but also in conjunction with the below).
+      link.classList.add("mimetype-no-icon");
+      // So for a long time we would display a search icon in the context menu,
+      // but only ever a search icon because that's the only thing we hardcode
+      // in the menuItems we would push in the logic above.
+      //
+      // But we accidentally removed the icon in
+      // 6c35b409a1d4dde7581a59bbad317a472732c15c in late 2021, so we haven't
+      // had the icon around anymore, so the context menu has had the whitespace
+      // where an icon would go, but we wouldn't display any.  The other icons
+      // removed at the same time were intended for the context menu to
+      // differentiate between searches, jumps, etc.
+      //
+      // In order to maintain the existing status quo, I'm commenting out the
+      // logic below so we don't have an icon, but we should probably strongly
+      // consider bringing icons back in a way that provides for the ability to
+      // visually distinguish stuff.
+      /*
       if (item.icon) {
         link.classList.add(item.icon);
       }
+      */
       link.innerHTML = item.html;
       this.menu.appendChild(li);
     }
@@ -185,7 +205,7 @@ var Hover = new (class Hover {
       return;
     }
 
-    let symbols = event.target.closest("[data-symbols]");
+    let symbols = event.target?.closest("[data-symbols]");
     if (!symbols) {
       return this.deactivate();
     }

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -1,8 +1,13 @@
 var Panel = new (class Panel {
   constructor() {
     this.panel = document.getElementById("panel");
+    // Avoid complaining if this page doesn't have a panel on it.
+    if (!this.panel) {
+      return;
+    }
     this.toggleButton = document.getElementById("panel-toggle");
     this.icon = this.panel.querySelector(".navpanel-icon");
+    this.settingsButton = document.getElementById("show-settings");
     this.content = document.getElementById("panel-content");
     this.accelEnabledCheckbox = document.getElementById("panel-accel-enable");
 
@@ -44,6 +49,11 @@ var Panel = new (class Panel {
         },
       },
     };
+
+    // We want the default event for clicking on the settings link to work, but
+    // we want to stop its propagation so that it doesn't bubble up to the
+    // toggle button handler that comes next.
+    this.settingsButton.addEventListener("click", (evt) => { evt.stopPropagation(); });
 
     this.toggleButton.addEventListener("click", () => this.toggle());
     this.accelEnabledCheckbox.addEventListener("change", () => {
@@ -280,6 +290,11 @@ var Panel = new (class Panel {
   }
 
   updateMarkdownState() {
+    // If we're on a page without a panel, there's nothing to do.
+    if (!this.panel) {
+      return;
+    }
+
     for (const [_, { node, isEnabled }] of Object.entries(this.markdown)) {
       if (!node) {
         continue;

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -438,6 +438,8 @@ function populateResults(data, full, jumpToSingle) {
 
   // If no data is returned, inform the user.
   let container = document.getElementById("content");
+  // Clobber any additional classes that existed on the content container.
+  container.setAttribute("class", "content");
   container.innerHTML = "";
 
   let timeoutWarning = timed_out

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,0 +1,534 @@
+/**
+ * Compactly defined setting names and defaults; expanded and interpreted by the
+ * `Settings` class as its construction time in conjunction with
+ * `SETTINGS_VERSION`.
+ *
+ * Although we define a more complex conceptual model for how settings work in
+ * `settings.liquid`, we have a simple nested model here that operates based
+ * on convention / specific names and it's on the `settings.liquid` page to make
+ * sure it names its input "id" attributes to match with the automatic mangling
+ * we perform below.
+ *
+ * General definition rules:
+ * - The top level defines settings groups, and these should be named using
+ *   camelCase.
+ * - Inside each of those group definitions, each camelCase key names a setting
+ *   that will be exposed as `Settings.[groupName].[keyName]` on the Settings
+ *   object.  For form binding purposes, the names will be normalized from
+ *   camelCase "fooBarBaz" to dash-delimited "foo-bar-baz", and the group name
+ *   will be separated from the key name by a double-dash, like
+ *   "group-name--key-name".
+ * - A key name of "enabled" is treated as a feature gate.  The value exposed to
+ *   JS will be a simple boolean (ex: `Settings.fancyBar.enabled`), but the
+ *   storage value will be one of "" (to use the default feature gate), "alpha",
+ *   "beta", or "release".
+ * - Setting keys will have a dictionary that may contain the following keys:
+ *   - `default`: This identifies the default value and also serves to indicate
+ *     the type of the value.  This is not relevant for "enabled" keys.
+ *   - `quality`: For the case of the special "enabled" featured gates, this
+ *     expresses the current quality of the feature for feature gate logic
+ *     purposes.  Legal values are "alpha", "beta", and "release".
+ *   - `dependencies`: For the case of the special "enabled" feature gates, this
+ *     expresses the other features that must also be enabled for this feature
+ *     to be enabled.  Only the camelCase groupName needs to be identified.  The
+ *     dependency check mechanism will run in as `SETTING_DEFS` is processed in
+ *     its natural order, so features that depend on other features should
+ *     appear after them in the dictionaries and will therefore emergently
+ *     support transitive dependency checks correctly.
+ *   - `introducedIn`: If present, indicates the `SETTINGS_VERSION` number
+ *     version in which the setting was introduced.  The intent is to enable the
+ *     ability to badge the settings button to let users know there are new
+ *     settings that they might want to check out and then to help highlight
+ *     and/or provide a table of contents with direct links to point out the
+ *     new settings on the settings page without requiring the user to manually
+ *     skim the page and guess what might be new.  This is used in conjunction
+ *     with the `userSawVersion` and `userAckedVersion` storage values.
+ */
+const SETTING_DEFS = {
+  global: {
+    defaultFeatureGate: {
+      default: "release",
+    },
+  },
+  pageTitle: {
+    lineSelection: {
+      default: true,
+    },
+
+    stickySymbol: {
+      default: true,
+    },
+  },
+  contextMenu: {
+    // There are a number of resources that may be gated behind Mozilla LDAP
+    // access.  For discoverability reasons, we want to default this to true,
+    // but for users without access, it should be possible to set this to false
+    // so they don't have to see options they can't use.
+    haveMozillaLdap: {
+      default: true,
+    }
+  },
+  fancyBar: {
+    enabled: {
+      quality: "alpha",
+    }
+  },
+};
+
+const QUALITY_ORDERING = [
+  "alpha",
+  "beta",
+  "release",
+];
+
+/**
+ * Checks if the user's selected quality gate (falling back to their default)
+ * is met/exceeded by the feature's current quality.
+ */
+function meetsQualityGate(userSpecific, userDefault, featureQuality) {
+  let userCriteria = userSpecific || userDefault;
+  let userIndex = QUALITY_ORDERING.indexOf(userCriteria);
+  let featureIndex = QUALITY_ORDERING.indexOf(featureQuality);
+  return featureIndex >= userIndex;
+}
+
+/**
+ * This is just a specialized version of SETTING_DEFS where each top-level
+ * group is conceptually associated with a widget which must usually must be
+ * explicitly enabled by the user, but we do allow for a default which will be
+ * populated on first load.  Currently there is no plan to build a widget
+ * abstraction layer; the term exists to distinguish optional, loosely-coupled
+ * features (widgets) from core features that will eventually be non-optional.
+ * (Noting that there are still discussions to be had in this space, but the
+ * intent is to set expectations appropriately.)
+ *
+ * The main differences from SETTINGS_DEFS above:
+ * - `enabled` can be omitted; if it's omitted, a value of `{ default: false }`
+ *   is assumed.  This is notably different from how feature `enabled` keys
+ *   work.  You can express `dependencies` if you want, but in general it will
+ *   probably be assumed that most widgets will depend on the "fancyBar" being
+ *   enabled.
+ */
+const WIDGET_DEFS = {
+  // Proposed in https://bugzilla.mozilla.org/show_bug.cgi?id=1808415 and with
+  // its setting definitions stubbed here as an exercise for seeing how
+  // widgets could be hooked up.  The widget doesn't actually exist yet.
+  openInEditor: {
+    enabled: {
+      default: false,
+    },
+    linkTemplate: {
+      default: "editor://open/?file={{tree}}/{{path}}",
+    }
+  }
+}
+
+/**
+ * This version is stored in local storage as part of our persisted settings
+ * structure.  In particular, we store it in the top level twice:
+ * - `version`: The version of SETTING_DEFS that was last used to populate the
+ *   `settings` field that contains the actual persisted settings values.
+ * - `userSawVersion`: The `SETTINGS_VERSION` of the last time the user saw the
+ *   settings page.  This would be used for quieting any badging that's
+ *   notifying the user there are new settings.
+ * - `userAckedVersion`: The `SETTINGS_VERSION` of the last time the user
+ *   implicitly or explicitly confirmed they understand what the new settings
+ *   are.  This differs from `userSawVersion` in that we might still highlight
+ *   (and list in a TOC) new settings introduced between `userAckedVersion` and
+ *   `version` even if we aren't displaying a badge.  In particular, it's our
+ *   expectation that many users may find the (probably opt-in) badge
+ *   distracting and that they likely would want to actually process the new
+ *   settings later on.
+ */
+const SETTINGS_VERSION = 1;
+
+/**
+ * Convert a "camelCaseString" to "camel-case-string".
+ */
+function camelCaseToLowerCaseDash(ccStr) {
+  return ccStr.replaceAll(/[A-Z]/g, x => `-${x.toLowerCase()}`);
+}
+
+/**
+ * Convert a "group-name--key-name" string to a tuple of ["groupName", "keyName"].
+ */
+function convertDashedIdentifierToGroupAndName(idStr) {
+  const pieces = idStr.split("--");
+  return pieces.map(s => s.replace(/-[a-z]/g, x => x[1].toUpperCase()));
+}
+
+/**
+ * Settings singleton which will block on loading LocalStorage data so that
+ * setting data is available immediately after its initialization.  We can
+ * potentially change this in the future.  Settings are exposed in a parallel
+ * fashion to how they are defined in `SETTING_DEFS` and `WIDGET_DEFS`, so
+ * the definition for `pageTitle.lineSelection` will be exposed at
+ * `Settings.pageTitle.lineSelection`.
+ *
+ * Binding to forms on the `settings.html` page derived from the
+ * `settings.liquid` template is handled via the `SettingsBinder` singleton
+ * below.
+ *
+ * Storage is global for the entire origin and is not tree-specific at this
+ * time.
+ *
+ * All settings storage happens in the single "settings" LocalStorage key,
+ * stored as JSON and read only at page load time, currently.  In the future
+ * we can have this listen for "storage" events to live-update, but the
+ * complexity does not seem merited at this time.
+ *
+ * The choice of a single JSON key/value is made because:
+ * - We want richer types and structures than just raw strings.
+ * - There are advantages to the coherency of a single key/value, including
+ *   self-descriptive versioning.
+ * - We read all of the settings at page load time, and given this access
+ *   pattern, and the fact that we don't/won't store much other data in
+ *   LocalStorage, it's easier and faster for Gecko's LocalStorage (NG) if it's
+ *   just giving us a single value.  (Actually, if we do start storing other
+ *   data in LS, using a single key/value ends up even better.)
+ *
+ * The choice of LocalStorage is the most pragmatic choice for storing a small
+ * amount of data in a way that can be used to impact UI to minimize flashes of
+ * changed content.  Cookies are not appropriate because they would be sent to
+ * the server (which we neither want nor need) and `document.cookie` is limited
+ * to 7-days by anti-tracking policy.  Firefox's LocalStorage (NG) will preload
+ * data when it knows the connection is going to happen, and will keep it around
+ * in memory so that file I/O should be avoided for searchfox.  This differs
+ * from options like IndexedDB and the Cache API.
+ */
+const Settings = new (class Settings {
+  #canonicalData;
+
+  constructor() {
+    // This will synchronously block if the browser has not been able to preload
+    // the LocalStorage for the origin.  This is a hard-block and will not
+    // spin an event loop.  This is the worst part of LocalStorage.
+    this.#canonicalData = this.#loadCanonicalData();
+    this.#applyAndTransformCanonicalDataToSelf();
+  }
+
+  #mergeSettingsCanonicalData(settingsRoot, groupName, groupDefs, isWidget) {
+    let groupVals = settingsRoot[groupName];
+    if (!groupVals) {
+      groupVals = settingsRoot[groupName] = {};
+    }
+
+    for (const [keyName, keyDef] of Object.entries(groupDefs)) {
+      // There's currently no concept of migration, so we have nothing to do if
+      // the key already exist in the values dictionary.
+      if (keyName in groupVals) {
+        continue;
+      }
+
+      if (keyName === "enabled") {
+        // For widgets we propagate the default, but for features we use an
+        // default
+        if (isWidget) {
+          groupVals[keyName] = ("default" in keyDef) ? keyDef.default : false;
+        } else {
+          groupVals[keyName] = "";
+        }
+      } else {
+        groupVals[keyName] = keyDef.default;
+      }
+    }
+  }
+
+  #generateDefaultSettings(parseFailed) {
+    const data = {
+      version: SETTINGS_VERSION,
+      // In order to help debug storage-related problems, we want to track when
+      // the data structured was first created.  These values will never be
+      // submitted anywhere, although we may ask the user to help
+      created: {
+        version: SETTINGS_VERSION,
+        timestamp: Date.now(),
+        // Did we have a local storage payload but we failed to parse it?
+        parseFailed,
+      },
+      userSawVersion: SETTINGS_VERSION,
+      userAckedVersion: SETTINGS_VERSION,
+      settings: {},
+    };
+
+    // Currently, the upgrade logic just fills in values it doesn't already
+    // know.
+    return this.#upgradeSettings(data);
+  }
+
+  #upgradeSettings(data) {
+    for (const [groupName, groupDefs] of Object.entries(SETTING_DEFS)) {
+      this.#mergeSettingsCanonicalData(data.settings, groupName, groupDefs, false);
+    }
+
+    for (const [widgetName, widgetDefs] of Object.entries(WIDGET_DEFS)) {
+      this.#mergeSettingsCanonicalData(data.settings, widgetName, widgetDefs, true);
+    }
+    return data;
+  }
+
+  /**
+   * Load the settings data from LocalStorage, creating default values if there
+   * was no existing data, and upgrading existing data if appropriate.  Data
+   * will automatically be written to LocalStorage if any changes may have
+   * happened.
+   *
+   * Note that the returned data has not had feature gates applied; those are
+   * only interpreted
+   */
+  #loadCanonicalData() {
+    const strData = window.localStorage.getItem("settings");
+    let data = null;
+    let parseFailed = false;
+    if (strData !== null) {
+      try {
+        data = JSON.parse(strData);
+      } catch(ex) {
+        parseFailed = true;
+      }
+    }
+    if (data === null) {
+      data = this.#generateDefaultSettings(parseFailed);
+      this.#saveCanonicalData(data);
+    } else if (data.version < SETTINGS_VERSION) {
+      data = this.#upgradeSettings(data);
+      this.#saveCanonicalData(data);
+    }
+    return data;
+  }
+
+  #saveCanonicalData(explicitData) {
+    if (explicitData) {
+      this.#canonicalData = explicitData;
+    }
+    const strData = JSON.stringify(this.#canonicalData);
+    window.localStorage.setItem("settings", strData);
+  }
+
+  /**
+   * Applies the storage-representation data in `this.#canonicalData` to `this`,
+   * applying feature-gating logic transformations in the process.  We freeze
+   * the group value objects, replacing them each time this method is called.
+   * No attempt is made to protect the group objects themselves because that
+   * seems like a less likely problem.
+   */
+  #applyAndTransformCanonicalDataToSelf() {
+    const settings = this.#canonicalData.settings;
+    const userDefaultQualityGate = settings.global.defaultFeatureGate;
+
+    for (const [groupName, groupValues] of Object.entries(settings)) {
+      let transformed = {};
+      const isWidget = groupName in WIDGET_DEFS;
+      let groupDef;
+      if (isWidget) {
+        groupDef = WIDGET_DEFS[groupName];
+      } else {
+        groupDef = SETTING_DEFS[groupName];
+      }
+
+      for (const [keyName, keyValue] of Object.entries(groupValues)) {
+        if (keyName === "enabled") {
+          let enabled;
+          if (isWidget) {
+            enabled = keyValue;
+          } else {
+            enabled = meetsQualityGate(keyValue, userDefaultQualityGate, groupDef.enabled.quality);
+          }
+          let maybeDeps = groupDef[keyName]?.dependencies;
+          if (maybeDeps) {
+            for (const depGroupName of maybeDeps) {
+              if (!this[depGroupName].enabled) {
+                enabled = false;
+              }
+            }
+          }
+          transformed.enabled = enabled;
+        } else {
+          transformed[keyName] = keyValue;
+        }
+      }
+
+      Object.freeze(transformed);
+      this[groupName] = transformed;
+    }
+  }
+
+  __hasUnseenSettings() {
+    return this.#canonicalData.userSawVersion < SETTINGS_VERSION;
+  }
+
+  __markSettingsSeen() {
+    this.#canonicalData.userSawVersion = SETTINGS_VERSION;
+    this.#saveCanonicalData();
+  }
+
+  __hasUnacknowledgedSettings() {
+    return this.#canonicalData.userAckedVersion < SETTINGS_VERSION;
+  }
+
+  __markSettingsAcknowledged() {
+    this.#canonicalData.userAckedVersion = SETTINGS_VERSION;
+    this.#saveCanonicalData();
+  }
+
+  __lookupSettingFromId(id) {
+    const [groupName, keyName] = convertDashedIdentifierToGroupAndName(id);
+    const isWidget = groupName in WIDGET_DEFS;
+    let groupDef;
+    if (isWidget) {
+      groupDef = WIDGET_DEFS[groupName];
+    } else {
+      groupDef = SETTING_DEFS[groupName];
+    }
+    if (!groupDef) {
+      return null;
+    }
+    const keyDef = groupDef[keyName];
+
+    let type;
+    let coerceFromString = x => x;
+    if (keyName === "enable") {
+      if (isWidget) {
+        type = "feature-gate";
+      } else {
+        type = "boolean"
+      }
+    } else {
+      type = typeof(keyDef);
+    }
+
+    if (type === "number") {
+      coerceFromString = x => parseInt(x, 10)
+    } else if (type === "boolean") {
+      // assuming checkbox with default "on" value if checked.
+      coerceFromString = x => x.length > 0;
+    }
+    // the identity transform is appropriate for "feature-gate" and everything
+    // else right now.
+
+    let rawValue = this.#canonicalData.settings[groupName][keyName];
+
+    return {
+      isWidget,
+      groupName,
+      groupDef,
+      keyName,
+      keyDef,
+      type,
+      rawValue,
+      coerceFromString,
+    };
+  }
+
+  __setValueFromIdSpace(id, value) {
+    const { groupName, keyName } = this.__lookupSettingFromId(id);
+
+    this.#canonicalData.settings[groupName][keyName] = value;
+    this.#saveCanonicalData();
+    this.#applyAndTransformCanonicalDataToSelf();
+  }
+})();
+
+/**
+ * Very basic routing / URL parsing / URL generating support.  This primarily
+ * exists to try and support varying URLs based on user settings as it relates
+ * to using the "search" endpoint versus the "query" endpoint and things like
+ * that.  Searchfox's URL scheme is stable and so, apart from experimental
+ * features that may not end up making it to "release", there is no reason to
+ * favor using this class over inline URL generation.  (And in particular, if
+ * you can generate a URL on the server as part of the HTML we serve, you
+ * absolutely should.)
+ */
+const Router = new (class Router {
+  constructor() {
+    const pathParts = document.location.pathname.split("/");
+    this.treeName = pathParts[1];
+    this.endpoint = pathParts[2];
+    if (this.endpoint === "pages") {
+      this.page = pathParts.slice(3).join("/");
+    } else if (this.endpoint === "rev") {
+      this.rev = pathParts[3];
+      this.sourcePath = pathParts.slice(4).join("/");
+    } else if (this.endpoint === "source") {
+      this.sourcePath = pathParts.slice(3).join("/");
+    }
+  }
+})();
+
+/**
+ * Self-activating singleton which will automatically bind itself to the
+ * `settings.html` page derived from the `settings.liquid` template.  In the
+ * future we may also provide a means for adding interactive mechanisms to
+ * opt-out of features without visiting the settings page, and that would also
+ * want to operate through this class.
+ */
+const SettingsBinder = new (class SettingsBinder {
+  constructor() {
+    // If we are the settings page, bind form elements and do any template
+    // expansions for the feature gate select payloads.  Our JS script is
+    // currently loaded as part of the `scroll_footer.liquid` template which
+    // comes after all content and so the DOM should therefore already exist.
+    if (Router.page === "settings.html") {
+      this.bindAndExpandTemplatedForms();
+    }
+  }
+
+  bindAndExpandTemplatedForms() {
+    // Make sure we only manipulate the content area and don't interfere with
+    // the search UI.
+
+    const root = document.querySelector("#content");
+
+    // Let's add an idempotency guard that complains in order to help shine a
+    // light on any logic problems which might otherwise result in weirdness.
+    if ("boundSettings" in root) {
+      console.error("Attempted to re-bind settings!");
+      throw new Error("Redundant attempt to bind settings.");
+    }
+    root.boundSettings = true;
+
+    const featureGateOptions = root.querySelector("#feature-gate-options");
+
+    // Neutralize all form elements so nothing ever submits anywhere, as this is
+    // all content-side.
+    for (const form of root.querySelectorAll("form")) {
+      form.addEventListener("submit", (evt) => { evt.preventDefault(); });
+    }
+
+    // Bind all form inputs
+    for (const elem of root.querySelectorAll("input, select")) {
+      const info = Settings.__lookupSettingFromId(elem.id);
+      if (!info) {
+        console.warn("Thought about binding to", elem, "with id", elem.id, "but could not.");
+        continue;
+      }
+      if (elem.tagName === "INPUT") {
+        if (elem.type === "checkbox") {
+          elem.checked = Settings[info.groupName][info.keyName];
+          elem.addEventListener("change", () => {
+            Settings.__setValueFromIdSpace(elem.id, elem.checked);
+          });
+        } else if (elem.type === "text") {
+          elem.value = Settings[info.groupName][info.keyName];
+          elem.addEventListener("change", () => {
+            Settings.__setValueFromIdSpace(elem.id, elem.value);
+          });
+        } else {
+          console.warn("Don't know how to bind to", elem, "with type", elem.type);
+        }
+      } else if (elem.tagName === "SELECT") {
+        // Enabling
+        if (!info.isWidget && info.keyName === "enabled") {
+          // To reduce maintenance if we change the feature gate payloads, we
+          // just use our template clone on the inside, and it could also make
+          // sense to may set/propagate any other attributes as appropriate.
+          elem.appendChild(featureGateOptions.content.cloneNode(true));
+        }
+        elem.value = info.rawValue;
+        elem.addEventListener("change", () => {
+          Settings.__setValueFromIdSpace(elem.id, elem.value);
+        });
+    }
+    }
+  }
+})();

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
@@ -103,6 +103,7 @@ expression: "&fb.contents"
 
   </div>
   
+<script src="/tests/static/js/settings.js"></script>
 <script src="/tests/static/js/search.js"></script>
 <script src="/tests/static/js/context-menu.js"></script>
 <script src="/tests/static/js/panel.js"></script>

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -585,6 +585,7 @@ Spread over multiple lines.
 
   </div>
   
+<script src="/tests/static/js/settings.js"></script>
 <script src="/tests/static/js/search.js"></script>
 <script src="/tests/static/js/context-menu.js"></script>
 <script src="/tests/static/js/panel.js"></script>

--- a/tests/tests/checks/snapshots/web/files/nav-panel/check_glob@wpt__some_cross_global_test__navpanel__html.snap
+++ b/tests/tests/checks/snapshots/web/files/nav-panel/check_glob@wpt__some_cross_global_test__navpanel__html.snap
@@ -6,6 +6,7 @@ expression: "&fb.contents"
   <button id="panel-toggle">
     <span class="navpanel-icon icon-down-dir expanded" aria-hidden="false"></span>
     Navigation
+    <a id="show-settings" title="Go to settings page" href="/tests/pages/settings.html"><span class="navpanel-icon icon-cog expanded" aria-hidden="false"></span></a>
   </button>
   <section id="panel-content" aria-expanded="true" aria-hidden="false">
   <label class="panel-accel"><input type="checkbox" id="panel-accel-enable" checked="checked">Enable keyboard shortcuts</label>

--- a/tests/tests/checks/snapshots/web/files/nav-panel/check_glob@wpt__test_ima_weird_meta_wpt__navpanel__html.snap
+++ b/tests/tests/checks/snapshots/web/files/nav-panel/check_glob@wpt__test_ima_weird_meta_wpt__navpanel__html.snap
@@ -6,6 +6,7 @@ expression: "&fb.contents"
   <button id="panel-toggle">
     <span class="navpanel-icon icon-down-dir expanded" aria-hidden="false"></span>
     Navigation
+    <a id="show-settings" title="Go to settings page" href="/tests/pages/settings.html"><span class="navpanel-icon icon-cog expanded" aria-hidden="false"></span></a>
   </button>
   <section id="panel-content" aria-expanded="true" aria-hidden="false">
   <label class="panel-accel"><input type="checkbox" id="panel-accel-enable" checked="checked">Enable keyboard shortcuts</label>

--- a/tests/tests/checks/snapshots/web/templates/check_glob@help_file__html.snap
+++ b/tests/tests/checks/snapshots/web/templates/check_glob@help_file__html.snap
@@ -177,6 +177,7 @@ indexes C++ and JavaScript code. This is the help page for Searchfox.
 
   </div>
   
+<script src="/tests/static/js/settings.js"></script>
 <script src="/tests/static/js/search.js"></script>
 <script src="/tests/static/js/context-menu.js"></script>
 <script src="/tests/static/js/panel.js"></script>

--- a/tests/tests/checks/snapshots/web/templates/check_glob@search_template__html.snap
+++ b/tests/tests/checks/snapshots/web/templates/check_glob@search_template__html.snap
@@ -61,6 +61,7 @@ expression: "&fb.contents"
     </script>
   </div>
   
+<script src="/tests/static/js/settings.js"></script>
 <script src="/tests/static/js/search.js"></script>
 <script src="/tests/static/js/context-menu.js"></script>
 <script src="/tests/static/js/panel.js"></script>

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -149,6 +149,10 @@ impl AbstractServer for LocalIndex {
                 "{}/templates/{}",
                 self.config_paths.index_path, sf_path
             )),
+            SearchfoxIndexRoot::IndexPages => Ok(format!(
+                "{}/pages/{}",
+                self.config_paths.index_path, sf_path
+            )),
             SearchfoxIndexRoot::UncompressedDirectoryListing => Ok(format!(
                 "{}/dir/{}/index.html",
                 self.config_paths.index_path, sf_path

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -197,8 +197,14 @@ pub enum SearchfoxIndexRoot {
     /// The root of the config repo.
     ConfigRepo,
     /// The templates dir under the index root, home of the search template and
-    /// the rendered help.html
+    /// the rendered help.html.  This differs from IndexPages because the pages
+    /// directory is intended to be exposed directly to the web, whereas if we
+    /// expose the templates pages, we do so individually via symlinks.
     IndexTemplates,
+    /// The "pages" dir under the index root.  This directory is intended to be
+    /// exposed to the web in its entirety, which differs from IndexTemplates,
+    /// which is not.  This is the home of the settings page.
+    IndexPages,
     /// Directory listings.
     UncompressedDirectoryListing,
 }

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -439,7 +439,7 @@ pub fn format_file_data(
 
     output::generate_breadcrumbs(&opt, writer, path)?;
 
-    output::generate_panel(writer, panel)?;
+    output::generate_panel(&opt, writer, panel)?;
 
     let info_boxes_container = F::Seq(vec![
         F::S(r#"<section class="info-boxes" id="info-boxes-container">"#),
@@ -1015,7 +1015,7 @@ pub fn format_diff(
         items: vcs_panel_items,
         raw_items: vec![],
     }];
-    output::generate_panel(writer, &sections)?;
+    output::generate_panel(&opt, writer, &sections)?;
 
     let f = F::Seq(vec![F::T(
         format!("<div id=\"file\" class=\"file\" role=\"table\"{}>", slug),

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -271,6 +271,7 @@ pub fn generate_footer(
     }
 
     let scripts = [
+        "settings.js",
         "search.js",
         "context-menu.js",
         "panel.js",
@@ -323,6 +324,7 @@ static COPY_ICONS: &str = r#"<span class="icon-docs copy-icon"></span><span clas
 /// Generate HTML for a panel containing the given sections and write it to the
 /// provided writer.  This is expected to be called once per document.
 pub fn generate_panel(
+    opt: &Options,
     writer: &mut dyn Write,
     sections: &[PanelSection],
 ) -> Result<(), &'static str> {
@@ -404,6 +406,8 @@ pub fn generate_panel(
             F::Indent(vec![
                 F::S(r#"<span class="navpanel-icon icon-down-dir expanded" aria-hidden="false"></span>"#),
                 F::S("Navigation"),
+                F::T(format!(r#"<a id="show-settings" title="Go to settings page" href="/{}/pages/settings.html"><span class="navpanel-icon icon-cog expanded" aria-hidden="false"></span></a>"#,
+                     opt.tree_name)),
             ]),
             F::S("</button>"),
             F::S(r#"<section id="panel-content" aria-expanded="true" aria-hidden="false">"#),

--- a/tools/src/templating/builder.rs
+++ b/tools/src/templating/builder.rs
@@ -94,3 +94,12 @@ pub fn build_and_parse_help_index() -> Template {
         .unwrap();
     build_and_parse(template_str)
 }
+
+pub fn build_and_parse_settings() -> Template {
+    let template_str = TEMPLATE_DIR
+        .get_file("settings.liquid")
+        .unwrap()
+        .contents_utf8()
+        .unwrap();
+    build_and_parse(template_str)
+}

--- a/tools/templates/scroll_footer.liquid
+++ b/tools/templates/scroll_footer.liquid
@@ -1,4 +1,5 @@
 
+<script src="/{{tree}}/static/js/settings.js"></script>
 <script src="/{{tree}}/static/js/search.js"></script>
 <script src="/{{tree}}/static/js/context-menu.js"></script>
 <script src="/{{tree}}/static/js/panel.js"></script>

--- a/tools/templates/settings.liquid
+++ b/tools/templates/settings.liquid
@@ -1,0 +1,209 @@
+{% include 'header_search.liquid' title: "Searchfox Settings", autofocus: false %}
+<div id="scrolling">
+  <div id="content" class="content settings-page" data-no-results="No results for current query.">
+    <h1>Searchfox Settings</h1>
+    <section>
+      <h2>About Searchfox Settings</h2>
+      <p>
+        This page describes and allows you to change your searchfox settings.
+        Settings are stored in LocalStorage and so will be specific to your
+        profile and any user container.  Settings only control client-side
+        JavaScript decision-making and are never directly sent to the server,
+        although settings can affect what requests are sent to the server.  Per
+        the <a href="https://www.visophyte.org/blog/2022/10/05/andrews-searchfox-vision-2022/">
+        current searchfox vision doc</a>, because URLs are intended to be
+        shareable and consistent, a shared URL may assume the existence of a
+        feature and effectively enable it while viewing that page so that the UI
+        experienced is consistent and not bizarrely broken.  The user's settings
+        in LocalStorage will not be affected, however, and when transitioning
+        back to a page that doesn't assume a feature, the user will return to
+        their normal flow.
+      </p>
+      <p>
+        There is currently no support for synchronizing settings, although if
+        searchfox ends up with enough settings, a mechanism to export settings
+        by generating a URL or a copy-and-pasteable JSON payload could be added.
+      </p>
+      <p>
+        Settings are organized into three categories:
+      </p>
+      <ul>
+        <li>
+          Widget Enable/Disable.  Searchfox widgets are pieces of functionality
+          that operate independently from each other.  They are conceptually
+          similar to web-extensions; when enabled they can add menu items to the
+          context menu and new interactable HTML to the fancy bar, but they will
+          not directly interact with other widgets or core features in a way
+          that would introduce functionality combinatorial explosions.
+        </li>
+        <li>
+          <p>
+            Core Feature Quality Gates.  As new functionality is added to
+            searchfox, it moves through several quality levels: alpha, beta, and
+            release.  Alpha features are under active development and
+            experimentation which can result in continual changes to the user
+            experience and where the experience may be brittle.  Beta features
+            have reached a stable experience, but one that it's not clear is
+            appropriate to yet push to users who primarily are interested in the
+            searchfox experience they are used to.  In particular, during 2023
+            it's likely new development will only promote features to beta with an
+            eye towards polishing their interaction near the end of 2023 and
+            then promoting many of those features to release simultaneously.
+          </p>
+          <p>
+            Unless abandoned, core features are always moving in the direction
+            of being enabled.  This means we can have features like "remove X"
+            as we don't have a concept of "disabling" a feature.  As a user, if
+            you don't want a specific feature and it hasn't yet reached
+            "release", then you can set your quality gate for that feature to
+            "release" even if you your global quality gate set to "alpha" or
+            "beta", but eventually that feature will become enabled when it hits
+            release.  That said, "behavior" settings are always a possibility as
+            long as they don't create combinatiorial explosions that complicate
+            maintenance and development.
+          </p>
+          <p>
+            Continuing the theme of avoiding creating combinatorial explosions,
+            features do not interact with each other, they only depend on each
+            other.  This means as new alpha/beta features evolve that initially
+            operate in isolation, new dependencies on other features may be
+            added that.
+          </p>
+        </li>
+        <li>
+          Behavior: A setting that changes how a core feature or a widget
+          behaves.  Behavioral settings should ideally operate independently
+          from each other to avoid combinatorial explosion that is hard to test
+          or reason about.
+        </li>
+      </ul>
+      <p>
+        Features are tracked as "alpha", "beta", and "release".
+        versions.
+        features which are either enabled or
+        disabled, a
+        Features are organized into alpha, beta, and release features.
+        As we implement new functionality in 2023 and pick new defaults, we are
+        currently trying to strike a balance between maintaining muscle memory
+        and exposing new functionality that's additive but without disrupting
+        the experience you had from searchfox at the end of 2022.  This is not a
+        commitment to never change anything or to add preferences for
+        everything, but it is a recognition that there needs to be a high bar
+        for changes that are not opt-in or which cannot be opted-out of.  It is
+        also a recognition that most new functionality will be developed
+        iteratively in consultation with the (actively involved) userbase, and
+        so there is likely to be a non-trivial amount of churn for new
+        functionality, so new functionality needs to be opt-in until the
+        experience has stabilized.
+      </p>
+      <p>
+        To this end, settings are broken into two categories:
+      </p>
+    </section>
+    <section>
+      <h2>Alpha/Beta/Release Default Core Feature Gate</h2>
+      <p>
+        As discussed above, core features are either alpha quality, beta
+        quality, or release quality.  This default setting controls what quality
+        is chosen if you do not choose a specific per-feature quality.  For
+        example, you could choose the default quality gate of "release", but for
+        specific features you are interested in, choose "alpha".  If you end up
+        not liking the churn of the feature, you could switch those features to
+        "beta" so you can experience them again when they're improved /
+        stabilized.
+      </p>
+      <form>
+        <label for="global--default-feature-gate">Default feature gate:</label>
+        <select id="global--default-feature-gate">
+          <option value="release">Release</option>
+          <option value="beta">Beta</option>
+          <option value="alpha">Alpha</option>
+        </select>
+      </form>
+      <!-- The existence of this template is assumed / hardcoded. Its contents
+           are always inserted inside any feature gate setting selects. -->
+      <template id="feature-gate-options">
+        <option value="">Use your default</option>
+        <option value="release">Release</option>
+        <option value="beta">Beta</option>
+        <option value="alpha">Alpha</option>
+      </template>
+    </section>
+    <section>
+      <h2>Source Listings</h2>
+
+      <section>
+        <h3>Page Titles Behavior</h3>
+        <p>
+          What do you want the document.title of source listing pages to be?
+        </p>
+        <p>
+          Currently, searchfox has the following sources of information available
+          for use when titling the page from most specific to most generic:
+        </p>
+        <ul>
+          <li>
+            The line selection.  Searchfox source listing pages interpret their
+            anchors as a comma-delimited list of line-number ranges.  All lines
+            covered by the ranges will be higlighted, and the page will be
+            scrolled so that the first anchored line is fully visible.  When you
+            click on a searchfox link result or use a "go to" context menu
+            option, searchfox will currently generate a direct line-number link.
+            Heuristics are used to attempt to extract the likely symbol that the
+            line selection is attempting to identify.
+          </li>
+          <li>
+            The most specific <code>position: sticky</code> nesting area
+            currently displayed at the top of the window.  When possible, source
+            listings attempt to provide you with the context of what namespace,
+            class, and method you're looking at by having them stick to the top
+            of the viewport.
+          </li>
+          <li>
+            The filename of the source file, not including the path.
+          </li>
+        </ul>
+        <p>
+          Originally, only the filename (sans path) was displayed, but starting
+          in mid 2021 <a href="https://bugzilla.mozilla.org/show_bug.cgi?id=1702319">
+          an attempt was made</a> to provide more context by adding line
+          selection and "sticky" title in that order, followed by the filename.
+        </p>
+        <form>
+          <fieldset>
+            <legend>Page Title Data Sources Other Than Filename</legend>
+            <ul>
+              <li>
+                <input type="checkbox" id="page-title--line-selection">
+                <label for="page-title--line-selection">Line Selection</label>
+              </li>
+              <li>
+                <input type="checkbox" id="page-title--sticky-symbol">
+                <label for="page-title--sticky-symbol">The most specific position: sticky symbol.</label>
+              </li>
+            </ul>
+          </fieldset>
+        </form>
+      </section>
+    </section>
+    <section>
+      <h2>Fancy Bar</h2>
+      <p>
+        The Fancy Bar currently replaces the navigation bar on the right side of
+        the screen with a collapsible sidebar.  It is the home of most widgets
+        that exist to provide context.
+      </p>
+      <section>
+        <h3>Fancy Bar Feature Gate</h3>
+        <form>
+          <label for="fancy-bar--enabled">Fancy bar feature gate:</label>
+          <select id="fancy-bar--enabled">
+          </select>
+        </form>
+
+      </section>
+    </section>
+  </div>
+  {% include 'scroll_footer.liquid' %}
+</div>
+{% include 'footer.liquid' %}


### PR DESCRIPTION
There was a little hiccup in bug 1809987 where it turns out the context menu actually thought it was displaying icons, and with the CSS class changes, the layout of the context menu regressed.  I hadn't realized icons went there because back in 2021 we deleted the CSS glue that used to always display search icons in the context menu.  (And I mean always!  DXR used icons to differentiate between different classes of options but in searchfox it seems we've only ever used the search icon.  There is more work to do on this moving forward.)