### PR TITLE
Rename Highlight to Highlighter to avoid collision

### DIFF
--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -411,7 +411,7 @@ var Sticky = new (class Sticky {
   }
 })();
 
-var Highlight = new (class Highlight {
+var Highlighter = new (class Highlighter {
   constructor() {
     for (let line of document.querySelectorAll(".line-number")) {
       line.addEventListener("click", event => this.onLineNumberClick(event));

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -38,7 +38,7 @@ var Panel = new (class Panel {
       block: {
         node: this.findItem("Code Block"),
         isEnabled: () => {
-          return Highlight?.selectedLines.size > 0;
+          return Highlighter?.selectedLines.size > 0;
         },
         getText: url => {
           const file = document.getElementById("file");
@@ -261,7 +261,7 @@ var Panel = new (class Panel {
       return lineText.substring(0, count);
     }
 
-    for (const line of [...Highlight.selectedLines].sort((a, b) => a - b)) {
+    for (const line of [...Highlighter.selectedLines].sort((a, b) => a - b)) {
       if (lastLine !== -1 && lastLine != line - 1) {
         lines.push(kPlaceholder);
       }


### PR DESCRIPTION
There is a relatively new web platform API with the name "Highlight", whose existence [1] breaks the line highlighting feature of Searchfox on Chromium-based browsers where this feature is implemented [2]. Rename Highlight to Highlighter to avoid this name collision.

References:
[1]: https://developer.mozilla.org/en-US/docs/Web/API/Highlight
[2]: https://chromestatus.com/feature/5436441440026624

Latest Chrome (112) gives the following error without this fix:

> Uncaught TypeError: Cannot read properties of undefined (reading 'size')
    at isEnabled (panel.js:41:42)
    at Panel.updateMarkdownState (panel.js:302:11)
    at Panel.onSelectedSymbolChanged (panel.js:317:10)
    at DocumentTitler.processLineSelection (code-highlighter.js:243:11)
    at Highlight.updateHash (code-highlighter.js:566:20)
    at Highlight.updateFromHash (code-highlighter.js:642:12)
    at new Highlight (code-highlighter.js:421:10)
    at code-highlighter.js:414:17