### PR TITLE
[WIP] Bug 1799579 - Handle OverloadExpr in MozSearchIndexer

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1980,6 +1980,26 @@ public:
     return true;
   }
 
+  bool VisitOverloadExpr(OverloadExpr *E) {
+    SourceLocation Loc = E->getExprLoc();
+    normalizeLocation(&Loc);
+    if (!isInterestingLocation(Loc)) {
+      return true;
+    }
+
+    for (auto *Candidate : E->decls()) {
+      if (TemplateDecl *TD = dyn_cast<TemplateDecl>(Candidate)) {
+        Candidate = TD->getTemplatedDecl();
+      }
+      if (FunctionDecl *F = dyn_cast<FunctionDecl>(Candidate)) {
+        std::string Mangled = getMangledName(CurMangleContext, F);
+        visitIdentifier("use", "function", getQualifiedName(F), Loc, Mangled,
+                        F->getType(), getContext(Loc));
+      }
+    }
+    return true;
+  }
+
   bool VisitCXXDependentScopeMemberExpr(CXXDependentScopeMemberExpr *E) {
     SourceLocation Loc = E->getMemberLoc();
     normalizeLocation(&Loc);

--- a/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Foo_Project
+++ b/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Foo_Project
@@ -1,0 +1,1 @@
+filter-analysis bug1781178.cpp -i Foo::Project

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
@@ -1,0 +1,41 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00006:7-14",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (Point<F>)",
+    "pretty": "function Foo::Project",
+    "sym": "_ZN3Foo7ProjectE5PointITL0__E"
+  },
+  {
+    "loc": "00006:7-14",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "Foo::Project",
+    "sym": "_ZN3Foo7ProjectE5PointITL0__E",
+    "context": "Foo",
+    "contextsym": "T_Foo",
+    "peekRange": "6-6"
+  },
+  {
+    "loc": "00010:4-11",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (Point<F>)",
+    "pretty": "function Foo::Project",
+    "sym": "_ZN3Foo7ProjectE5PointITL0__E"
+  },
+  {
+    "loc": "00010:4-11",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Foo::Project",
+    "sym": "_ZN3Foo7ProjectE5PointITL0__E",
+    "context": "Foo::Bar",
+    "contextsym": "_ZN3Foo3BarEv"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -182,6 +182,12 @@ expression: "&fb.contents"
         </tr>
 
         <tr>
+          <td><a href="/tests/source/bug1781178.cpp" class="icon icon-cpp">bug1781178.cpp</a></td>
+          <td class="description"><a href="/tests/source/bug1781178.cpp" title=""></td>
+          <td><a href="/tests/source/bug1781178.cpp">180</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/build.rs" class="icon icon-rs">build.rs</a></td>
           <td class="description"><a href="/tests/source/build.rs" title=""></td>
           <td><a href="/tests/source/build.rs">337</a></td>

--- a/tests/tests/files/bug1781178.cpp
+++ b/tests/tests/files/bug1781178.cpp
@@ -1,0 +1,12 @@
+template <typename> struct Point {};
+
+template <typename>
+struct Foo {
+  template <typename F>
+  void Project(Point<F>);
+
+  void Bar() {
+    Point<float> p;
+    Project(p);
+  }
+};


### PR DESCRIPTION
Posting a WIP patch for [bug 1799579](https://bugzilla.mozilla.org/show_bug.cgi?id=1799579).

The patch partially fixes the bug, in that the call to `Project` is now clickable and offers the menu item "Search for function `Foo::Project`", but it does not yet offer the menu item "Go to definition of `Foo::Project`", which we'd like as well.

I will continue investigating why it doesn't offer that second menu item, but in the meantime I wanted to post what I have.

---

Also, a note on why I didn't use the `AutoTemplateContext` machinery:

While `OverloadExpr` is (usually, and in this testcase in particular) dependent, it's a bit different from `CXXDependentScopeMemberExpr` in that candidate declarations being referenced are available, and it's only the selection among the candidates that's deferred until instantiation (whereas, with `CXXDependentScopeMemberExpr`, candidate declarations are not available prior to instantiation because the scope in which name lookup would have to be performed to find the candidates is itself not available).

As a result, we can provide heuristic results for `OverloadExpr` without looking at instantiations (namely, just provide all the candidates), and I think this is useful enough for a first pass.

I think there's an opportunity to _improve_ the results by using the `AutoTemplateContext` machinery to discover which candidates are actually used by instantiations and potentially narrow the results that way, but I'm proposing to defer that to a future improvement.

(I should definitely expand the testcase to include a scenario with multiple overloads to illustrate the behaviour, I will do that in an upcoming revision of this patch.) 