### PR TITLE
Update to clang 17

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -51,9 +51,10 @@
             pkg-config
 
             # Dependencies required to build clang-plugin
+            # Update to llvmPackages_17 when available
             clang
-            llvmPackages_14.libllvm
-            llvmPackages_14.libclang
+            llvmPackages_16.libllvm
+            llvmPackages_16.libclang
 
             scip
             protobuf

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -12,12 +12,12 @@ set -o pipefail # Check all commands in a pipeline
 # Note that for the most recent LLVM/clang release (ex: right now v13), you
 # would actually want to leave this empty.  Check out https://apt.llvm.org/ for
 # the latest info in all cases.
-CLANG_SUFFIX=-14
+CLANG_SUFFIX=-17
 # Bumping the priority with each version upgrade lets running the provisioning
 # script on an already provisioned machine do the right thing alternative-wise.
 # Actually, we no longer support re-provisioning, but it's fun to increment
 # numbers.
-CLANG_PRIORITY=412
+CLANG_PRIORITY=413
 # The clang packages build the Ubuntu release name in; let's dynamically extract
 # it since I, asuth, once forgot to update this.
 UBUNTU_RELEASE=$(lsb_release -cs)

--- a/tests/tests/checks/snapshots/analysis/cpp/template_shapes.cpp/check_glob@Foo_Project-2.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/template_shapes.cpp/check_glob@Foo_Project-2.snap
@@ -7,7 +7,7 @@ expression: "&json_results"
     "loc": "00022:7-11",
     "source": 1,
     "syntax": "decl,function",
-    "type": "void (class Rectangle)",
+    "type": "void (Rectangle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE9Rectangle"
   },
@@ -25,7 +25,7 @@ expression: "&json_results"
     "loc": "00023:7-11",
     "source": 1,
     "syntax": "decl,function",
-    "type": "void (class Triangle)",
+    "type": "void (Triangle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE8Triangle"
   },
@@ -43,7 +43,7 @@ expression: "&json_results"
     "loc": "00024:7-11",
     "source": 1,
     "syntax": "decl,function",
-    "type": "void (class Circle)",
+    "type": "void (Circle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE6Circle"
   },
@@ -61,7 +61,7 @@ expression: "&json_results"
     "loc": "00029:4-8",
     "source": 1,
     "syntax": "use,function",
-    "type": "void (class Circle)",
+    "type": "void (Circle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE6Circle"
   },
@@ -69,7 +69,7 @@ expression: "&json_results"
     "loc": "00029:4-8",
     "source": 1,
     "syntax": "use,function",
-    "type": "void (class Rectangle)",
+    "type": "void (Rectangle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE9Rectangle"
   },
@@ -77,7 +77,7 @@ expression: "&json_results"
     "loc": "00029:4-8",
     "source": 1,
     "syntax": "use,function",
-    "type": "void (class Triangle)",
+    "type": "void (Triangle)",
     "pretty": "function DrawingContext::draw",
     "sym": "_ZN14DrawingContext4drawE8Triangle"
   },

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
@@ -4,15 +4,15 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "11:13-24",
+    "loc": "11:14-25",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property ModuleClass",
     "sym": "#ModuleClass",
-    "nestingRange": "11:25-18:0"
+    "nestingRange": "11:25-18:1"
   },
   {
-    "loc": "11:13-24",
+    "loc": "11:14-25",
     "target": 1,
     "kind": "def",
     "pretty": "ModuleClass",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass_error__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass_error__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "13:4-10",
+    "loc": "13:5-11",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property ModuleClass.#error",
     "sym": "ModuleClass##error"
   },
   {
-    "loc": "13:4-10",
+    "loc": "13:5-11",
     "target": 1,
     "kind": "def",
     "pretty": "ModuleClass.#error",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "5:13-24",
+    "loc": "5:14-25",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property moduleConst",
     "sym": "#moduleConst"
   },
   {
-    "loc": "5:13-24",
+    "loc": "5:14-25",
     "target": 1,
     "kind": "def",
     "pretty": "moduleConst",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
@@ -4,15 +4,15 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "7:16-26",
+    "loc": "7:17-27",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property moduleFunc",
     "sym": "#moduleFunc",
-    "nestingRange": "7:43-9:0"
+    "nestingRange": "7:44-9:1"
   },
   {
-    "loc": "7:16-26",
+    "loc": "7:17-27",
     "target": 1,
     "kind": "def",
     "pretty": "moduleFunc",

--- a/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "12:6-21",
+    "loc": "12:7-22",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property rootModuleConst",
     "sym": "#rootModuleConst"
   },
   {
-    "loc": "12:6-21",
+    "loc": "12:7-22",
     "target": 1,
     "kind": "def",
     "pretty": "rootModuleConst",

--- a/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "8:6-25",
+    "loc": "8:7-26",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property secretMadjewelConst",
     "sym": "#secretMadjewelConst"
   },
   {
-    "loc": "8:6-25",
+    "loc": "8:7-26",
     "target": 1,
     "kind": "def",
     "pretty": "secretMadjewelConst",

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
@@ -6,14 +6,14 @@ expression: "&aggr_str"
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="33"></div>
-  <code role="cell" class="source-line">  <span class="syn_def syn_def" data-symbols="##priv_field_num,ClassWithProperties##priv_field_num">#priv_field_num</span> = 10;
+  <code role="cell" class="source-line">  #priv_field_num = 10;
 </code>
 </div>
 <div role="row" id="line-76" class="source-line-with-number">
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="76"></div>
-  <code role="cell" class="source-line">    <span class="syn_reserved" >return</span> <span class="syn_reserved" >this</span>.<span data-symbols="##priv_field_num">#priv_field_num</span>;
+  <code role="cell" class="source-line">    <span class="syn_reserved" >return</span> <span class="syn_reserved" >this</span>.#priv_field_num;
 </code>
 </div>
 

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "33:2-17",
+    "loc": "33:3-18",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property #priv_field_num",
     "sym": "##priv_field_num"
   },
   {
-    "loc": "33:2-17",
+    "loc": "33:3-18",
     "target": 1,
     "kind": "def",
     "pretty": "#priv_field_num",
@@ -19,14 +19,14 @@ expression: "&json_results"
     "context": "ClassWithProperties"
   },
   {
-    "loc": "76:16-31",
+    "loc": "76:17-32",
     "source": 1,
     "syntax": "use,prop",
     "pretty": "property #priv_field_num",
     "sym": "##priv_field_num"
   },
   {
-    "loc": "76:16-31",
+    "loc": "76:17-32",
     "target": 1,
     "kind": "use",
     "pretty": "#priv_field_num",

--- a/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__json.snap
+++ b/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__json.snap
@@ -18,7 +18,7 @@ expression: "&json_results"
     "kind": "def",
     "pretty": "simple::Loader::new",
     "sym": "S_rs_rust_Loader#new().",
-    "context": "simple::Loader",
+    "context": "Loader",
     "contextsym": "S_rs_rust_Loader#"
   }
 ]

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -1631,7 +1631,7 @@ expression: "&json_results"
     "pretty": "variable superBob",
     "sym": "V_c90cdf45607c3527_74bc848dc87ea1",
     "no_crossref": 1,
-    "type": "class outerNS::Superhero",
+    "type": "Superhero",
     "typesym": "T_outerNS::Superhero"
   },
   {
@@ -1664,7 +1664,7 @@ expression: "&json_results"
     "pretty": "variable victor",
     "sym": "V_c3d4ef45607c3527_c9114c22356",
     "no_crossref": 1,
-    "type": "WhatsYourVector<class outerNS::Superhero>",
+    "type": "WhatsYourVector<Superhero>",
     "typesym": "T_WhatsYourVector"
   },
   {
@@ -1674,7 +1674,7 @@ expression: "&json_results"
     "pretty": "variable superBob",
     "sym": "V_c90cdf45607c3527_74bc848dc87ea1",
     "no_crossref": 1,
-    "type": "class outerNS::Superhero",
+    "type": "Superhero",
     "typesym": "T_outerNS::Superhero"
   },
   {
@@ -1700,7 +1700,7 @@ expression: "&json_results"
     "pretty": "variable bob",
     "sym": "V_bb56ff45607c3527_872688b",
     "no_crossref": 1,
-    "type": "class outerNS::Human",
+    "type": "Human",
     "typesym": "T_outerNS::Human"
   },
   {
@@ -1733,7 +1733,7 @@ expression: "&json_results"
     "pretty": "variable goodReferenceRight",
     "sym": "V_442fff45607c3527_bbca21f4b95005a5",
     "no_crossref": 1,
-    "type": "WhatsYourVector<class outerNS::Human>",
+    "type": "WhatsYourVector<Human>",
     "typesym": "T_WhatsYourVector"
   },
   {
@@ -1743,7 +1743,7 @@ expression: "&json_results"
     "pretty": "variable bob",
     "sym": "V_bb56ff45607c3527_872688b",
     "no_crossref": 1,
-    "type": "class outerNS::Human",
+    "type": "Human",
     "typesym": "T_outerNS::Human"
   },
   {
@@ -1753,7 +1753,7 @@ expression: "&json_results"
     "pretty": "variable victor",
     "sym": "V_c3d4ef45607c3527_c9114c22356",
     "no_crossref": 1,
-    "type": "WhatsYourVector<class outerNS::Superhero>",
+    "type": "WhatsYourVector<Superhero>",
     "typesym": "T_WhatsYourVector"
   },
   {
@@ -1762,7 +1762,7 @@ expression: "&json_results"
     "syntax": "function,use",
     "pretty": "function WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
     "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
-    "type": "WhatsYourVector_impl<class outerNS::Superhero, class CoolAlloc>::elem_type"
+    "type": "elem_type"
   },
   {
     "loc": "00217:4-22",
@@ -1771,7 +1771,7 @@ expression: "&json_results"
     "pretty": "variable goodReferenceRight",
     "sym": "V_442fff45607c3527_bbca21f4b95005a5",
     "no_crossref": 1,
-    "type": "WhatsYourVector<class outerNS::Human>",
+    "type": "WhatsYourVector<Human>",
     "typesym": "T_WhatsYourVector"
   },
   {
@@ -1780,7 +1780,7 @@ expression: "&json_results"
     "syntax": "function,use",
     "pretty": "function WhatsYourVector_impl::forwardDeclaredTemplateThingInlinedBelow",
     "sym": "_ZN20WhatsYourVector_impl40forwardDeclaredTemplateThingInlinedBelowEPKTL0__",
-    "type": "WhatsYourVector_impl<class outerNS::Human, class CoolAlloc>::elem_type"
+    "type": "elem_type"
   },
   {
     "loc": "00221:6-14",
@@ -1965,7 +1965,7 @@ expression: "&json_results"
     "pretty": "function outerNS::OuterCat::meet",
     "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
     "nestingRange": "340:26-342:2",
-    "type": "void (class outerNS::Human &)"
+    "type": "void (Human &)"
   },
   {
     "loc": "00340:12-17",
@@ -1983,7 +1983,7 @@ expression: "&json_results"
     "pretty": "variable human",
     "sym": "V_5c239875607c3527_e79fa9f013",
     "no_crossref": 1,
-    "type": "class outerNS::Human &"
+    "type": "Human &"
   },
   {
     "loc": "00341:4-9",
@@ -1992,7 +1992,7 @@ expression: "&json_results"
     "pretty": "variable human",
     "sym": "V_5c239875607c3527_e79fa9f013",
     "no_crossref": 1,
-    "type": "class outerNS::Human &"
+    "type": "Human &"
   },
   {
     "loc": "00341:10-16",
@@ -2009,7 +2009,7 @@ expression: "&json_results"
     "pretty": "function outerNS::OuterCat::meet",
     "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
     "nestingRange": "351:26-385:2",
-    "type": "void (class outerNS::Couch &)"
+    "type": "void (Couch &)"
   },
   {
     "loc": "00351:12-17",
@@ -2027,7 +2027,7 @@ expression: "&json_results"
     "pretty": "variable couch",
     "sym": "V_7a7db975607c3527_7f65d3f013",
     "no_crossref": 1,
-    "type": "class outerNS::Couch &"
+    "type": "Couch &"
   },
   {
     "loc": "00352:4-9",
@@ -2044,7 +2044,7 @@ expression: "&json_results"
     "pretty": "variable couch",
     "sym": "V_7a7db975607c3527_7f65d3f013",
     "no_crossref": 1,
-    "type": "class outerNS::Couch &"
+    "type": "Couch &"
   },
   {
     "loc": "00354:9-22",
@@ -2069,7 +2069,7 @@ expression: "&json_results"
     "pretty": "variable couch",
     "sym": "V_7a7db975607c3527_7f65d3f013",
     "no_crossref": 1,
-    "type": "class outerNS::Couch &"
+    "type": "Couch &"
   },
   {
     "loc": "00363:15-46",
@@ -2094,7 +2094,7 @@ expression: "&json_results"
     "pretty": "variable couch",
     "sym": "V_7a7db975607c3527_7f65d3f013",
     "no_crossref": 1,
-    "type": "class outerNS::Couch &"
+    "type": "Couch &"
   },
   {
     "loc": "00390:7-12",
@@ -2103,7 +2103,7 @@ expression: "&json_results"
     "pretty": "function outerNS::OuterCat::shred",
     "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
     "nestingRange": "390:27-392:2",
-    "type": "void (class outerNS::Thing &)"
+    "type": "void (Thing &)"
   },
   {
     "loc": "00390:13-18",
@@ -2121,7 +2121,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_26da3e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00391:4-9",
@@ -2130,7 +2130,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_26da3e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00391:10-20",
@@ -2147,7 +2147,7 @@ expression: "&json_results"
     "pretty": "function outerNS::OuterCat::destroy",
     "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
     "nestingRange": "397:29-412:2",
-    "type": "void (class outerNS::Thing &)"
+    "type": "void (Thing &)"
   },
   {
     "loc": "00397:15-20",
@@ -2165,7 +2165,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00399:4-9",
@@ -2182,7 +2182,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00402:4-9",
@@ -2199,7 +2199,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00405:4-9",
@@ -2216,7 +2216,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00408:4-9",
@@ -2233,7 +2233,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00411:4-9",
@@ -2250,7 +2250,7 @@ expression: "&json_results"
     "pretty": "variable thing",
     "sym": "V_b0487e75607c3527_f3fec60113",
     "no_crossref": 1,
-    "type": "class outerNS::Thing &"
+    "type": "Thing &"
   },
   {
     "loc": "00415:8-14",


### PR DESCRIPTION
Attempt at fixing the wubkat index, and making the clang version we use closer to the one the Firefox build uses.
nixpkgs doesn't have llvmPackages_17 yet, so updating to 16 there for the time being.