### PR TITLE
Bug 1852405 - Provision ninja to support LLVM semantic indexing.

### DIFF
--- a/docs/aws.md
+++ b/docs/aws.md
@@ -380,7 +380,7 @@ our shell scripts:
   (Instead, the VM should be destroyed and rebuilt.)
 
 Generating a new AMI should now be largely automated thanks to the work on
-[https://bugzilla.mozilla.org/show_bug.cgi?id=1747289](bug 1747289).
+[bug 1747289](https://bugzilla.mozilla.org/show_bug.cgi?id=1747289).
 However, there are a set of manual steps that need to be taken, see below.
 
 To re-provision the indexer AMI, run the following:

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -10,6 +10,9 @@ sudo apt-get install -y zlib1g-dev
 # Install python2 and six (needed for cinnabar and idl-analyze.py)
 sudo apt-get install -y python2.7 python-six
 
+# Building LLVM likes to have ninja; pernosco also can use it if we ever index that.
+sudo apt-get install -y ninja-build
+
 # cargo-insta makes it possible to use the UI documented at
 # https://insta.rs/docs/cli/ to review changes to "check" scripts.  For the test
 # repo, this is used by `make review-test-repo`.  It's not expected that this


### PR DESCRIPTION
This also includes a doc fix where I got the markdown syntax backwards before (whoops!).