### PR TITLE
Add support to specify an alias to a repository.

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -162,6 +162,12 @@ for repo in config['trees']:
             # If this fails just leave head_rev as None and skip the optimization
             pass
 
+    alias = tree_config['alias']
+    if alias:
+        location(f'~ /{alias}(.*)$', [
+            f'return 301 $scheme://$http_host/{repo}$1;'
+        ])
+
     # we use alias because the we don't want the "/{repo}" portion.
     location(f'/{repo}/static/', [f'alias {mozsearch_path}/static/;'])
 

--- a/tests/config.json
+++ b/tests/config.json
@@ -6,6 +6,7 @@
 
   "trees": {
     "tests": {
+      "alias": "old-tests",
       "priority": 100,
       "on_error": "halt",
       "cache": "everything",


### PR DESCRIPTION
This might be useful if we decide to rename /wubkat to /webkit or similar.