### PR TITLE
Bug 1703656 - Remove settings page text detritus, bind feature qualities.

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -528,7 +528,14 @@ const SettingsBinder = new (class SettingsBinder {
         elem.addEventListener("change", () => {
           Settings.__setValueFromIdSpace(elem.id, elem.value);
         });
+      }
     }
+
+    // Bind things that say what current qualities are:
+    for (const elem of root.querySelectorAll('[id^="quality--"]')) {
+      const useId = elem.id.substring("quality--".length);
+      const info = Settings.__lookupSettingFromId(useId);
+      elem.textContent = info.keyDef.quality;
     }
   }
 })();

--- a/tools/templates/settings.liquid
+++ b/tools/templates/settings.liquid
@@ -67,7 +67,8 @@
             features do not interact with each other, they only depend on each
             other.  This means as new alpha/beta features evolve that initially
             operate in isolation, new dependencies on other features may be
-            added that.
+            added that could disable the feature until you enable the other
+            features.
           </p>
         </li>
         <li>
@@ -78,11 +79,6 @@
         </li>
       </ul>
       <p>
-        Features are tracked as "alpha", "beta", and "release".
-        versions.
-        features which are either enabled or
-        disabled, a
-        Features are organized into alpha, beta, and release features.
         As we implement new functionality in 2023 and pick new defaults, we are
         currently trying to strike a balance between maintaining muscle memory
         and exposing new functionality that's additive but without disrupting
@@ -95,9 +91,6 @@
         so there is likely to be a non-trivial amount of churn for new
         functionality, so new functionality needs to be opt-in until the
         experience has stabilized.
-      </p>
-      <p>
-        To this end, settings are broken into two categories:
       </p>
     </section>
     <section>
@@ -191,7 +184,8 @@
       <p>
         The Fancy Bar currently replaces the navigation bar on the right side of
         the screen with a collapsible sidebar.  It is the home of most widgets
-        that exist to provide context.
+        that exist to provide context.  It is currently believed to be
+        <b><span id="quality--fancy-bar--enabled"></span></b> quality.
       </p>
       <section>
         <h3>Fancy Bar Feature Gate</h3>


### PR DESCRIPTION
I had missed a final cleanup pass on the settings page text, leaving a number of fragments of text that were obsoleted by the bullet structuring.  This should now be addressed (hopefully)!  But there's still conversations to have around the text which could lead to future iteration.

I also realized the quality levels of features was not being reflected into the page, so I added a mechanism for that by using identifiers of the form "quality--group-name--key-name" where the "group-name--key-name" following "quality--" is the same identifier we expect to see when performing form binding.