### PR TITLE
Made available as OpenSearch provider

### DIFF
--- a/static/mozsearch.xml
+++ b/static/mozsearch.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+  <OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+  <ShortName>SearchFox</ShortName>
+  <Description>SearchFox code search</Description>
+  <InputEncoding>UTF-8</InputEncoding>
+  <Image width="16" height="16" type="image/x-icon">https://searchfox.org/mozilla-central/static/icons/search.png</Image>
+  <Query role="example" searchTerms="BrandFullName" />
+  <Url type="text/html" template="https://searchfox.org/mozilla-central/search?q={searchTerms}&amp;path=&amp;case=false&amp;regexp=false"></Url>
+</OpenSearchDescription>

--- a/tools/templates/header_search.liquid
+++ b/tools/templates/header_search.liquid
@@ -14,6 +14,7 @@
   <link href="/{{tree}}/static/css/mozsearch.css" rel="stylesheet" media="screen"/>
   <link href="/{{tree}}/static/css/icons.css" rel="stylesheet" media="screen" />
   <link href="/{{tree}}/static/css/font-icons.css" rel="stylesheet" media="screen" />
+  <link href="/{{tree}}/static/searchfox.xml" rel="search" title="{{ title }}" type="application/opensearchdescription+xml"/>
 </head>
 
 <body>


### PR DESCRIPTION
This is supposed to add the possibility to add searchfox to the list of search providers within the browser. This is a suggestion and only tested off-tree right now. Please let me know if you like the idea of it so that I know if it makes sense to invest more time into it.

With this change the search box is supposed to look like this:
![searchbox](https://github.com/mozsearch/mozsearch/assets/13811871/f15eec8d-4c23-4638-ad20-e418cd575839)
