### PR TITLE
Avoid using stale XPIDL libs.

### DIFF
--- a/scripts/idl-analyze.sh
+++ b/scripts/idl-analyze.sh
@@ -22,6 +22,18 @@ else
     TREE_PYMODULES="/tmp/pymodules"
     PULL_FROM_MC=1
 fi
+
+# Delete the temp dir if xpidl.py is older than a day (in minutes to avoid
+# quantization weirdness).  We'll also try and delete the dir if the file just
+# doesn't exist, which also means if the directory doesn't exist.  (We could
+# have instead done `-mmin +1440` for affirmative confirmation it's old, but
+# since our next check is just for the existence of the directory, this is least
+# likely to result in weirdness.)
+if [ ! "$(find $TREE_PYMODULES/xpidl.py -mmin -1440)" ]; then
+    rm -rf $TREE_PYMODULES
+fi
+
+# download/copy as needed
 if [ ! -d "${TREE_PYMODULES}" ]; then
     mkdir "${TREE_PYMODULES}"
     pushd "${TREE_PYMODULES}"

--- a/scripts/update-fonts.sh
+++ b/scripts/update-fonts.sh
@@ -49,7 +49,7 @@ FONTELLO_ROOT=https://fontello.com
 # will be written to `.fontello-sid`.  We only need to do this if we don't have
 # a sufficiently recent SID.  We use `-mmin -1440` to express less than 24
 # hours because `-mtime` quantizes to days, and we use less than and negation
-# because we want to creat the file if it doesn't exist in addition to it being
+# because we want to create the file if it doesn't exist in addition to it being
 # too old.
 if [ ! "$(find .fontello-sid -mmin -1440)" ]; then
     curl --silent --show-error --fail --output .fontello-sid \


### PR DESCRIPTION
When running `make build-mozilla-repo` from a persistent VM volume, it's necessary to be ready to delete the XPIDL libs and re-extract them to avoid being inconsistent with the tree.