### PR TITLE
Bug 1553666 - Use load() function to load sax.js

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1930,6 +1930,6 @@ fileIndex = scriptArgs[0];
 mozSearchRoot = scriptArgs[1];
 localFile = scriptArgs[2];
 
-run(mozSearchRoot + "/sax/sax.js");
+load(mozSearchRoot + "/sax/sax.js");
 
 analyzeFile(localFile);


### PR DESCRIPTION
with `load`, the backtrace becomes the following:
```
/PATH/TO/mozsearch/sax/sax.js:6:1 uncaught exception: 1
Stack:
  @/PATH/TO/mozsearch/sax/sax.js:6:1
  @/PATH/TO/mozsearch/sax/sax.js:1581:3
  @scripts/js-analyze.js:1933:5
```