### PR TITLE
Bug 1852419 - "inc" files are probably C++ files.

### DIFF
--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -660,7 +660,7 @@ pub fn select_formatting(filename: &str) -> FormatAs {
         None => "",
     };
     match ext {
-        "c" | "cc" | "cpp" | "cxx" | "h" | "hh" | "hxx" | "hpp" | "mm" | "m" => {
+        "c" | "cc" | "cpp" | "cxx" | "h" | "hh" | "hxx" | "hpp" | "inc" | "mm" | "m" => {
             FormatAs::FormatCLike(&*CPP_SPEC)
         }
         "aidl" => FormatAs::FormatCLike(&*AIDL_SPEC),


### PR DESCRIPTION
Assume "inc" files are C++ files because we frequently have C++ analysis records for them, whereas we never have analysis records for any other "inc" file extension, and we need to tokenize the file as C++ to use that analysis information.