### PR TITLE
Bug 1828223 - Implement heuristic resolution of CXXDependentScopeMemberExpr

### DIFF
--- a/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Point_IsThereOne
+++ b/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Point_IsThereOne
@@ -1,0 +1,1 @@
+filter-analysis bug1781178.cpp -i Point::IsThereOne

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
@@ -4,45 +4,45 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00006:7-14",
+    "loc": "00008:7-14",
     "source": 1,
-    "nestingRange": "6:25-6:26",
+    "nestingRange": "8:25-8:26",
     "syntax": "def,function",
     "type": "void (Point<F>)",
     "pretty": "function Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__E"
   },
   {
-    "loc": "00006:7-14",
+    "loc": "00008:7-14",
     "target": 1,
     "kind": "def",
     "pretty": "Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__E",
     "context": "Foo",
     "contextsym": "T_Foo",
-    "peekRange": "6-6"
+    "peekRange": "8-8"
   },
   {
-    "loc": "00009:7-14",
+    "loc": "00011:7-14",
     "source": 1,
-    "nestingRange": "9:35-9:36",
+    "nestingRange": "11:35-11:36",
     "syntax": "def,function",
     "type": "void (Point<F>, Point<F>)",
     "pretty": "function Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_"
   },
   {
-    "loc": "00009:7-14",
+    "loc": "00011:7-14",
     "target": 1,
     "kind": "def",
     "pretty": "Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_",
     "context": "Foo",
     "contextsym": "T_Foo",
-    "peekRange": "9-9"
+    "peekRange": "11-11"
   },
   {
-    "loc": "00013:4-11",
+    "loc": "00015:4-11",
     "source": 1,
     "syntax": "use,function",
     "type": "void (Point<F>)",
@@ -50,7 +50,7 @@ expression: "&json_results"
     "sym": "_ZN3Foo7ProjectE5PointITL0__E"
   },
   {
-    "loc": "00013:4-11",
+    "loc": "00015:4-11",
     "source": 1,
     "syntax": "use,function",
     "type": "void (Point<F>, Point<F>)",
@@ -58,7 +58,7 @@ expression: "&json_results"
     "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_"
   },
   {
-    "loc": "00013:4-11",
+    "loc": "00015:4-11",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::Project",
@@ -67,7 +67,7 @@ expression: "&json_results"
     "contextsym": "_ZN3Foo3BarEv"
   },
   {
-    "loc": "00013:4-11",
+    "loc": "00015:4-11",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::Project",

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
@@ -1,0 +1,24 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00002:7-17",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "_Bool (void)",
+    "pretty": "function Point::IsThereOne",
+    "sym": "_ZN5Point10IsThereOneEv"
+  },
+  {
+    "loc": "00002:7-17",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "Point::IsThereOne",
+    "sym": "_ZN5Point10IsThereOneEv",
+    "context": "Point",
+    "contextsym": "T_Point",
+    "peekRange": "2-2"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
@@ -20,5 +20,22 @@ expression: "&json_results"
     "context": "Point",
     "contextsym": "T_Point",
     "peekRange": "2-2"
+  },
+  {
+    "loc": "00021:4-14",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "_Bool (void)",
+    "pretty": "function Point::IsThereOne",
+    "sym": "_ZN5Point10IsThereOneEv"
+  },
+  {
+    "loc": "00021:4-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Point::IsThereOne",
+    "sym": "_ZN5Point10IsThereOneEv",
+    "context": "TemplateFunc",
+    "contextsym": "_Z12TemplateFuncv"
   }
 ]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -191,7 +191,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/bug1781178.cpp" class="mimetype-fixed-container mimetype-icon-cpp">bug1781178.cpp</a></td>
           <td class="description"><a href="/tests/source/bug1781178.cpp" title=""></td>
-          <td><a href="/tests/source/bug1781178.cpp">245</a></td>
+          <td><a href="/tests/source/bug1781178.cpp">346</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/bug1781178.cpp
+++ b/tests/tests/files/bug1781178.cpp
@@ -1,4 +1,6 @@
-template <typename> struct Point {};
+template <typename> struct Point {
+  bool IsThereOne();
+};
 
 template <typename>
 struct Foo {
@@ -13,3 +15,8 @@ struct Foo {
     Project(p);
   }
 };
+
+template <typename T> void TemplateFunc() {
+  Point<T> p;
+  p.IsThereOne();
+}


### PR DESCRIPTION
Posting a draft fix for bug 1828223 for feedback.

I would appreciate feedback on two points in particular:

 1. Currently, in `IndexConsumer::VisitCXXDependentScopeMemberExpr()`, I both (1) produce a heuristic result (that's what's new in this patch), **and** (2) record the location for possibly producing concrete results when visiting instantiations (if we have any) during the `AnalyzeDependent` phase (what the code was doing before).
 
    I'm wondering, should we add some logic to **only** produce the heuristic result if we didn't end up producing concrete results from the `AnalyzeDependent` phase?

    I feel like I could go either way on this. On the one hand, the indexer might only know about a subset of the instantiations actually occurring in the project, and the concrete results might therefore miss something that the heuristic results catch. On the other hand, if e.g. we're working with an overload set, it's possible that all instantiations end up using only a subset of the overloads, and the heuristic results would add noise by providing all overloads. In other words, I don't think either approach is _categorically_ more accurate than the other.

 2. The `HeuristicResolver` facility added in this patch is a slimmed-down version of clangd's (currently much more featureful) facility [of the same name](https://searchfox.org/llvm/rev/be9c91843bab5bb46574c27836bfcd9ad6fc9ef5/clang-tools-extra/clangd/HeuristicResolver.h#45).

    My current approach is to port over pieces of this facility to Searchfox as we need them to make specific testcases work.

    However, one could imagine a different approach of just... copying the class from clangd wholesale, as a piece of code which has been battle-tested in a different project? (It doesn't have any dependencies on anything else in clangd, only public clang APIs.)

    Let me know if you have a preference here, I'm happy to switch approaches.

    (Granted, even better would be to upstream `HeuristicResolver` to `libClangTooling` or somesuch and expose it as a public clang API, and have both clangd and Searchfox consume it from there. I'd like to explore this, but I'd prefer not to block our progress on Searchfox enhancements on this LLVM change, because LLVM patches can be slow to be reviewed (and then we'd need to adopt the new LLVM version in which it appears and so on.))