### PR TITLE
Bug 1841556 - Add rust-analyzer component

### DIFF
--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -40,6 +40,7 @@ set -o pipefail # Check all commands in a pipeline
 rustup component remove clippy || true
 rustup component remove rustfmt || true
 rustup component remove rust-docs || true
+rustup component add rust-analyzer || true
 rustup update
 
 # Install SpiderMonkey.


### PR DESCRIPTION
Some repos want this installed, and it seems like it's not installed by default any more.