### PR TITLE
Bug 1818027 - Handle spread inside object in JS.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1150,6 +1150,11 @@ let Analyzer = {
     case "ObjectExpression":
     case "ObjectPattern":
       for (let prop of expr.properties) {
+        if (prop.type === "SpreadExpression") {
+          this.expression(prop.expression);
+          continue;
+        }
+
         let name;
 
         if (prop.key) {


### PR DESCRIPTION
Added dedicate path for `SpreadExpression` inside `ObjectExpression` and `ObjectPattern`, to handle `({...foo})` syntax in JS