### PR TITLE
Podman support and Nix flake

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# Configuration file for direnv.net
+# Uses Nix to provide podman, awscli and a couple of Python dependencies
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ addons
 !/trees/README.md
 /tree-configs/*
 !/tree-configs/README.md
+.direnv

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ that:
   This makes sure that the vagrant user in the container can read/write inside
   the bind mount at /vagrant.
 
+> Note for Nix users: the devShell in flake.nix provides both of those requirements.
+
 #### Installing on macOS/OS X
 
 I don't think anyone has tried this yet, but it seems like there are a variety

--- a/README.md
+++ b/README.md
@@ -35,14 +35,24 @@ If you do want to use it and you work at Mozilla, you should acquire a license
 through Service Desk before doing anything else.  If you already have a license,
 that's fine too.
 
+#### Alternative to Docker: Podman
+
+Podman can be used almost as a drop-in replacement to Docker. Just make sure
+that:
+- You have a podman wrapper or symlink named docker in your PATH, the scripts
+  call docker extensively.
+- You set the environment variable PODMAN_USERNS="keep-id" − or the equavalent
+  option in containers.conf. The source repository is bind-mounted inside the
+  container and the user in the container gets the same UID/GID as the caller.
+  This makes sure that the vagrant user in the container can read/write inside
+  the bind mount at /vagrant.
+
 #### Installing on macOS/OS X
 
 I don't think anyone has tried this yet, but it seems like there are a variety
 of options.  Here are some I've just briefly researched:
 - Use podman.  https://podman.io/docs/installation explains how to use QEMU on
-  macOS.  Note that we don't currently have native podman docs or support, but
-  it's something that's come up a number of times, so this is something we
-  could support.
+  macOS.
 - Use Colima: https://github.com/abiosoft/colima
 - Use lima, the thing that colima wraps: https://github.com/lima-vm/lima
 

--- a/build-docker.sh
+++ b/build-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # See `run-docker.sh` for context; it uses these defs too. Yes, we could source.
 IMAGE_NAME=${SEARCHFOX_DOCKER_IMAGE_NAME:-searchfox}

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -109,6 +109,7 @@ scary avenue for compromise, so I'm going to suggest:
     package becomes v2.
   - Debian: Yeah, v2 is available on some versions, `apt show awscli` and see if
     the major version is >= 2.  Keep upgrading until that's true.
+  - Nix: the devShell in our flake.nix provides awscli2. Just call `nix develop`.
 - OS X:
   - In the #iam channel, using "brew" was recommended.
 - Everything else, or if the above didn't work for you:
@@ -168,6 +169,9 @@ Because we need the boto3 lib and a few other things, we're going to set up a
 python venv now.  See https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/
 for more on installing venv, but on ubuntu you should be able to run
 `apt install python3-venv`.
+
+> Note for Nix users: you don't need to setup a venv, the right Python packages
+> are provided by our devShell.
 
 ```
 # RUN THESE COMMANDS OUTSIDE THE VM!

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,60 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1699262175,
+        "narHash": "sha256-MMqnXPV3TbJgoxY+YOW8k5WPHbglhFI+hFs9r7PQHAw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "49f444897b1d53e7a0408449773f66f830532a61",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  inputs = {
+    nixpkgs.url = github:NixOS/nixpkgs;
+    flake-utils.url = github:numtide/flake-utils;
+  };
+
+  outputs = { self, nixpkgs, flake-utils }: (
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        # A symlink from `docker` to `podman`, because the scripts call `docker`.
+        dockerCompat = pkgs.runCommandNoCC "docker-podman-compat" {} ''
+          mkdir -p $out/bin
+          ln -s ${pkgs.podman}/bin/podman $out/bin/docker
+        '';
+
+        pythonPackages = p: with p; [
+          boto3
+          rich
+        ];
+      in {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            dockerCompat
+            podman
+
+            # Those are probably not all required, copied from
+            # https://gist.github.com/adisbladis/187204cb772800489ee3dac4acdd9947
+            runc  # Container runtime
+            conmon  # Container runtime monitor
+            skopeo  # Interact with container registry
+            slirp4netns  # User-mode networking for unprivileged namespaces
+            fuse-overlayfs  # CoW for images, much faster than default vfs
+
+            jq
+
+            awscli2
+            (python3.withPackages pythonPackages)
+          ];
+
+          PODMAN_USERNS = "keep-id";
+
+          AWS_PROFILE = "searchfox";
+
+          shellHook = ''
+            echo "TL;DR:"
+            echo "- './build-docker.sh' to build the container"
+            echo "- './run-docker.sh' to enter the container"
+            echo "- 'cd /vagrant; make build-test-repo' inside to build"
+            echo "- open http://localhost:16995 in a browser"
+          '';
+        };
+      }
+    )
+  );
+}

--- a/infrastructure/docker-provision.sh
+++ b/infrastructure/docker-provision.sh
@@ -15,7 +15,7 @@ apt-get install -y apt-utils lsb-release sudo curl wget
 
 USERNAME=vagrant
 useradd -u $USE_UID -o -ms /bin/bash $USERNAME
-groupmod -g $USE_GID $USERNAME
+groupmod -o -g $USE_GID $USERNAME
 usermod -aG sudo $USERNAME && echo "$USERNAME ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/$USERNAME
 chmod 0440 /etc/sudoers.d/$USERNAME
 

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -80,7 +80,7 @@ else
     # directive, it will be copied into the volume.
     VOLMOUNTS=()
     if volume_exists; then
-      VOLMOUNTS+=( --mount source=${VOLUME_NAME},target=/home/vagrant )
+      VOLMOUNTS+=( --mount type=volume,source=${VOLUME_NAME},target=/home/vagrant )
     fi
 
     # flags:

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This command tries to start up your searchfox docker container, creating it
 # from the image created in `build.docker.sh` if it doesn't already exist, and
@@ -40,7 +40,7 @@ OUTSIDE_CONTAINER_PORT=16995
 # which is served at this port inside the container
 INSIDE_CONTAINER_PORT=80
 
-SHELL=/usr/bin/bash
+SHELL=bash
 
 container_exists() {
     docker container inspect ${CONTAINER_NAME} &> /dev/null
@@ -73,7 +73,7 @@ else
     LINKMOUNTS=()
     while read -r link; do
       LINKMOUNTS+=( --mount type=bind,source=$(readlink -f ${link}),target=/vagrant/${link} )
-    done < <(/usr/bin/find trees -type l)
+    done < <(find trees -type l)
 
     # Mount the home directory volume if it exists.  The docker docs say that
     # if there is anything already at that location prior to us passing this

--- a/scripts/indexer-logs-analyze.sh
+++ b/scripts/indexer-logs-analyze.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 SCRIPT_DIR=$(dirname $0)
 

--- a/scripts/indexer-logs-fetch.sh
+++ b/scripts/indexer-logs-fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # AFAICT in order to download a specific set of files, we need to use recursive
 # and exclude everything and then only include what we want.  The following

--- a/scripts/tc-coverage-timestamps.sh
+++ b/scripts/tc-coverage-timestamps.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This is a script to determine when mozilla-central code coverage artifacts
 # were uploaded.

--- a/scripts/weblog-analyze.sh
+++ b/scripts/weblog-analyze.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Arguments: <log path>
 

--- a/scripts/weblog-elb-analyze.sh
+++ b/scripts/weblog-elb-analyze.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Arguments: <log path>
 

--- a/scripts/weblog-elb-fetch.sh
+++ b/scripts/weblog-elb-fetch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Helper to download one of the following date ranges' worth of logs to the
 # current directory, as given by the argument to give to this script:


### PR DESCRIPTION
As requested by @asutherland in https://bugzilla.mozilla.org/show_bug.cgi?id=1490144#c7 I'm sharing here my Podman/Nix-based setup:

> For your stack, it's great that you're adding podman and nix support! For nix, I'm not really familiar with nix, although I understand it's popular and something I should be more familiar with! It would be great to split those out into their own pull request(s), and in particular since I'm not familiar with nix, it would be great if you could make sure to[1]:
> 
> - Provide brief context about what the .envrc file is in the commit message. (In particular, since it's a fairly generic dotfile name, it'd be good for the history for the file to help provide that context.)
> - Add some additional context to the docs about what nix is and when people would want to use it. It might make sense to split this out into a separate markdown file under docs/ with a pointer. Specifically, I think a lot of existing Firefox contributors may be in a similar situation as me where we could benefit from some pointers about nix and how using it might be useful with searchfox and whether one can usefully use it on Ubuntu/Fedora/etc. or whether one would really only want to use it if switching to nix OS.

I didn't add too much to the docs about Nix, only notes in the places where it is useful. If I were duplicating the Docker provisioning logic into Nix then more would be needed, but at the moment it's just a convenient way (for me at least) to install podman, awscli2, boto3 and rich. The commit message has more details.
For a pointer, I think [zero-to-nix.com](https://zero-to-nix.com) is great to start with.
You can enjoy most of the features of Nix without using NixOS. I'd even recommend using Nix on another distro to begin with: it's better to be a bit familiar with the tool before having the world depend on it.

[Direnv](https://direnv.net/) is a per-directory development environment manager.
Basically using Nix and Direnv together enables this:
```
➜  Mozilla > aws
aws: command not found

➜  Mozilla > cd mozsearch
direnv: loading ~/Mozilla/mozsearch/.envrc
direnv: using flake
direnv: nix-direnv: using cached dev shell
TL;DR:
- './build-docker.sh' to build the container
- './run-docker.sh' to enter the container
- 'cd /vagrant; make build-test-repo' inside to build
- open http://localhost:16995 in a browser
direnv: export […] +AWS_PROFILE […] ~PATH […]

➜  Mozilla/mozsearch > aws

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

aws: error: the following arguments are required: command

➜  Mozilla/mozsearch > cd ..
direnv: unloading

➜  Mozilla > aws  
aws: command not found
```