### PR TITLE
Workaround multiple_implements flakiness

### DIFF
--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -885,6 +885,10 @@ fn analyze_using_scip(
                     }
                 }
 
+                // Ensure that supers and overrides are sorted to avoid flaky tests
+                supers.sort_unstable_by_key(|r| r.sym);
+                overrides.sort_unstable_by_key(|r| r.sym);
+
                 let structured = AnalysisStructured {
                     structured: StructuredTag::Structured,
                     pretty: symbol_info.pretty,


### PR DESCRIPTION
The order in which relationships are ordered in the java.scip index can change between scip-java runs, resulting in the check crossref/java/ JavaLibrary.java/multiple_implements__json check being flaky.

Sorting those relationships ourselves resolves this flakiness at the cost of a (minor, as long as the lists remain small) runtime cost.