### PR TITLE
Document use of docker, add support for "trees" repo, provision scip-typescript and scip-python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ repos
 /config
 addons
 /tests/tests/checks/explanations
+/trees/*
+!/trees/README.md

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ addons
 /tests/tests/checks/explanations
 /trees/*
 !/trees/README.md
+/tree-configs/*
+!/tree-configs/README.md

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,18 @@ build-mozilla-repo: check-in-vagrant build-clang-plugin build-rust-tools
 	/vagrant/infrastructure/web-server-setup.sh ~/mozilla-config config1.json ~/mozilla-index ~
 	/vagrant/infrastructure/web-server-run.sh ~/mozilla-config ~/mozilla-index ~
 
+build-trees: check-in-vagrant build-clang-plugin build-rust-tools
+	mkdir -p ~/trees-index
+	/vagrant/infrastructure/indexer-setup.sh /vagrant/tree-configs config.json ~/trees-index
+	/vagrant/infrastructure/indexer-run.sh /vagrant/tree-configs ~/trees-index
+	/vagrant/infrastructure/web-server-setup.sh /vagrant/tree-configs config.json ~/trees-index ~
+	/vagrant/infrastructure/web-server-run.sh /vagrant/tree-configs ~/trees-index ~ WAIT
+	/vagrant/infrastructure/web-server-check.sh /vagrant/tree-configs ~/trees-index "http://localhost/"
+
+serve-trees: check-in-vagrant build-clang-plugin build-rust-tools
+	/vagrant/infrastructure/web-server-setup.sh /vagrant/tree-configs config.json ~/trees-index ~
+	/vagrant/infrastructure/web-server-run.sh /vagrant/tree-configs ~/trees-index ~ WAIT
+
 # This is similar to build-mozilla-repo, except it strips out the non-mozilla-central trees
 # from config.json and puts the stripped version into trypush.json.
 trypush: check-in-vagrant build-clang-plugin build-rust-tools

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,10 +1,55 @@
 #!/bin/bash
 
-# See `run-docker.sh` for context.
+# See `run-docker.sh` for context; it uses these defs too. Yes, we could source.
 IMAGE_NAME=${SEARCHFOX_DOCKER_IMAGE_NAME:-searchfox}
+CONTAINER_NAME=${SEARCHFOX_DOCKER_CONTAINER_NAME:-searchfox}
+VOLUME_NAME=${SEARCHFOX_DOCKER_VOLUME_NAME:-searchfox-vol}
 
 docker build \
     -t ${IMAGE_NAME} \
     --build-arg LOCAL_UID=$(id -u $USER) \
     --build-arg LOCAL_GID=$(id -g $USER) \
     infrastructure/
+
+## Clean up any existing container and affiliated volumes
+#
+# Because our provisioning process installs a lot of things into our user's home
+# dir ("vagrant" for legacy reasons), it's necessary for us to remove the volume
+# we create in addition to any existing container.  Because volumes can only be
+# removed after their container, this mandates removing the container first.  We
+# want to remove the container anyways since we want the container to use our
+# freshly updated image!
+
+container_exists() {
+    docker container inspect ${CONTAINER_NAME} &> /dev/null
+}
+
+volume_exists() {
+    docker volume inspect ${VOLUME_NAME} &> /dev/null
+}
+
+if container_exists; then
+    echo "Removing existing container: ${CONTAINER_NAME}"
+    docker rm ${CONTAINER_NAME}
+fi
+
+
+if volume_exists; then
+    # Note: There's a force flag but I'm not sure what it's for since it doesn't do
+    # anything if the container exists.
+    echo "Removing existing volume: ${VOLUME_NAME}"
+    docker volume rm ${VOLUME_NAME}
+fi
+
+# You don't have to actually create the volume, but this is the closest thing to
+# what we did for Vagrant and it seems potentially desirable.  The run-docker.sh
+# script should handle if this does not exist.
+#
+# If the volume is not created, then any changes to the user's home directory
+# will be lost when the first `run-docker.sh` invocation that started the
+# container ends.  Since this is where our indexing byproducts exist, it can be
+# nice for this directory to be durable.  And in the case of develoeprs using
+# `make build-mozilla-repo` it's particularly desirable because of how long the
+# build process takes.
+docker volume create ${VOLUME_NAME}
+

--- a/docs/old-vagrant-setup.md
+++ b/docs/old-vagrant-setup.md
@@ -1,0 +1,126 @@
+## Deprecated Vagrant Setup
+
+There are almost no circumstances in which you'd want to use this Vagrant setup,
+and with any luck it will bit-rot into obsolescence and we can delete this doc
+and the Vagrant file, but... here you go:
+
+### Setting up the VM
+
+We use Vagrant to setup a virtual machine.  This may be the most frustrating part of
+working with Searchfox.  If you can help provide better/more explicit instructions
+for your platform, please do!
+
+#### Linux
+
+Important note: In order to expose the Searchfox source directory into the VM, we
+need to be able to export it via NFS.  If you are using a FUSE-style filesystem
+like `eCryptFS` which is a means of encrypting your home directory, things will not
+work.  You will need to move searchfox to a partition that's a normal block device
+(which includes LUKS-style encrypted partitions, etc.)
+
+##### Ubuntu
+
+```shell
+# make sure the apt package database is up-to-date
+sudo apt update
+# vagrant will also install vagrant-libvirt which is the vagrant provider we use.
+# virt-manager is a UI that helps inspect that your VM got created
+# The rest are related to enabling libvirt and KVM-based virtualization
+sudo apt install vagrant virt-manager qemu libvirt-daemon-system libvirt-clients
+
+git clone https://github.com/mozsearch/mozsearch
+cd mozsearch
+git submodule update --init
+vagrant up
+```
+##### Other Linux
+Note: VirtualBox is an option on linux, but not recommended.
+
+1. [install Vagrant](https://www.vagrantup.com/downloads.html).
+2. Install libvirt via [vagrant-libvirt](https://github.com/vagrant-libvirt/vagrant-libvirt).
+   Follow the [installation instructions](https://github.com/vagrant-libvirt/vagrant-libvirt#installation).
+  - Note that if you didn't already have libvirt installed, then a new `libvirt`
+    group may just have been created and your existing logins won't have the
+    permissions necessary to talk to the management socket.  If you do
+    `exec su -l $USER` you can get access to your newly assigned group.
+  - See troubleshooting below if you have problems.
+
+Once that's installed:
+```shell
+git clone https://github.com/mozsearch/mozsearch
+cd mozsearch
+git submodule update --init
+vagrant up
+```
+
+If vagrant up times out in the "Mounting NFS shared folders..." step, chances
+are that you cannot access nfs from the virtual machine.
+
+Under stock Fedora 31, you probably need to allow libvirt to access nfs:
+
+```
+firewall-cmd --permanent --add-service=nfs --zone=libvirt
+firewall-cmd --permanent --add-service=rpc-bind --zone=libvirt
+firewall-cmd --permanent --add-service=mountd --zone=libvirt
+firewall-cmd --reload
+```
+
+#### OS X and Windows
+
+Note: The current Homebrew version of Vagrant is currently not able to use the most
+recent version of VirtualBox so it's recommended to install things directly via their
+installers.
+
+1. [install Vagrant](https://www.vagrantup.com/downloads.html).
+2. Figure out the right virtualization option for you.
+  - OS X:
+    - Are you on an M1 mac?  Then you probably need to get a license for Parallels
+      and use it, maybe.  And then you can do `vagrant plugin install vagrant-parallels`
+      below.
+    - Maybe get a license for parallels anyways?
+    - Otherwise do the virtualbox thing below.
+  - Windows,  Visit the [VirtualBox downloads page](https://www.virtualbox.org/wiki/Downloads) and
+    follow the instructions for your OS.  You do not need and should not install
+    any extra extensions.  You only need the Open Source piece and should avoid
+    installing anything closed source or with a commercial license.
+
+Then clone Mozsearch and provision a Vagrant instance:
+```
+git clone https://github.com/mozsearch/mozsearch
+cd mozsearch
+git submodule update --init
+
+# If using VirtualBox; if using Parallels, install `vagrant-parallels`
+vagrant plugin install vagrant-vbguest
+vagrant up
+```
+
+### Once vagrant up has started...
+
+The last step will take some time (10 or 15 minutes on a fast laptop)
+to download a lot of dependencies and build some tools locally.  **Note
+that this step can fail!**  Say, if you're at a Mozilla All-Hands and the
+network isn't exceedingly reliable.  In particular, if you are seeing
+errors related to host resolution and you have access to a VPN, it may
+be advisable to connect to the VPN.
+
+A successful provisioning run will end with `mv update-log provision-update-log-2`.
+
+In the event of failure you will want to run
+`vagrant destroy` to completely delete the VM and then
+run `vagrant up` again to re-create it.  The base image gets cached on
+your system, so you'll save ~1GB of download, but all the Ubuntu package
+installation will be re-done.
+
+After `vagrant up` completes, ssh into the VM as follows. From this point
+onward, all commands should be executed inside the VM.
+
+```
+vagrant ssh
+```
+
+At this point, your Mozsearch git directory has been mounted into a
+shared folder at `/vagrant` in the VM. Any changes made from inside or
+outside the VM will be mirrored to the other side. Generally I find it
+best to edit code outside the VM, but any commands to build or run
+scripts must run inside the VM.

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -20,6 +20,29 @@ sudo apt-get install -y ninja-build
 # the update process.
 cargo install cargo-insta
 
+# To help install node.js and similar, we install rtx-cli, a rust-based "asdf"
+# alternative, which if you don't know what "asdf" is, but know what "nvm" is,
+# it's basically a super-nvm for multiple languages, etc.  We use the install
+# method documented at https://github.com/jdxcode/rtx#cargo but there are a
+# bunch of other options.
+#
+# The core rationale here is that I've locally been using "nvm" for node.js
+# purposes for a while now and it's been a much better experience than trying to
+# use debian/ubuntu distro-provided versions of node, and in particular can be
+# invaluable when trying to just get things to work when packages are involved
+# that may involve native modules/libraries which can make it hard to uniformly
+# use the latest revision.  I'm somewhat hopeful that
+cargo install rtx-cli
+
+# Install node.js v18 for scip-typescript
+rtx install nodejs@18
+
+# Install scip-typescript under node.js v18
+rtx exec nodejs@18 -- npm install -g @sourcegraph/scip-typescript
+
+# Install scip-python under node.js v18 as well
+rtx exec nodejs@18 -- npm install -g @sourcegraph/scip-python
+
 # Create update script.
 cat > update.sh <<"THEEND"
 #!/usr/bin/env bash

--- a/tree-configs/README.md
+++ b/tree-configs/README.md
@@ -1,0 +1,16 @@
+Put config files for the trees you symlinked in `/trees` in here.  The
+assumed default config (which can list multiple trees) is `config.json`.
+
+A good starting point is probably `tests/searchfox-config.json`, noting
+that you probably want to increment the `codesearch_port` to start at
+port 8082 and keep incrementing from there.  The `tests` repo uses port
+8080 and `searchfox` uses 8081, so this avoids edge cases if you are
+switching between what is indexed.
+
+You can then build the trees via `make build-trees` from `/vagrant`
+inside of your docker image if your config file is the default of
+`config.json`.  If your config file is named something else, then
+you can set the `CONFIG` env variable by doing something like
+`CONFIG=my-config.json make build-trees`.  Note that although make
+can accept variable assignments as part of its arguments, that's not
+how this is intended to work, and so maybe it won't work!

--- a/trees/README.md
+++ b/trees/README.md
@@ -1,1 +1,11 @@
 Put symlinks to trees you want to index in here.
+
+The configs for the trees go in the parallel `tree-configs` directory.
+
+You can then build the trees via `make build-trees` from `/vagrant`
+inside of your docker image if your config file is the default of
+`config.json`.  If your config file is named something else, then
+you can set the `CONFIG` env variable by doing something like
+`CONFIG=my-config.json make build-trees`.  Note that although make
+can accept variable assignments as part of its arguments, that's not
+how this is intended to work, and so maybe it won't work!

--- a/trees/README.md
+++ b/trees/README.md
@@ -1,0 +1,1 @@
+Put symlinks to trees you want to index in here.


### PR DESCRIPTION
This is slightly more of my hobby-stack touching the docker scripts than I was expecting when I said what I was going to do in https://github.com/mozsearch/mozsearch/pull/653 but I think this is probably a reasonable subset and gets all the re-provisioning out of the way at once.  I have locally re-provisioned with `./build-docker.sh` with these changes and it just ran fine.  I will perform automated re-provisioning of the AMIs if/when this PR gets r+'ed to land and I land it.

The most helpful change to the docker scripts is that it defines a persistent volume that gets mounted at the "vagrant" user's home directory.  Without this change, anything that happens in the docker container is entirely ephemeral and evaporates when the canonical run-docker.sh session exists.  This didn't matter too much for "make build-test-repo", but does start to matter if you've done "make build-mozilla-repo" and would like to not have to redo that every time.  This is what https://bugzilla.mozilla.org/show_bug.cgi?id=1812838#c1 was talking about.

The docker docs are mainly an attempt to update my WSL2 notes at https://docs.google.com/document/d/10uOwXBENgHzTAyOogSKu6cdxl-T6yQ7ars1CLYUJe2k/edit that I'd been pointing people at.  I've also added some handwaving for macOS/OS X.  (People for whom Vagrant is already working it should still keep working for them.)

This also includes mechanics for have a "trees" repo and a corresponding "tree-configs" dir so that one can run `make build-trees`.  I used this to experiment with scip-typescript on the m-c "devtools" subtree and my "gaia-email-libs-and-more" fork (via symlink) and scip-python on the m-c "python" subtree without having to deal with all of m-c and the indexing time that takes.  It's not something I would particularly point other people at right now, but since it involved touching the docker scripts in order to support some of these files being symlinks, it seemed simplest to just land it.

As part of the "trees" commit, and therefore included here, this installs "rtx" to help install node.js and scip-typescript and scip-python.  Relatedly, the other day I was interested in seeing if I could use "scip-ruby" to index "mastodon", but scip-ruby cannot be installed the same way and scip-ruby can't easily index mastodon because it's a monorepo or something like that.  (There's an issue in the scip-ruby repo about this, but I don't want to xref it here because that would be confusing for that issue.)