### PR TITLE
Bug 1829273 - Fix crash when processing NSS

### DIFF
--- a/tools/src/file_format/crossref_converter.rs
+++ b/tools/src/file_format/crossref_converter.rs
@@ -24,7 +24,7 @@ pub fn convert_crossref_value_to_sym_info_rep(cross_val: Value, sym: &Ustr, fall
                 let path_val = path_hit.remove("path").unwrap();
                 let path = path_val.as_str().unwrap();
                 if let Some(Value::Array(mut lines)) = path_hit.remove("lines") {
-                    if lines.len() > 1 {
+                    if lines.len() != 1 {
                         return;
                     }
                     if let Value::Object(line_hit) = lines.remove(0) {


### PR DESCRIPTION
It appears that sometimes lines has a length of zero, and so the lines.remove(0) crashes. This updates the guard to protect against that case too. I have no idea what this code is doing though so maybe there's a better fix, but this should hopefully at least unblock the indexer.