### PR TITLE
Teach indexer log analysis about scip, add "today" for ELB log analysis.

### DIFF
--- a/scripts/indexer-logs-analyze.sh
+++ b/scripts/indexer-logs-analyze.sh
@@ -7,7 +7,7 @@ PARSE_EXPR+=' as time, script, args'
 PARSE_EXPR+=' | parseDate(time) as time'
 PARSE_EXPR+=' | split(args) on " "'
 PARSE_EXPR+=' | if(script == "find-repo-files.py" or script == "build.sh" or script=="output.sh", args[2], "") as tree'
-PARSE_EXPR+=' | if(script == "js-analyze.sh" or script == "java-analyze.sh" or script == "idl-analyze.sh" or script == "ipdl-analyze.sh" or script == "crossref.sh" or script == "build-codesearch.py" or script == "check-index.sh" or script == "compress-outputs.sh" or script == "check-index.sh", args[1], tree) as tree'
+PARSE_EXPR+=' | if(script == "js-analyze.sh" or script == "java-analyze.sh" or script == "scip-analyze.sh" or script == "idl-analyze.sh" or script == "ipdl-analyze.sh" or script == "crossref.sh" or script == "build-codesearch.py" or script == "check-index.sh" or script == "compress-outputs.sh" or script == "check-index.sh", args[1], tree) as tree'
 
 # - Grep the log in Perl mode looking for the pattern where a "date" invocation
 #   is followed by a script invocation from mozsearch/scripts.

--- a/scripts/weblog-elb-fetch.sh
+++ b/scripts/weblog-elb-fetch.sh
@@ -17,7 +17,10 @@
 
 DATE_RANGE=${1:-yesterday}
 
-if [[ "$DATE_RANGE" == "yesterday" ]]; then
+if [[ "$DATE_RANGE" == "today" ]]; then
+  S3_DATE_URI=$(date -u --date='0 days ago' +s3://searchfox-web-logs/AWSLogs/653057761566/elasticloadbalancing/us-west-2/%Y/%m/%d/)
+  aws s3 cp ${S3_DATE_URI} . --recursive
+elif [[ "$DATE_RANGE" == "yesterday" ]]; then
   S3_DATE_URI=$(date -u --date='1 days ago' +s3://searchfox-web-logs/AWSLogs/653057761566/elasticloadbalancing/us-west-2/%Y/%m/%d/)
   aws s3 cp ${S3_DATE_URI} . --recursive
 elif [[ "$DATE_RANGE" == "last-week" ]]; then


### PR DESCRIPTION
I was worried about the config1 indexer time so I ran the logs and noticed it didn't understand scip-analyze, so I fixed that.

I also was wondering if anyone had done any novel python queries and taught the log fetcher human date constraint about "today".