### PR TITLE
Bug 1868235 - Adapt to SpiderMonkey's new 1-based columns.

### DIFF
--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass__json.snap
@@ -4,15 +4,15 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "11:14-25",
+    "loc": "11:13-24",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property ModuleClass",
     "sym": "#ModuleClass",
-    "nestingRange": "11:25-18:1"
+    "nestingRange": "11:24-18:0"
   },
   {
-    "loc": "11:14-25",
+    "loc": "11:13-24",
     "target": 1,
     "kind": "def",
     "pretty": "ModuleClass",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass_error__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_ModuleClass_error__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "13:5-11",
+    "loc": "13:4-10",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property ModuleClass.#error",
     "sym": "ModuleClass##error"
   },
   {
-    "loc": "13:5-11",
+    "loc": "13:4-10",
     "target": 1,
     "kind": "def",
     "pretty": "ModuleClass.#error",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "5:14-25",
+    "loc": "5:13-24",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property moduleConst",
     "sym": "#moduleConst"
   },
   {
-    "loc": "5:14-25",
+    "loc": "5:13-24",
     "target": 1,
     "kind": "def",
     "pretty": "moduleConst",

--- a/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/imported-module.mjs/check_glob@def_moduleFunc__json.snap
@@ -4,15 +4,15 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "7:17-27",
+    "loc": "7:16-26",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property moduleFunc",
     "sym": "#moduleFunc",
-    "nestingRange": "7:44-9:1"
+    "nestingRange": "7:43-9:0"
   },
   {
-    "loc": "7:17-27",
+    "loc": "7:16-26",
     "target": 1,
     "kind": "def",
     "pretty": "moduleFunc",

--- a/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/root-module.mjs/check_glob@def_rootModuleConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "12:7-22",
+    "loc": "12:6-21",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property rootModuleConst",
     "sym": "#rootModuleConst"
   },
   {
-    "loc": "12:7-22",
+    "loc": "12:6-21",
     "target": 1,
     "kind": "def",
     "pretty": "rootModuleConst",

--- a/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/secret-madjewel.js/check_glob@def_secretMadjewelConst__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "8:7-26",
+    "loc": "8:6-25",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property secretMadjewelConst",
     "sym": "#secretMadjewelConst"
   },
   {
-    "loc": "8:7-26",
+    "loc": "8:6-25",
     "target": 1,
     "kind": "def",
     "pretty": "secretMadjewelConst",

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__html.snap
@@ -6,14 +6,14 @@ expression: "&aggr_str"
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="33"></div>
-  <code role="cell" class="source-line">  #priv_field_num = 10;
+  <code role="cell" class="source-line">  <span class="syn_def syn_def" data-symbols="##priv_field_num,ClassWithProperties##priv_field_num">#priv_field_num</span> = 10;
 </code>
 </div>
 <div role="row" id="line-76" class="source-line-with-number">
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="76"></div>
-  <code role="cell" class="source-line">    <span class="syn_reserved" >return</span> <span class="syn_reserved" >this</span>.#priv_field_num;
+  <code role="cell" class="source-line">    <span class="syn_reserved" >return</span> <span class="syn_reserved" >this</span>.<span data-symbols="##priv_field_num">#priv_field_num</span>;
 </code>
 </div>
 

--- a/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/some_javascript.js/check_glob@all__priv_field_num__json.snap
@@ -4,14 +4,14 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "33:3-18",
+    "loc": "33:2-17",
     "source": 1,
     "syntax": "def,prop",
     "pretty": "property #priv_field_num",
     "sym": "##priv_field_num"
   },
   {
-    "loc": "33:3-18",
+    "loc": "33:2-17",
     "target": 1,
     "kind": "def",
     "pretty": "#priv_field_num",
@@ -19,14 +19,14 @@ expression: "&json_results"
     "context": "ClassWithProperties"
   },
   {
-    "loc": "76:17-32",
+    "loc": "76:16-31",
     "source": 1,
     "syntax": "use,prop",
     "pretty": "property #priv_field_num",
     "sym": "##priv_field_num"
   },
   {
-    "loc": "76:17-32",
+    "loc": "76:16-31",
     "target": 1,
     "kind": "use",
     "pretty": "#priv_field_num",


### PR DESCRIPTION
The checks here are the inverse of the changes in
https://github.com/mozsearch/mozsearch/pull/677 as expected.

This also slips in a change to quiet this warning we're seeing in config1 emails:
```
WARN when parsing as 'module': Unable to parse JS file /mnt/index-scratch/comm-central/git/mozilla/testing/web-platform/tests/wasm/webapi/esm-integration/resources/worker-source-phase.js:1 because SyntaxError: missing keyword 'from' after import clause: /mnt/index-scratch/comm-central/git/mozilla/testing/web-platform/tests/wasm/webapi/esm-integration/resources/worker-source-phase.js:1
```