### PR TITLE
Provision scip CLI 0.3.0 to get `scip print`

### DIFF
--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -176,7 +176,7 @@ if [ ! -d git-cinnabar ]; then
 fi
 
 # Install scip
-SCIP_VERSION=v0.2.0
+SCIP_VERSION=v0.3.0
 curl -L https://github.com/sourcegraph/scip/releases/download/$SCIP_VERSION/scip-linux-amd64.tar.gz | tar xzf - scip
 sudo ln -fs $(pwd)/scip /usr/local/bin/scip
 


### PR DESCRIPTION
`scip print` is extremely useful for debugging / understanding what's going on with SCIP indices.  Note that it can take some time to run on large indices and the output will be voluminous, so you'll always want to pipe to a pager.

Originally we were updating to 0.2.3 but 0.3.0 makes the print command also support JSON output via `--json` which seems potentially useful.