### PR TITLE
Bug 1459188 - Relax router.py result limits, especially file result limits.

### DIFF
--- a/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@abstractart__json.snap
+++ b/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@abstractart__json.snap
@@ -79,5 +79,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "outerNS::AbstractArt",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@abstractart_beart__json.snap
+++ b/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@abstractart_beart__json.snap
@@ -43,5 +43,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "outerNS::AbstractArt::beArt",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@human__json.snap
+++ b/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@human__json.snap
@@ -109,5 +109,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "outerNS::Human",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@practicalart__json.snap
+++ b/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@practicalart__json.snap
@@ -43,5 +43,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "outerNS::PracticalArt",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@practicalart_beart__json.snap
+++ b/tests/tests/checks/snapshots/web/search/big_cpp.cpp/check_glob@practicalart_beart__json.snap
@@ -43,5 +43,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "outerNS::PracticalArt::beArt",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/overs.cpp/check_glob@doublePure__json.snap
+++ b/tests/tests/checks/snapshots/web/search/overs.cpp/check_glob@doublePure__json.snap
@@ -82,5 +82,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "DoubleBase::doublePure",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }

--- a/tests/tests/checks/snapshots/web/search/overs.cpp/check_glob@triplePure__json.snap
+++ b/tests/tests/checks/snapshots/web/search/overs.cpp/check_glob@triplePure__json.snap
@@ -104,5 +104,6 @@ expression: "&jv.value"
     ]
   },
   "*title*": "TripleBase::triplePure",
-  "*timedout*": false
+  "*timedout*": false,
+  "*limits*": []
 }


### PR DESCRIPTION
While we can ideally do a lot of clever things in the future with the "query" endpoint, this patch:
- Quadruples the result limit to 4000 from 1000.
- Applies a limit of 32000 to search_files because search_files is not aware of test file categorization/etc. and so applying the same limit here as we do for results demonstrably can be confusing and unhelpful!
- The scaling factor here is 4 and I have un-helpfully put this behind a new constant, `EXTREME_FACTOR`.  In general I try and avoid optimizing code for my enjoyment over maintainability, but since router.py is explicitly not slated for any meaningful feature enhancements, I shall allow myself this novelty.  (But I also have no problem if someone wants to rename it something less fun.)
- Adds explicit signaling if we hit a quantity limit via a new `*limits*` key which holds an array of limits that were hit.  This avoids the need for users to infer when they hit the limit, which was also effectively impossible for users to do when search_files hit a limit and then the results set was refined to be less than the 1000 limit.
- Bumps the codesearch max_matches limit up to 4000, and without using the super cool `EXTREME_FACTOR` constant.
- Change codesearch to return an explicit boolean indicating whether its count limit was hit, not just its time limit.

This patch does not affect the "query" endpoint's concept of limits for the "default" search at this time.  Assuming we see no regressions from this, we would want the query endpoint to have limits at least as generous as these. Noting that the query endpoint can potentially do faceting/summarization even if it limits the result set sent to the user.  Also, since it returns HTML directly instead of tunneling it through JSON, a much larger result set from the query endpoint should not jank in the same way because async OMT HTML parsing will be used.