### PR TITLE
Fixes to SCIP ingestion: multiple inheritance & ignoring declaration order when parsing relationships

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1064,7 +1064,6 @@ public:
 
         J.objectBegin();
 
-        J.attribute("pretty", getQualifiedName(BaseDecl));
         J.attribute("sym", getMangledName(CurMangleContext, BaseDecl));
 
         J.attributeBegin("props");
@@ -1219,7 +1218,6 @@ public:
         // I think our pre-emptive dereferencing/avoidance of templates may
         // protect us from this, but it needs more investigation.
 
-        J.attribute("pretty", getQualifiedName(MethodDecl));
         J.attribute("sym", getMangledName(CurMangleContext, MethodDecl));
 
         J.objectEnd();

--- a/docs/analysis.md
+++ b/docs/analysis.md
@@ -300,7 +300,6 @@ Raw record info.  These are attributes that will be found in the analysis files.
   - `slotLang`: See `BindingSlotLang`
   - `sym`
 - `supers`: For class-like symbols, an array of:
-  - `pretty`: The pretty name/identifier for this super.
   - `sym`: The searchfox symbol for this super.
   - `props`: An array of strings whose presence indicates a semantic attribute:
     - `virtual`: It's a virtual base class if present.
@@ -328,7 +327,6 @@ Raw record info.  These are attributes that will be found in the analysis files.
     - `width`
   - `sizeBytes`: Only present in non-bit-fields.  The size of the fieldin bytes.
 - `overrides`: For methods, an array of method signatures that are overridden.
-  - `pretty`: The pretty name/identifier for the referenced method.
   - `sym`: The searchfox symbol for the referenced method.
 - `props`: For methods, an array of strings whose presence indicates a semantic
   attribute.  These are the same as the props under a class-like symbol's

--- a/scripts/idl-analyze.py
+++ b/scripts/idl-analyze.py
@@ -236,7 +236,6 @@ def handle_interface(methods, enums, iface):
         base_loc = '%d:%d-%d' % (lineno, colno, colno + len(iface.base))
 
         iface_supers.append({
-            'pretty': iface.base,
             'sym': base_idl_sym,
         })
 

--- a/tests/tests/checks/inputs/crossref/java/JavaLibrary.java/multiple_implements__json
+++ b/tests/tests/checks/inputs/crossref/java/JavaLibrary.java/multiple_implements__json
@@ -1,0 +1,1 @@
+search-identifiers sample::JavaLibrary::C | crossref-lookup

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_human__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_human__json.snap
@@ -12,7 +12,6 @@ expression: "&json_results"
     "sizeBytes": 16,
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
@@ -12,7 +12,6 @@ expression: "&json_results"
     "sizeBytes": 16,
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_practicalart_beart__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_practicalart_beart__json.snap
@@ -12,7 +12,6 @@ expression: "&json_results"
     "parentsym": "T_outerNS::PracticalArt",
     "overrides": [
       {
-        "pretty": "outerNS::AbstractArt::beArt",
         "sym": "_ZN7outerNS11AbstractArt5beArtEv"
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero__json.snap
@@ -12,7 +12,6 @@ expression: "&json_results"
     "sizeBytes": 16,
     "supers": [
       {
-        "pretty": "outerNS::Human",
         "sym": "T_outerNS::Human",
         "props": []
       }

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero_takedamage__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero_takedamage__json.snap
@@ -12,7 +12,6 @@ expression: "&json_results"
     "parentsym": "T_outerNS::Superhero",
     "overrides": [
       {
-        "pretty": "outerNS::Thing::takeDamage",
         "sym": "_ZN7outerNS5Thing10takeDamageEi"
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
@@ -18,7 +18,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "sample::Interface::someFunction",
         "sym": "S_java_gradle_sample/Interface#someFunction()."
       }
     ],
@@ -39,7 +38,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "sample::Interface::someFunction",
         "sym": "S_java_gradle_sample/Interface#someFunction()."
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
@@ -18,7 +18,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "sample::Interface::someOtherFunction",
         "sym": "S_java_gradle_sample/Interface#someOtherFunction()."
       }
     ],
@@ -39,7 +38,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "sample::Interface::someOtherFunction",
         "sym": "S_java_gradle_sample/Interface#someOtherFunction()."
       }
     ],

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -54,7 +54,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::Thing",
               "sym": "T_outerNS::Thing",
               "props": []
             }
@@ -545,7 +544,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::Thing",
               "sym": "T_outerNS::Thing",
               "props": []
             }
@@ -677,7 +675,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::Thing",
               "sym": "T_outerNS::Thing",
               "props": []
             }
@@ -798,7 +795,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::Thing",
               "sym": "T_outerNS::Thing",
               "props": []
             }
@@ -949,7 +945,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::Human",
               "sym": "T_outerNS::Human",
               "props": []
             }
@@ -1069,7 +1064,6 @@ expression: "&to_value(scil).unwrap()"
           "bindingSlots": [],
           "supers": [
             {
-              "pretty": "outerNS::AbstractArt",
               "sym": "T_outerNS::AbstractArt",
               "props": []
             }

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
@@ -1,0 +1,66 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(scil).unwrap()"
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_java_gradle_sample/JavaLibrary#C#",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "src/main/java/sample/JavaLibrary.java",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 16,
+                "bounds": [
+                  12,
+                  13
+                ],
+                "line": "final class C implements I0, I1 {}",
+                "context": "sample::JavaLibrary::<init>",
+                "contextsym": "S_java_gradle_sample/JavaLibrary#<init>()."
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "sample::JavaLibrary::C",
+          "sym": "S_java_gradle_sample/JavaLibrary#C#",
+          "type_pretty": null,
+          "kind": "class",
+          "parentsym": "S_java_gradle_sample/JavaLibrary#",
+          "implKind": "impl",
+          "sizeBytes": null,
+          "bindingSlots": [],
+          "supers": [
+            {
+              "sym": "S_java_gradle_sample/JavaLibrary#I0#",
+              "props": []
+            },
+            {
+              "sym": "S_java_gradle_sample/JavaLibrary#I1#",
+              "props": []
+            }
+          ],
+          "methods": [
+            {
+              "pretty": "sample::JavaLibrary::C::<init>",
+              "sym": "S_java_gradle_sample/JavaLibrary#C#<init>().",
+              "props": []
+            }
+          ],
+          "fields": [],
+          "overrides": [],
+          "props": []
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
@@ -57,7 +57,10 @@ expression: "&to_value(scil).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "subclasses": [
+            "S_java_gradle_sample/JavaLibrary#B#"
+          ]
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -2578,7 +2578,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }
@@ -2660,7 +2659,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }
@@ -2715,7 +2713,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }
@@ -2788,7 +2785,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::Thing",
         "sym": "T_outerNS::Thing",
         "props": []
       }
@@ -2918,7 +2914,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::AbstractArt",
         "sym": "T_outerNS::AbstractArt",
         "props": []
       }
@@ -2982,7 +2977,6 @@ expression: "&json_results"
     "bindingSlots": [],
     "supers": [
       {
-        "pretty": "outerNS::Human",
         "sym": "T_outerNS::Human",
         "props": []
       }
@@ -3380,7 +3374,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "outerNS::AbstractArt::beArt",
         "sym": "_ZN7outerNS11AbstractArt5beArtEv"
       }
     ],
@@ -3687,7 +3680,6 @@ expression: "&json_results"
     "fields": [],
     "overrides": [
       {
-        "pretty": "outerNS::Thing::takeDamage",
         "sym": "_ZN7outerNS5Thing10takeDamageEi"
       }
     ],

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
@@ -110,7 +110,6 @@ expression: sgc.to_json()
         "bindingSlots": [],
         "supers": [
           {
-            "pretty": "outerNS::Thing",
             "sym": "T_outerNS::Thing",
             "props": []
           }
@@ -171,7 +170,6 @@ expression: sgc.to_json()
         "bindingSlots": [],
         "supers": [
           {
-            "pretty": "outerNS::Thing",
             "sym": "T_outerNS::Thing",
             "props": []
           }

--- a/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@practicalart__beart__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@practicalart__beart__lookup__json.snap
@@ -23,7 +23,6 @@ expression: "&to_value(jvl).unwrap()"
           "fields": [],
           "overrides": [
             {
-              "pretty": "outerNS::AbstractArt::beArt",
               "sym": "_ZN7outerNS11AbstractArt5beArtEv"
             }
           ],

--- a/tests/tests/files/src/main/java/sample/JavaLibrary.java
+++ b/tests/tests/files/src/main/java/sample/JavaLibrary.java
@@ -10,4 +10,8 @@ public class JavaLibrary {
 
     interface B extends A {}
     interface A {}
+
+    interface I0 {}
+    interface I1 {}
+    final class C implements I0, I1 {}
 }

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -851,9 +851,9 @@ fn analyze_using_scip(
                 let mut overrides = vec![];
 
                 // SCIP provides the full transitive closure of relationships,
-                // but our current model favors only having the immediate links,
-                // so only process the first element.
-                if let Some(rel) = scip_sym_info.relationships.first() {
+                // but our current model favors only having the immediate links.
+                // TODO: filter out indirect ancestors
+                for rel in &scip_sym_info.relationships {
                     let parent_symbol_info = analyse_symbol(
                         &scip::symbol::parse_symbol(&rel.symbol).unwrap(),
                         &lang,

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -863,14 +863,12 @@ fn analyze_using_scip(
                         match symbol_info.kind {
                             Some("class") => {
                                 supers.push(StructuredSuperInfo {
-                                    pretty: rel_sinfo.pretty.clone(),
                                     sym: rel_sinfo.sym.clone(),
                                     props: vec![],
                                 });
                             }
                             Some("method") => {
                                 overrides.push(StructuredOverrideInfo {
-                                    pretty: rel_sinfo.pretty.clone(),
                                     sym: rel_sinfo.sym.clone(),
                                 });
                             }

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -162,8 +162,6 @@ pub enum StructuredTag {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredSuperInfo {
     #[serde(default)]
-    pub pretty: Ustr,
-    #[serde(default)]
     pub sym: Ustr,
     #[serde(default)]
     pub props: Vec<Ustr>,
@@ -187,8 +185,6 @@ pub struct StructuredBitPositionInfo {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredOverrideInfo {
-    #[serde(default)]
-    pub pretty: Ustr,
     #[serde(default)]
     pub sym: Ustr,
 }


### PR DESCRIPTION
Extra fixes to the SCIP ingestion as discussed in /pull/667.