### PR TITLE
rust: Prefer scip index if available.

### DIFF
--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -34,12 +34,11 @@ GENERATED_SRC=$4
 SF_ANALYSIS_OUT=$5
 
 if [ -d "$RUST_ANALYSIS_IN" ]; then
-  INPUTS="$(find $RUST_ANALYSIS_IN -type d -name save-analysis)"
-  SCIP_FLAGS=""
+  INPUTS="$(find $RUST_ANALYSIS_IN -type f -name rust.scip)"
+  SCIP_FLAGS="--scip --scip-prefix $RUST_ANALYSIS_IN"
   if [ "x$INPUTS" = "x" ]; then
-    INPUTS="$(find $RUST_ANALYSIS_IN -type f -name rust.scip)"
-    SCIP_FLAGS="--scip --scip-prefix $RUST_ANALYSIS_IN"
-  else
+    INPUTS="$(find $RUST_ANALYSIS_IN -type d -name save-analysis)"
+    SCIP_FLAGS=""
     # Rust stdlib files use `analysis` directories instead of `save-analysis`, so
     # even though they live under the same root, it needs a separate find pass
     # because the above will not have found them.


### PR DESCRIPTION
With the latest mozilla-config and scip changes, this gives me a working mozilla-central index.

There are some regressions that I noticed that might be worth addressing first:

 * No stdlib symbols: If you have `use std::io::Write;`, clicking `Write` won't find all references to it. Not super-surprising given we have a bunch of extra code to deal with the rust stdlib in save analysis, but maybe we can do something about it.

 * No module definitions: If you have `mod foo;`, clicking `foo` won't show the "Go to definition" button to get you to the file.

 * #[no_mangle] functions keep the rust-module-namespaced symbol names. I'm not sure how easy to address is this without upstream fixes, we'll see.

Other than that, it seems to be working, and maybe we can even enable it by default if those regressions get worked on or if we consider they're not such a huge deal.