### PR TITLE
Bug 1884591 - Harden pipeline-server, improve diagramming efficiency

### DIFF
--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -182,6 +182,13 @@ labels = ["uses-diagram:stop"]
 [pretty."TelemetryEvent::RecordEventNative"]
 labels = ["uses-diagram:stop"]
 
+# Until we are able to understand the observer service arguments and refine the
+# calls to tuple over the argument, we want uses diagrams to stop at the
+# interface because otherwise they entrain impossible control flow paths.
+# TODO: Understand observer notification arguments / subscriptions.
+[pretty."nsIObserver::Observe"]
+labels = ["uses-diagram:stop"]
+
 # stay out of debug spam stuff
 [pretty."NS_warn_if_impl"]
 labels = ["calls-diagram:stop"]

--- a/infrastructure/web-server-run.sh
+++ b/infrastructure/web-server-run.sh
@@ -31,6 +31,25 @@ nohup $MOZSEARCH_PATH/router/router.py $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/
 export RUST_BACKTRACE=1
 nohup $MOZSEARCH_PATH/tools/target/release/web-server $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/rust-server.log 2> $SERVER_ROOT/rust-server.err < /dev/null &
 
+# let's try and stop the pipeline-server from causing problems by setting a ulimit
+# on virtual memory usage.  Currently, the worst-case scenario is mozilla-central
+# where it starts with 13.7G of VM usage where we know we have 8.9G of memory
+# mapped files.  At that point the resident memory usage is 390M.  If we trigger
+# a worst-case scenario graph traversal (before fixes), we see 24.0G virt, 11.1G
+# resident.  We're setting our virt limit to 24G accordingly since on a t3.xlarge
+# that only has 16G of RAM, that leaves enough for the rest not to fall over.
+#
+# TODO: automate updating/calculating this number somewhat.  In particular, the
+# indexer check mechanism will stand up the web-server, which makes it possible
+# to inspect the pipeline-server's VM use at that time and then write it to a
+# file and then do some math on it.  I'm not doing that right now because it's
+# more work and more likely to have problems that defeat the point.  Also,
+# there are some upsides to having this be an absolute value that's 3/4 of the
+# expected system memory for t3.2xlarge.
+#
+# ulimit -v units are kilobytes, so we do 24 * 1024 * 1024.
+ulimit -v 25165824
+
 # Note that we do not currently wait for the pipeline-server and it does not
 # write to the STATUS_FILE.
 nohup $MOZSEARCH_PATH/tools/target/release/pipeline-server $CONFIG_FILE > $SERVER_ROOT/pipeline-server.log 2> $SERVER_ROOT/pipeline-server.err < /dev/null &

--- a/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__colorize__outercat_meet__dot
+++ b/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__colorize__outercat_meet__dot
@@ -1,1 +1,1 @@
-search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse | graph --colorize-callees=takeDamage --format=raw-dot --hier=flat
+search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse --retain-all-symbol-data | graph --colorize-callees=takeDamage --format=raw-dot --hier=flat

--- a/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__colorize__outercat_meet__svg
+++ b/tests/tests/checks/inputs/fancy/diagram/traverse/big_cpp.cpp/callees__colorize__outercat_meet__svg
@@ -1,1 +1,1 @@
-search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse | graph --colorize-callees=takeDamage --format=svg --hier=flat
+search-identifiers outerNS::OuterCat::meet | crossref-lookup | traverse --retain-all-symbol-data | graph --colorize-callees=takeDamage --format=svg --hier=flat


### PR DESCRIPTION
- Adds a virtual memory ulimit on the pipeline-server that works in docker at least.
- Overhauls the path-propagation logic to directly process the list of discovered paths instead of buffering them first.
- Limits the all-paths petgraph algorithm invocation to have a max depth of the depth traversal we set for the graph.  This was likely a major factor in performance problems, as adding this made a huge difference.  This makes sense because in many cases there's a ton of internal control flow.