### PR TITLE
Bug 1417586 - Handle preproced IPDL, determine C++ locations from objdir-files lookup.

### DIFF
--- a/scripts/ipdl-analyze.sh
+++ b/scripts/ipdl-analyze.sh
@@ -19,8 +19,8 @@ TREE_NAME=$2
 pushd $FILES_ROOT
 cat $INDEX_ROOT/ipdl-files | \
     xargs $MOZSEARCH_PATH/tools/target/release/ipdl-analyze $(cat $INDEX_ROOT/ipdl-includes) \
-          -d $INDEX_ROOT/analysis/__GENERATED__/ipc/ipdl/_ipdlheaders \
           -f $INDEX_ROOT/repo-files \
+          -o $INDEX_ROOT/objdir-files \
           -b $(realpath $FILES_ROOT) \
           -a $INDEX_ROOT/analysis
 popd


### PR DESCRIPTION
This updates us to use https://github.com/mozsearch/ipdl_parser/pull/12 so we can parse PContent, and with the remainder of the changes here, correctly do the C++ semantic linkage as well.

Previously we used a predicted path, but this doesn't work for preprocessed files which can't be unified by the platform merge step for trees like mozilla-central.