### PR TITLE
Various improvements to using `make build-mozilla-repo` under docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,9 @@ build-searchfox-repo: check-in-vagrant build-clang-plugin build-rust-tools
 build-mozilla-repo: check-in-vagrant build-clang-plugin build-rust-tools
 	[ -d ~/mozilla-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/mozilla-config
 	mkdir -p ~/mozilla-index
-	/vagrant/infrastructure/indexer-setup.sh ~/mozilla-config config1.json ~/mozilla-index
+	/vagrant/infrastructure/indexer-setup.sh ~/mozilla-config just-mc.json ~/mozilla-index
 	/vagrant/infrastructure/indexer-run.sh ~/mozilla-config ~/mozilla-index
-	/vagrant/infrastructure/web-server-setup.sh ~/mozilla-config config1.json ~/mozilla-index ~
+	/vagrant/infrastructure/web-server-setup.sh ~/mozilla-config just-mc.json ~/mozilla-index ~
 	/vagrant/infrastructure/web-server-run.sh ~/mozilla-config ~/mozilla-index ~
 
 build-trees: check-in-vagrant build-clang-plugin build-rust-tools

--- a/scripts/mkdirs.sh
+++ b/scripts/mkdirs.sh
@@ -4,7 +4,13 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-rm -rf $INDEX_ROOT/analysis
+# Remove the analysis dir and any platform variations.
+rm -rf $INDEX_ROOT/analysis*
+# Remove any objdir variants; in general we expect the "objdir" itself to
+# potentially have been created during the "setup" step, or at least that's the
+# case for m-c.
+rm -rf $INDEX_ROOT/objdir-*
+rm -rf $INDEX_ROOT/generated-*
 rm -rf $INDEX_ROOT/file
 rm -rf $INDEX_ROOT/dir
 rm -rf $INDEX_ROOT/description

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -26,6 +26,15 @@ JOBLOG_PATH=${DIAGS_DIR}/output.joblog
 TMPDIR_PATH=${DIAGS_DIR}
 
 # parallel args:
+# --jobs 8: Limits us to 8 jobs to avoid creating an OOM nightmare; this is
+#   consistent with our vagrant-on-linux setting.  The immediate motivation is
+#   that under docker all of the system's cores will be exposed, which is
+#   good for non-memory-intensive things.  But for mozilla-central, each
+#   output-file instance ends up using ~2GiB of RAM individually and so a memory
+#   budget of ~16GiB is reasonable.  Otherwise on my 28-core machines the 64GiB
+#   of RAM gets eaten up and every other process terminated.
+#   TODO: Overhaul output-file to have better memory usage characteristics by
+#   using forking or just being parallel itself or something.
 # --pipepart, -a: Pass the filenames to each job on the job's stdin by chopping
 #   up the file passed via `-a`.  Compare with `--pipe` which instead divvies
 #   inside the parallel perl process and can in theory be a bottleneck.
@@ -52,7 +61,7 @@ TMPDIR_PATH=${DIAGS_DIR}
 # --env RUST_BACKTRACE: propagate the RUST_BACKTRACE environment variable.
 # "2>&1": If we don't do this, `--files` seems to just eat the stderr output
 #   which is obviously suboptimal.
-parallel --pipepart -a $INDEX_ROOT/all-files --files --joblog $JOBLOG_PATH --tmpdir $TMPDIR_PATH \
+parallel --jobs 8 --pipepart -a $INDEX_ROOT/all-files --files --joblog $JOBLOG_PATH --tmpdir $TMPDIR_PATH \
     --block -1 --halt 2 --env RUST_BACKTRACE \
     "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME - 2>&1"
 


### PR DESCRIPTION
Three small changes here:
- Use `just-mc.json` to build mozilla-central, not all of config1.json.
- Clean up more things from repeated invocations of `make build-mozilla-repo` (under `/vagrant`).  I think blame will still be inefficiently recalculated, though.
- Limit output-file to 8 threads because for m-c because the downside of docker exposing all cores/hyperthreads is that memory intensive tasks like output-file (needs ~2GiB per thread/instance for m-c) it can be brutal on the host system.  Especially with proactive OOM-killers, it can wipe out a bunch of important processes.

I'm going to land these directly as I'm landing these as part of doing the first bunch of review for scip-indexer from my asuth-hobby-stack and I think these are a distraction, but am happy to follow-up on any post-landing review comments made.