### PR TITLE
rust: Avoid warning spew.

### DIFF
--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -958,7 +958,7 @@ fn analyze_using_scip(tree_info: &TreeInfo, scip_prefix: Option<&PathBuf>, scip_
             match doc_symbols_to_index.get(s) {
                 Some(i) => Cow::Borrowed(&doc.symbols[*i]),
                 None => {
-                    warn!("Didn't find symbol {:?} in local symbol table", s);
+                    debug!("Didn't find symbol {:?} in local symbol table", s);
                     // Fake it till you make it? We have no info for this
                     // symbol, so...
                     Cow::Owned(SymbolInformation {


### PR DESCRIPTION
This is useful for debugging but not so much otherwise.