### PR TITLE
Bug 1621788 - Add "Remove the Permalink" button for the latest revision.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -649,7 +649,8 @@ tr.after-context-line + tr.before-context-line {
   border: unset;
   text-align: unset;
 }
-.panel section .item:disabled {
+.panel section .item:disabled,
+.panel section .item.disabled {
   opacity: 0.5;
   cursor: not-allowed;
 }

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -12,6 +12,7 @@ var Panel = new (class Panel {
     this.accelEnabledCheckbox = document.getElementById("panel-accel-enable");
 
     this.permalinkNode = this.findItem("Permalink");
+    this.unpermalinkNode = this.findItem("Remove the Permalink");
     this.logNode = this.findItem("Log");
     this.rawNode = this.findItem("Raw");
 
@@ -76,6 +77,20 @@ var Panel = new (class Panel {
       });
     }
 
+    const updateUnpermalink = () => {
+      if (/^\/[^\/]+\/rev\//.test(document.location.pathname)) {
+        if (this.unpermalinkNode) {
+           this.unpermalinkNode.classList.remove("disabled");
+        }
+      } else {
+        if (this.unpermalinkNode) {
+           this.unpermalinkNode.classList.add("disabled");
+        }
+      }
+    };
+
+    updateUnpermalink();
+
     if (this.permalinkNode) {
       this.permalinkNode.addEventListener("click", event => {
         if (
@@ -93,6 +108,30 @@ var Panel = new (class Panel {
           event.target.href
         );
         event.preventDefault();
+
+        updateUnpermalink();
+      });
+    }
+
+    if (this.unpermalinkNode) {
+      this.unpermalinkNode.addEventListener("click", event => {
+        if (
+          event.defaultPrevented ||
+          event.altKey ||
+          event.ctrlKey ||
+          event.metaKey ||
+          event.shiftKey
+        ) {
+          return;
+        }
+        window.history.pushState(
+          {},
+          window.title,
+          event.target.href
+        );
+        event.preventDefault();
+
+        updateUnpermalink();
       });
     }
 

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -317,6 +317,13 @@ fn main() {
                     accel_key: Some('Y'),
                     copyable: true,
                 });
+                vcs_panel_items.push(PanelItem {
+                    title: "Remove the Permalink".to_owned(),
+                    link: format!("/{}/source/{}", tree_name, path),
+                    update_link_lineno: "#{}",
+                    accel_key: None,
+                    copyable: false,
+                });
                 if let Some(ref hg_root) = tree_config.paths.hg_root {
                     vcs_panel_items.push(PanelItem {
                         title: "Log".to_owned(),


### PR DESCRIPTION
This changes:
  * Add "Remove the Permalink" link to the Navigation box for the latest revision
    * This is a link to the same thing as "Go to latest version" in older revision
    * This is disabled when the URL is not permalink
    * This is enabled when the URL is permalink
    * The enabled/disabled status is dynamically updated when clicking "Permalink" and "Remove the Permalink"

(left: navigation box for non-permalink, right: navigation box for permalink)
<img width="403" alt="remove-permalink" src="https://github.com/mozsearch/mozsearch/assets/6299746/9876d02d-0695-4f9b-a8df-57e2f3e624ff">

The "Permalink" item isn't disabled, because it has "copy" button, and I think the button should be available regardless of the current URL.