### PR TITLE
Bug 1468445 - implement field-layout and related infrastructure

### DIFF
--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -47,7 +47,10 @@
 const SETTING_DEFS = {
   global: {
     defaultFeatureGate: {
-      default: "release",
+      // On release channels stick to "release" as our default gate, but for
+      // experimental channels let's turn everything on.  Users can set this
+      // back to "release" if they want.
+      default: (document.location.host === "searchfox.org") ? "release" : "alpha",
     },
   },
   pageTitle: {
@@ -71,12 +74,17 @@ const SETTING_DEFS = {
   fancyBar: {
     enabled: {
       quality: "alpha",
-    }
+    },
+  },
+  semanticInfo: {
+    enabled: {
+      quality: "alpha",
+    },
   },
   diagramming: {
     enabled: {
       quality: "alpha",
-    }
+    },
   },
 };
 

--- a/tests/tests/checks/inputs/fancy/format-symbol/field-layout/big_cpp.cpp/field_layout__outercat__json
+++ b/tests/tests/checks/inputs/fancy/format-symbol/field-layout/big_cpp.cpp/field_layout__outercat__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::OuterCat | crossref-lookup | format-symbols --mode="field-layout"

--- a/tests/tests/checks/inputs/web/query/execution/field-layout/query__field_layout__outercat__json
+++ b/tests/tests/checks/inputs/web/query/execution/field-layout/query__field_layout__outercat__json
@@ -1,0 +1,1 @@
+query "field-layout:'outerNS::OuterCat'"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -1,0 +1,656 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(sttl).unwrap()"
+---
+{
+  "tables": [
+    {
+      "jumprefs": {
+        "F_<T_outerNS::OuterCat>_mFavoriteCouch": {
+          "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+          "pretty": "outerNS::OuterCat::mFavoriteCouch",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mFavoriteCouch",
+            "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#245"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mIsFriendly": {
+          "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+          "pretty": "outerNS::OuterCat::mIsFriendly",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mIsFriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#241"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly": {
+          "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+          "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#242"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mOwner": {
+          "sym": "F_<T_outerNS::OuterCat>_mOwner",
+          "pretty": "outerNS::OuterCat::mOwner",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mOwner",
+            "sym": "F_<T_outerNS::OuterCat>_mOwner",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#244"
+          }
+        },
+        "F_<T_outerNS::Thing>_mDefunct": {
+          "sym": "F_<T_outerNS::Thing>_mDefunct",
+          "pretty": "outerNS::Thing::mDefunct",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing::mDefunct",
+            "sym": "F_<T_outerNS::Thing>_mDefunct",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::Thing",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#151"
+          }
+        },
+        "F_<T_outerNS::Thing>_mHP": {
+          "sym": "F_<T_outerNS::Thing>_mHP",
+          "pretty": "outerNS::Thing::mHP",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing::mHP",
+            "sym": "F_<T_outerNS::Thing>_mHP",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::Thing",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#147"
+          }
+        },
+        "T_outerNS::OuterCat": {
+          "sym": "T_outerNS::OuterCat",
+          "pretty": "outerNS::OuterCat",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat",
+            "sym": "T_outerNS::OuterCat",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 40,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1Ebb",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isFriendlyCat",
+                "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+                "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+                "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::meet",
+                "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::meet",
+                "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::shred",
+                "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::destroy",
+                "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::operator=",
+                "sym": "_ZN7outerNS8OuterCataSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::operator=",
+                "sym": "_ZN7outerNS8OuterCataSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::~OuterCat",
+                "sym": "_ZN7outerNS8OuterCatD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "outerNS::OuterCat::mIsFriendly",
+                "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 13,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+                "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 14,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "outerNS::OuterCat::mOwner",
+                "sym": "F_<T_outerNS::OuterCat>_mOwner",
+                "type": "class std::shared_ptr<class outerNS::Human>",
+                "typesym": "T_std::shared_ptr",
+                "offsetBytes": 16,
+                "bitPositions": null,
+                "sizeBytes": 16,
+                "labels": [
+                  "cc-unlink"
+                ],
+                "pointerInfo": [
+                  {
+                    "kind": "strong",
+                    "sym": "T_outerNS::Human"
+                  }
+                ]
+              },
+              {
+                "pretty": "outerNS::OuterCat::mFavoriteCouch",
+                "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+                "type": "class outerNS::Couch *",
+                "typesym": "T_outerNS::Couch",
+                "offsetBytes": 32,
+                "bitPositions": null,
+                "sizeBytes": 8,
+                "labels": [
+                  "cc-unlink"
+                ],
+                "pointerInfo": [
+                  {
+                    "kind": "raw",
+                    "sym": "T_outerNS::Couch"
+                  }
+                ]
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "labels": [
+              "cc"
+            ]
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#227"
+          }
+        },
+        "T_outerNS::Thing": {
+          "sym": "T_outerNS::Thing",
+          "pretty": "outerNS::Thing",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1Ei",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::ignore",
+                "sym": "_ZN7outerNS5Thing6ignoreEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::takeDamage",
+                "sym": "_ZN7outerNS5Thing10takeDamageEi",
+                "props": [
+                  "instance",
+                  "virtual",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::operator=",
+                "sym": "_ZN7outerNS5ThingaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::operator=",
+                "sym": "_ZN7outerNS5ThingaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::~Thing",
+                "sym": "_ZN7outerNS5ThingD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "outerNS::Thing::mHP",
+                "sym": "F_<T_outerNS::Thing>_mHP",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 4
+              },
+              {
+                "pretty": "outerNS::Thing::mDefunct",
+                "sym": "F_<T_outerNS::Thing>_mDefunct",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 12,
+                "bitPositions": null,
+                "sizeBytes": 1
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_outerNS::Human",
+              "T_outerNS::Couch",
+              "T_outerNS::OuterCat",
+              "T_outerNS::AbstractArt"
+            ]
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#141"
+          }
+        }
+      },
+      "columns": [],
+      "rows": [
+        {
+          "label": [],
+          "sym": "T_outerNS::OuterCat",
+          "colVals": [],
+          "children": [
+            {
+              "label": [
+                {
+                  "Heading": "outerNS::OuterCat"
+                }
+              ],
+              "sym": "T_outerNS::OuterCat",
+              "colVals": [
+                {
+                  "header": true,
+                  "contents": [
+                    {
+                      "Text": ""
+                    }
+                  ]
+                }
+              ],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mIsFriendly - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xd len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mIsSecretlyUnfriendly - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xe len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mOwner - class std::shared_ptr<class outerNS::Human>"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mOwner",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x10 len 0x10"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mFavoriteCouch - class outerNS::Couch *"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x20 len 0x8"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "label": [
+                {
+                  "Heading": "outerNS::Thing"
+                }
+              ],
+              "sym": "T_outerNS::Thing",
+              "colVals": [
+                {
+                  "header": true,
+                  "contents": [
+                    {
+                      "Text": ""
+                    }
+                  ]
+                }
+              ],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::Thing::mHP - int"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::Thing>_mHP",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x8 len 0x4"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::Thing::mDefunct - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::Thing>_mDefunct",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xc len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -1,0 +1,656 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(sttl).unwrap()"
+---
+{
+  "tables": [
+    {
+      "jumprefs": {
+        "F_<T_outerNS::OuterCat>_mFavoriteCouch": {
+          "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+          "pretty": "outerNS::OuterCat::mFavoriteCouch",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mFavoriteCouch",
+            "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#245"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mIsFriendly": {
+          "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+          "pretty": "outerNS::OuterCat::mIsFriendly",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mIsFriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#241"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly": {
+          "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+          "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+            "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#242"
+          }
+        },
+        "F_<T_outerNS::OuterCat>_mOwner": {
+          "sym": "F_<T_outerNS::OuterCat>_mOwner",
+          "pretty": "outerNS::OuterCat::mOwner",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat::mOwner",
+            "sym": "F_<T_outerNS::OuterCat>_mOwner",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::OuterCat",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#244"
+          }
+        },
+        "F_<T_outerNS::Thing>_mDefunct": {
+          "sym": "F_<T_outerNS::Thing>_mDefunct",
+          "pretty": "outerNS::Thing::mDefunct",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing::mDefunct",
+            "sym": "F_<T_outerNS::Thing>_mDefunct",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::Thing",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#151"
+          }
+        },
+        "F_<T_outerNS::Thing>_mHP": {
+          "sym": "F_<T_outerNS::Thing>_mHP",
+          "pretty": "outerNS::Thing::mHP",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing::mHP",
+            "sym": "F_<T_outerNS::Thing>_mHP",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": "Core/Big",
+            "parentsym": "T_outerNS::Thing",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#147"
+          }
+        },
+        "T_outerNS::OuterCat": {
+          "sym": "T_outerNS::OuterCat",
+          "pretty": "outerNS::OuterCat",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::OuterCat",
+            "sym": "T_outerNS::OuterCat",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 40,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1Ebb",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isFriendlyCat",
+                "sym": "_ZN7outerNS8OuterCat13isFriendlyCatEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isSecretlyUnfriendly",
+                "sym": "_ZN7outerNS8OuterCat20isSecretlyUnfriendlyEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::isFriendlyIfNotCurrentlyVisible",
+                "sym": "_ZN7outerNS8OuterCat31isFriendlyIfNotCurrentlyVisibleEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::meet",
+                "sym": "_ZN7outerNS8OuterCat4meetERNS_5HumanE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::meet",
+                "sym": "_ZN7outerNS8OuterCat4meetERNS_5CouchE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::shred",
+                "sym": "_ZN7outerNS8OuterCat5shredERNS_5ThingE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::destroy",
+                "sym": "_ZN7outerNS8OuterCat7destroyERNS_5ThingE",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::OuterCat",
+                "sym": "_ZN7outerNS8OuterCatC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::operator=",
+                "sym": "_ZN7outerNS8OuterCataSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::operator=",
+                "sym": "_ZN7outerNS8OuterCataSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::OuterCat::~OuterCat",
+                "sym": "_ZN7outerNS8OuterCatD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "outerNS::OuterCat::mIsFriendly",
+                "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 13,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
+                "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 14,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "outerNS::OuterCat::mOwner",
+                "sym": "F_<T_outerNS::OuterCat>_mOwner",
+                "type": "class std::shared_ptr<class outerNS::Human>",
+                "typesym": "T_std::shared_ptr",
+                "offsetBytes": 16,
+                "bitPositions": null,
+                "sizeBytes": 16,
+                "labels": [
+                  "cc-unlink"
+                ],
+                "pointerInfo": [
+                  {
+                    "kind": "strong",
+                    "sym": "T_outerNS::Human"
+                  }
+                ]
+              },
+              {
+                "pretty": "outerNS::OuterCat::mFavoriteCouch",
+                "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+                "type": "class outerNS::Couch *",
+                "typesym": "T_outerNS::Couch",
+                "offsetBytes": 32,
+                "bitPositions": null,
+                "sizeBytes": 8,
+                "labels": [
+                  "cc-unlink"
+                ],
+                "pointerInfo": [
+                  {
+                    "kind": "raw",
+                    "sym": "T_outerNS::Couch"
+                  }
+                ]
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "labels": [
+              "cc"
+            ]
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#227"
+          }
+        },
+        "T_outerNS::Thing": {
+          "sym": "T_outerNS::Thing",
+          "pretty": "outerNS::Thing",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Thing",
+            "sym": "T_outerNS::Thing",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1Ei",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::ignore",
+                "sym": "_ZN7outerNS5Thing6ignoreEv",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::takeDamage",
+                "sym": "_ZN7outerNS5Thing10takeDamageEi",
+                "props": [
+                  "instance",
+                  "virtual",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::operator=",
+                "sym": "_ZN7outerNS5ThingaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::operator=",
+                "sym": "_ZN7outerNS5ThingaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::~Thing",
+                "sym": "_ZN7outerNS5ThingD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Thing::Thing",
+                "sym": "_ZN7outerNS5ThingC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "outerNS::Thing::mHP",
+                "sym": "F_<T_outerNS::Thing>_mHP",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 4
+              },
+              {
+                "pretty": "outerNS::Thing::mDefunct",
+                "sym": "F_<T_outerNS::Thing>_mDefunct",
+                "type": "_Bool",
+                "typesym": "",
+                "offsetBytes": 12,
+                "bitPositions": null,
+                "sizeBytes": 1
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_outerNS::Human",
+              "T_outerNS::Couch",
+              "T_outerNS::OuterCat",
+              "T_outerNS::AbstractArt"
+            ]
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#141"
+          }
+        }
+      },
+      "columns": [],
+      "rows": [
+        {
+          "label": [],
+          "sym": "T_outerNS::OuterCat",
+          "colVals": [],
+          "children": [
+            {
+              "label": [
+                {
+                  "Heading": "outerNS::OuterCat"
+                }
+              ],
+              "sym": "T_outerNS::OuterCat",
+              "colVals": [
+                {
+                  "header": true,
+                  "contents": [
+                    {
+                      "Text": ""
+                    }
+                  ]
+                }
+              ],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mIsFriendly - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xd len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mIsSecretlyUnfriendly - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xe len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mOwner - class std::shared_ptr<class outerNS::Human>"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mOwner",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x10 len 0x10"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::OuterCat::mFavoriteCouch - class outerNS::Couch *"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x20 len 0x8"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            },
+            {
+              "label": [
+                {
+                  "Heading": "outerNS::Thing"
+                }
+              ],
+              "sym": "T_outerNS::Thing",
+              "colVals": [
+                {
+                  "header": true,
+                  "contents": [
+                    {
+                      "Text": ""
+                    }
+                  ]
+                }
+              ],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::Thing::mHP - int"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::Thing>_mHP",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0x8 len 0x4"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "outerNS::Thing::mDefunct - _Bool"
+                    }
+                  ],
+                  "sym": "F_<T_outerNS::Thing>_mDefunct",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "offset 0xc len 0x1"
+                        }
+                      ]
+                    }
+                  ],
+                  "children": []
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tools/src/abstract_server/lazy_crossref.rs
+++ b/tools/src/abstract_server/lazy_crossref.rs
@@ -1,0 +1,73 @@
+//! Lazy computation that could have taken place in crossref.rs but did not.
+//!
+//! Logic goes in here that likely should run in crossref.rs once we're:
+//! - Certain we want the functionality.
+//! - Largely done iterating on the logic.  crossref for m-c takes 21 minutes so
+//!   it is hard to have a tight experimentation loop.  It's also the case that
+//!   `make build-test-repo` is much slower now since we added Java/Kotlin
+//!   support.
+//!
+//! Functionality currently under development:
+//! - Argument string population.  Currently for C++ we emit the argRanges on
+//!   source and target records but not the string payloads.  (This was partly
+//!   done for cost reasons, but also because we want to be able to use the
+//!   ranges to know what semantic records they cover.)
+//!
+//! Some shorter term potential functionality:
+//! - Inferred thread usage for methods that are looked up; classes would be
+//!   useful too but is something where it either needs to happen in crossref
+//!   proper or the lazy crossref mechanism here needs to become stateful and
+//!   cache some things.  That's likely a dangerous path in terms of the
+//!   potential for it to stick around and get increasingly messy.
+//!   - Arguably any commands that want to know things for classes should
+//!     probably support arbitrary predicates/checks which can only be
+//!     determined by performing on-the-fly per-method checks, so this should
+//!     also not be a limiting factor although it would probably be a huge
+//!     performance win if it was reliably precomputed for those use-cases.
+//!
+//! Some longer term potential functionality:
+//! - Improved argument processing to leverage the semantic tokens.
+//! - Some level of dataflow analysis.  Note that this would require the C++
+//!   indexer to emit additional information and/or using tree-sitter to help
+//!   detect writes/assignment.
+
+use super::{local_index::LocalIndex, server_interface::Result};
+
+use serde_json::{Value};
+
+/// Perform the actual lazy cross-reference process.
+///
+/// Note that while we make an effort to be efficient within this method in
+/// terms of loading the contents of source files at most once, this is
+/// fundamentally not efficient when multiple calls are made to this method
+/// where it's highly likely we could have reused the line-parsed files where it
+/// is very likely for there to be file overlap.  (That said, we do expect this
+/// to be fine in most cases and this is a trade-off we are intentionally
+/// making.)
+pub async fn perform_lazy_crossref(_server: &LocalIndex, val: Value) -> Result<Value> {
+    // Consume the "uses" array if present so we can transform it.
+    /*
+    let use_path_containers: Vec<PathSearchResult> = match val.get_mut("uses") {
+        Some(uses) => from_value(uses.take()).unwrap_or_default(),
+        _ => vec![]
+    };
+
+    let mut source_file: HashMap<String, Vec<String>>
+
+    for use_path_container in &use_path_containers {
+
+    }
+    */
+
+    // ## Figure out what source files we need to load
+
+    // ### Determine files to load for uses
+
+    // ## Load the source files in
+
+    // ## Process Source files
+
+    // ### Walk the argument excerpts
+
+    Ok(val)
+}

--- a/tools/src/abstract_server/mod.rs
+++ b/tools/src/abstract_server/mod.rs
@@ -1,3 +1,4 @@
+mod lazy_crossref;
 mod local_index;
 mod remote_server;
 mod server_interface;

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -6,7 +6,8 @@ use ustr::Ustr;
 
 use super::{
     server_interface::{
-        AbstractServer, ErrorDetails, ErrorLayer, FileMatches, Result, ServerError, SearchfoxIndexRoot,
+        AbstractServer, ErrorDetails, ErrorLayer, FileMatches, Result, SearchfoxIndexRoot,
+        ServerError,
     },
     HtmlFileRoot, TextMatches, TreeInfo,
 };
@@ -143,7 +144,7 @@ impl AbstractServer for RemoteServer {
         Ok(html)
     }
 
-    async fn crossref_lookup(&self, _symbol: &str) -> Result<Value> {
+    async fn crossref_lookup(&self, _symbol: &str, _extra_processing: bool) -> Result<Value> {
         // Let's require local index for now; we'll expose this once this
         // mechanism is exposed to the web so we can talk to the corresponding
         // local server over https.

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -308,8 +308,10 @@ pub trait AbstractServer {
     async fn fetch_html(&self, root: HtmlFileRoot, sf_path: &str) -> Result<String>;
 
     /// Retrieve the JSON contents of the crossref database for the given
-    /// symbol.
-    async fn crossref_lookup(&self, symbol: &str) -> Result<Value>;
+    /// symbol.  Optionally performs the extra processing provided by
+    /// `lazy_crossref.rs` on local indices; this should only be passed for
+    /// specific use-cases that know they need the new experimental data.
+    async fn crossref_lookup(&self, symbol: &str, extra_processing: bool) -> Result<Value>;
 
     /// Retrieve the JSON contents of the jumpref database for the given
     /// symbol.

--- a/tools/src/bin/pipeline-server.rs
+++ b/tools/src/bin/pipeline-server.rs
@@ -81,6 +81,9 @@ async fn handle_query(
             PipelineValues::GraphResultsBundle(grb) => {
                 serde_json::to_string(&grb.symbols).unwrap_or_else(|_| "{}".to_string())
             }
+            PipelineValues::SymbolTreeTableList(sttl) => {
+                serde_json::to_string(&sttl.unioned_node_sets_as_jumprefs()).unwrap_or_else(|_| "{}".to_string())
+            }
             _ => "{}".to_string(),
         };
 

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -144,6 +144,10 @@ async fn main() {
             emit_json(&to_value(bg).unwrap());
             0
         }
+        Ok(PipelineValues::SymbolTreeTableList(sttl)) => {
+            emit_json(&to_value(sttl).unwrap());
+            0
+        }
         Err(err) => {
             println!("Pipeline Error!");
             println!("{:?}", err);

--- a/tools/src/blame.rs
+++ b/tools/src/blame.rs
@@ -1,7 +1,6 @@
 use crate::file_format::config::Config;
 use crate::links;
 
-use git2;
 use std::borrow::Cow;
 use serde_json::{json, Map, to_string};
 

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -18,7 +18,7 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_augment_results::AugmentResultsCommand, cmd_traverse::TraverseCommand, cmd_batch_render::BatchRenderCommand, cmd_render::RenderCommand, cmd_jumpref_lookup::JumprefLookupCommand, cmd_tokenize_source::TokenizeSourceCommand};
+use super::{cmd_augment_results::AugmentResultsCommand, cmd_batch_render::BatchRenderCommand, cmd_format_symbols::FormatSymbolsCommand, cmd_jumpref_lookup::JumprefLookupCommand, cmd_render::RenderCommand, cmd_tokenize_source::TokenizeSourceCommand, cmd_traverse::TraverseCommand};
 use super::{
     cmd_cat_html::CatHtmlCommand,
     cmd_compile_results::CompileResultsCommand,
@@ -50,6 +50,8 @@ pub fn fab_command_from_opts(opts: ToolOpts) -> Result<Box<dyn PipelineCommand +
         Command::CrossrefLookup(cl) => Ok(Box::new(CrossrefLookupCommand { args: cl })),
 
         Command::FilterAnalysis(fa) => Ok(Box::new(FilterAnalysisCommand { args: fa })),
+
+        Command::FormatSymbols(fs) => Ok(Box::new(FormatSymbolsCommand { args: fs })),
 
         Command::Graph(g) => Ok(Box::new(GraphCommand { args: g })),
 

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -139,7 +139,7 @@ impl PipelineCommand for CrossrefExpandCommand {
             let mut info = match maybe_info {
                 Some(existing) => existing,
                 None => {
-                    let fresh_info = server.crossref_lookup(&symbol).await?;
+                    let fresh_info = server.crossref_lookup(&symbol, false).await?;
                     SymbolCrossrefInfo {
                         symbol: symbol.clone(),
                         crossref_info: fresh_info,

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -66,7 +66,7 @@ impl PipelineCommand for CrossrefLookupCommand {
         let mut symbol_crossref_infos = vec![];
         let mut unknown_symbols = vec![];
         for (symbol, quality) in symbol_list {
-            let info = server.crossref_lookup(&symbol).await?;
+            let info = server.crossref_lookup(&symbol, false).await?;
 
             if info.is_null() {
                 unknown_symbols.push(symbol);
@@ -87,7 +87,7 @@ impl PipelineCommand for CrossrefLookupCommand {
             if self.args.methods {
                 if let Some(method_syms) = crossref_info.get_method_symbols() {
                     for method_sym in method_syms {
-                        let method_info = server.crossref_lookup(&method_sym).await?;
+                        let method_info = server.crossref_lookup(&method_sym, false).await?;
                         symbol_crossref_infos.push(SymbolCrossrefInfo {
                             symbol: method_sym,
                             crossref_info: method_info,

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -1,0 +1,189 @@
+use std::collections::VecDeque;
+
+use async_trait::async_trait;
+use clap::{Args, ValueEnum};
+use itertools::Itertools;
+
+use super::{
+    interface::{
+        BasicMarkup, PipelineCommand, PipelineValues, SymbolTreeTable, SymbolTreeTableCell, SymbolTreeTableList, SymbolTreeTableNode
+    },
+    symbol_graph::DerivedSymbolInfo,
+};
+
+use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
+
+#[derive(Clone, Debug, PartialEq, ValueEnum)]
+pub enum SymbolFormatMode {
+    FieldLayout,
+    // - class-field-use-matrix: table for each class, look up all its methods and all its
+    //   fields, then filter the method "calls" to the fields.
+    // - caller-matrix: look up a class, get all its methods.  look up all of
+    //   the callers of all of those methods.  group them by their class.
+    //   - row depth 0 is subsystem
+    //   - row depth 1 is class or file if no class
+    //   - row depth 2 is method/function
+    //   - columns are the methods on the class, probably alphabetical.
+    //     - columns could maybe have an upsell to the arg-matrix?
+    //   - cells are a count.
+    // - arg-matrix:
+    //   - like caller-matrix but only for a single matrix and the columns are
+    //     the args.
+}
+
+/// Given a list of symbol crossref infos, produce a SymbolTreeTable for display
+/// purposes.
+#[derive(Debug, Args)]
+pub struct FormatSymbols {
+    #[clap(long, value_parser, value_enum, default_value = "field-layout")]
+    pub mode: SymbolFormatMode,
+}
+
+#[derive(Debug)]
+pub struct FormatSymbolsCommand {
+    pub args: FormatSymbols,
+}
+
+#[async_trait]
+impl PipelineCommand for FormatSymbolsCommand {
+    async fn execute(
+        &self,
+        server: &Box<dyn AbstractServer + Send + Sync>,
+        input: PipelineValues,
+    ) -> Result<PipelineValues> {
+        let cil = match input {
+            PipelineValues::SymbolCrossrefInfoList(cil) => cil,
+            _ => {
+                return Err(ServerError::StickyProblem(ErrorDetails {
+                    layer: ErrorLayer::ConfigLayer,
+                    message: "format-symbols needs a CrossrefInfoList".to_string(),
+                }));
+            }
+        };
+
+        match self.args.mode {
+            SymbolFormatMode::FieldLayout => {
+                let mut tables = vec![];
+
+                for nom_sym_info in cil.symbol_crossref_infos {
+                    let mut stt = SymbolTreeTable::new();
+                    let (root_sym_id, _) = stt.node_set.add_symbol(DerivedSymbolInfo::new(
+                        nom_sym_info.symbol,
+                        nom_sym_info.crossref_info,
+                        0,
+                    ));
+
+                    let mut pending_ids = VecDeque::new();
+                    pending_ids.push_back(root_sym_id.clone());
+
+                    let mut root_node = SymbolTreeTableNode {
+                        sym_id: Some(root_sym_id),
+                        label: vec![],
+                        col_vals: vec![],
+                        children: vec![],
+                    };
+
+                    while let Some(sym_id) = pending_ids.pop_front() {
+                        let sym_info = stt.node_set.get(&sym_id);
+                        let depth = sym_info.depth;
+                        let Some(structured) = sym_info.get_structured() else {
+                            continue;
+                        };
+
+                        for super_info in &structured.supers {
+                            let (super_id, _) = stt
+                                .node_set
+                                .ensure_symbol(&super_info.sym, server, depth + 1)
+                                .await?;
+                            pending_ids.push_back(super_id);
+                        }
+
+                        let mut class_node = SymbolTreeTableNode {
+                            sym_id: Some(sym_id),
+                            label: vec![BasicMarkup::Heading(structured.pretty.to_string())],
+                            col_vals: vec![],
+                            children: vec![],
+                        };
+
+                        let platforms_and_fields = structured.fields_across_all_variants();
+                        let mut per_plat_fields_by_defloc = vec![];
+                        for (platforms, fields) in platforms_and_fields {
+                            let plat_idx = class_node.col_vals.len();
+                            class_node.col_vals.push(SymbolTreeTableCell::header_text(
+                                platforms.join(" ").to_owned(),
+                            ));
+                            let mut plat_fields_by_defloc = vec![];
+                            for field in fields {
+                                let (field_id, field_info) = stt
+                                    .node_set
+                                    .ensure_symbol(&field.sym, server, depth + 1)
+                                    .await?;
+                                plat_fields_by_defloc.push((
+                                    field_info.get_def_lno(),
+                                    plat_idx,
+                                    field,
+                                    field_id,
+                                ));
+                            }
+                            plat_fields_by_defloc.sort_by_key(|ft| ft.0);
+                            per_plat_fields_by_defloc.push(plat_fields_by_defloc);
+                        }
+
+                        for (_lno, group) in &per_plat_fields_by_defloc
+                            .into_iter()
+                            // merge in order of lexical line number of the field definition
+                            .kmerge_by(|a, b| a.0 < b.0)
+                            // and then also group on that line number
+                            .group_by(|x| x.0)
+                        {
+                            let mut field_node = SymbolTreeTableNode {
+                                sym_id: None,
+                                label: vec![],
+                                col_vals: vec![],
+                                children: vec![],
+                            };
+                            // and then within the group let's process in order of increasing platform to match the columns.
+                            for (_lno, plat_idx, field_info, field_id) in
+                                group.sorted_by_key(|pfi| pfi.1)
+                            {
+                                if field_node.sym_id.is_none() {
+                                    field_node.sym_id = Some(field_id);
+                                    field_node.label =
+                                        vec![BasicMarkup::Text(match &field_info.type_pretty.is_empty() {
+                                            false => format!(
+                                                "{} - {}",
+                                                field_info.pretty, field_info.type_pretty
+                                            ),
+                                            true => format!("{}", field_info.pretty),
+                                        })];
+                                }
+                                while field_node.col_vals.len() < plat_idx {
+                                    field_node.col_vals.push(SymbolTreeTableCell::empty());
+                                }
+                                field_node.col_vals.push(SymbolTreeTableCell::text(format!(
+                                    "offset {:#x} len {:#x}",
+                                    field_info.offset_bytes,
+                                    field_info.size_bytes.unwrap_or(0),
+                                )));
+
+                                // XXX uh, for at least IDBFactory some weird stuff happens for mRefCnt.
+                                if field_node.col_vals.len() >= class_node.col_vals.len() {
+                                    break;
+                                }
+                            }
+                            class_node.children.push(field_node);
+                        }
+                        root_node.children.push(class_node);
+                    }
+
+                    stt.rows.push(root_node);
+                    tables.push(stt);
+                }
+
+                Ok(PipelineValues::SymbolTreeTableList(SymbolTreeTableList {
+                    tables,
+                }))
+            }
+        }
+    }
+}

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -5,7 +5,7 @@ use async_trait::async_trait;
 use clap::{Args, ValueEnum};
 use dot_generator::*;
 use dot_structures::*;
-use regex::{self, Captures, Regex};
+use regex::{Captures, Regex};
 use serde_json::{Value, json};
 
 use graphviz_rust::cmd::{CommandArg, Format, Layout};
@@ -334,7 +334,7 @@ impl PipelineCommand for GraphCommand {
                         "edges": render_state.svg_edge_extra,
                     }),
                 }],
-                symbols: graphs.symbols_meta_to_jumpref_json_destructive(),
+                symbols: graphs.node_set.symbols_meta_to_jumpref_json_destructive(),
                 overloads_hit: graphs.overloads_hit,
             })),
             _ => Ok(PipelineValues::TextFile(TextFile {

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -13,6 +13,7 @@ mod cmd_compile_results;
 mod cmd_crossref_expand;
 mod cmd_crossref_lookup;
 mod cmd_filter_analysis;
+mod cmd_format_symbols;
 mod cmd_graph;
 mod cmd_jumpref_lookup;
 mod cmd_merge_analyses;

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -7,6 +7,7 @@ use super::cmd_compile_results::CompileResults;
 use super::cmd_crossref_expand::CrossrefExpand;
 use super::cmd_crossref_lookup::CrossrefLookup;
 use super::cmd_filter_analysis::FilterAnalysis;
+use super::cmd_format_symbols::FormatSymbols;
 use super::cmd_graph::Graph;
 use super::cmd_jumpref_lookup::JumprefLookup;
 use super::cmd_merge_analyses::MergeAnalyses;
@@ -71,6 +72,7 @@ pub enum Command {
     CrossrefExpand(CrossrefExpand),
     CrossrefLookup(CrossrefLookup),
     FilterAnalysis(FilterAnalysis),
+    FormatSymbols(FormatSymbols),
     Graph(Graph),
     JumprefLookup(JumprefLookup),
     MergeAnalyses(MergeAnalyses),

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -22,7 +22,6 @@ use crate::output::{self, Options, PanelItem, PanelSection, F};
 use chrono::datetime::DateTime;
 use chrono::naive::datetime::NaiveDateTime;
 use chrono::offset::fixed::FixedOffset;
-use git2;
 use serde_json::{json, Map, to_string, to_string_pretty};
 use ustr::{Ustr, ustr};
 

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -144,6 +144,17 @@ command = "augment-results"
 args.before = "$0"
 args.after = "$0"
 
+[term.field-layout]
+[[term.field-layout.group.semantic-lookup]]
+command = "search-identifiers"
+args.positional = "$0"
+args.exact-match = true
+[[term.field-layout.group.semantic-lookup]]
+command = "crossref-lookup"
+[[term.field-layout.group.semantic-format]]
+command = "format-symbols"
+args.mode = "field-layout"
+
 # The default term is what gets applied to things without a term.  It can also
 # be explicitly referenced by other terms.
 [term.default]
@@ -259,3 +270,15 @@ output = "result"
 [[group.graph-render.commands]]
 command = "graph"
 args.format = "mozsearch"
+
+[group.semantic-lookup]
+output = "semantic-lookup"
+next = "semantic-filter"
+
+[group.semantic-filter]
+output = "semantic-filter"
+next = "semantic-format"
+
+[group.semantic-format]
+output = "result"
+

--- a/tools/templates/query_results.liquid
+++ b/tools/templates/query_results.liquid
@@ -5,13 +5,15 @@
     {% for result_pair in results %}
       {% case result_pair[0] %}
         {% when "FlattenedResultsBundle" %}
-            {% include 'query_results/rb_root.liquid' %}
-          {% when "GraphResultsBundle" %}
-            {% include 'query_results/graph_root.liquid' %}
-          {% when "SymbolGraphCollection" %}
-            {% include 'query_results/graph_collection_root.liquid' %}
-          {% when "TextFile" %}
-            {% include 'query_results/text_file_root.liquid' %}
+          {% include 'query_results/rb_root.liquid' %}
+        {% when "GraphResultsBundle" %}
+          {% include 'query_results/graph_root.liquid' %}
+        {% when "SymbolGraphCollection" %}
+          {% include 'query_results/graph_collection_root.liquid' %}
+        {% when "SymbolTreeTableList" %}
+            {% include 'query_results/symbol_tree_table_list_root.liquid' %}
+        {% when "TextFile" %}
+          {% include 'query_results/text_file_root.liquid' %}
         {% else %}
           Unhandled results type {{result_pair[0]}}!
         {% endcase %}

--- a/tools/templates/query_results/basic_markup_array.liquid
+++ b/tools/templates/query_results/basic_markup_array.liquid
@@ -1,0 +1,7 @@
+{% for piece in markup %}
+  {% if piece contains "Heading" %}
+    <h3>{{ piece.Heading | escape }}</h3>
+  {% elsif piece contains "Text" %}
+    {{ piece.Text | escape }}
+  {% endif %}
+{% endfor %}

--- a/tools/templates/query_results/symbol_crossref_info_list_root.liquid
+++ b/tools/templates/query_results/symbol_crossref_info_list_root.liquid
@@ -1,0 +1,3 @@
+{% for sym_info in results.SymbolCrossrefInfoList.symbol_crossref_infos %}
+{% include 'query_results/symbol.liquid' sym_info: sym_info, forloop: forloop %}
+{% endfor %}

--- a/tools/templates/query_results/symbol_tree_table.liquid
+++ b/tools/templates/query_results/symbol_tree_table.liquid
@@ -1,0 +1,16 @@
+<table class="symbol-tree-table">
+{% if table.columns != empty %}
+  <thead>
+    <tr>
+    {% for col in table.columns %}
+        <th scope="col">{% include 'query_results/basic_markup_array.liquid' markup: col.contents %}</th>
+    {% endfor %}
+    </tr>
+  </thead>
+{% endif %}
+  <tbody>
+    {%- for kid in table.rows -%}
+      {%- include 'query_results/symbol_tree_table_node.liquid' node: kid -%}
+    {%- endfor -%}
+  </tbody>
+</table>

--- a/tools/templates/query_results/symbol_tree_table_list_root.liquid
+++ b/tools/templates/query_results/symbol_tree_table_list_root.liquid
@@ -1,0 +1,3 @@
+{% for table in results.SymbolTreeTableList.tables %}
+    {% include 'query_results/symbol_tree_table.liquid' table: table, forloop: forloop %}
+{% endfor %}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -1,0 +1,13 @@
+<tr>
+  <td>
+    <span data-symbols="{{ node.sym }}">{%- include 'query_results/basic_markup_array.liquid' markup: node.label -%}</span>
+  </td>
+  {% for col in node.colVals %}
+    {% if col.header %}<th>{% else %}<td>{% endif %}
+      {%- include 'query_results/basic_markup_array.liquid' markup: col.contents -%}
+    {% if col.header %}</th>{% else %}</td>{% endif %}
+  {% endfor %}
+</tr>
+{%- for kid in node.children -%}
+  {%- include 'query_results/symbol_tree_table_node.liquid' node: kid -%}
+{%- endfor -%}

--- a/tools/templates/settings.liquid
+++ b/tools/templates/settings.liquid
@@ -197,6 +197,22 @@
       </section>
     </section>
     <section>
+      <h2>Semantic Info Queries</h2>
+      <p>
+        We're experimenting with exposing information like the field layout of
+        classes.  According to our settings code it is
+        <b><span id="quality--semantic-info--enabled"></span></b> quality.
+      </p>
+      <section>
+        <h3>Semantic Info Queries Feature Gate</h3>
+        <form>
+          <label for="semantic-info--enabled">Semantic Info feature gate:</label>
+          <select id="semantic-info--enabled">
+          </select>
+        </form>
+      </section>
+    </section>
+    <section>
       <h2>Diagramming</h2>
       <p>
         Searchfox has very experimental diagramming functionality.  According to

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -135,6 +135,9 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         Ok(PipelineValues::BatchGroups(bg)) => {
                             insta::assert_json_snapshot!(&to_value(bg).unwrap());
                         }
+                        Ok(PipelineValues::SymbolTreeTableList(sttl)) => {
+                            insta::assert_json_snapshot!(&to_value(sttl).unwrap());
+                        }
                         Err(ServerError::Unsupported) => {
                             // We're intentionally skipping doing anything here.
                             // Our assumption is that this error will only be


### PR DESCRIPTION
The UI is not amazing on this and the context menu option makes my muscle memory a bit irritable, so I've introduced a new "semanticInfo" feature gate.

This introduces a new symbol tree table result type which also introdues some new very limited markup support.  Our markup isn't horrible but could be improved.  I think we probably want to put the offset and length in their own columns like the fancy branch prototype had done (in React) using a colgroup.  But I think that also likely wants to happen only once another format-symbols mode is introduced.

Something this absolutely reveals is that the structured "variants" mechanism where we hash on content is causing duplicates.  Additionally, this raises the issue that we really need to the root structured rep to be a composite of all variants, not just one arbitrary one.  Otherwise the diagram functionality and anything else that is trying to treat the root structured object as canonical is potentially going to be misleading.