### PR TITLE
Remove duplicate ontology entry.

### DIFF
--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -555,9 +555,6 @@ kind = "contains"
 [types."WTF::RawPointer".pointer]
 kind = "raw"
 
-[types."WTF::RawPointer".pointer]
-kind = "raw"
-
 # RefPtr but no support for null
 [types."WTF::Ref".pointer]
 kind = "strong"


### PR DESCRIPTION
A smoke test on graphviz didn't find this, but after the last merge I did a check of the test repo and it caught the dupe.  Presumably the check process was necessary, although I'm a little surprised.