### PR TITLE
Bug 1884591 - Diagramming improvements / hardening.

### DIFF
--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -198,6 +198,8 @@ labels = ["calls-diagram:stop"]
 labels = ["calls-diagram:stop"]
 [pretty."MOZ_ReportCrash"]
 labels = ["calls-diagram:stop"]
+[pretty."NS_IsMainThread"]
+labels = ["calls-diagram:stop"]
 # the above cases should prevent this, but this has an annoying fan-out if we get here
 [pretty."PR_GetEnv"]
 labels = ["calls-diagram:stop"]
@@ -220,6 +222,8 @@ labels = ["calls-diagram:stop"]
 # Avoid some NSPR stuff that comes up; this very much could be handled via subsystem
 # heuristics about NSPR always being boring.
 [pretty."PR_JoinThread"]
+labels = ["calls-diagram:stop"]
+[pretty."PR_Now"]
 labels = ["calls-diagram:stop"]
 
 # ### Refcounted Types ###

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse__calls_to__colorize__takeDamage__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse__calls_to__colorize__takeDamage__json.snap
@@ -46,7 +46,9 @@ expression: "&jv.value"
         {
           "command": "crossref-lookup",
           "args": {
-            "bool_args": [],
+            "bool_args": [
+              "exact-match"
+            ],
             "named_args": {},
             "positional_args": []
           }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse__calls_to__takeDamage__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse__calls_to__takeDamage__json.snap
@@ -42,7 +42,9 @@ expression: "&jv.value"
         {
           "command": "crossref-lookup",
           "args": {
-            "bool_args": [],
+            "bool_args": [
+              "exact-match"
+            ],
             "named_args": {},
             "positional_args": []
           }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse_calls_to__graoh_format__takeDamage__json.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/big_cpp.cpp/check_glob@query__parse_calls_to__graoh_format__takeDamage__json.snap
@@ -42,7 +42,9 @@ expression: "&jv.value"
         {
           "command": "crossref-lookup",
           "args": {
-            "bool_args": [],
+            "bool_args": [
+              "exact-match"
+            ],
             "named_args": {},
             "positional_args": []
           }

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/lots_of_calls.cpp/check_glob@query__parse__calls_between__four_left_one_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/lots_of_calls.cpp/check_glob@query__parse__calls_between__four_left_one_right__svg.snap
@@ -44,6 +44,7 @@ expression: "&jv.value"
           "command": "crossref-lookup",
           "args": {
             "bool_args": [
+              "exact-match",
               "methods"
             ],
             "named_args": {},

--- a/tests/tests/checks/snapshots/web/query/parsing/simple/lots_of_calls.cpp/check_glob@query__parse__calls_to__four_left_and_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/parsing/simple/lots_of_calls.cpp/check_glob@query__parse__calls_to__four_left_and_right__svg.snap
@@ -43,7 +43,9 @@ expression: "&jv.value"
         {
           "command": "crossref-lookup",
           "args": {
-            "bool_args": [],
+            "bool_args": [
+              "exact-match"
+            ],
             "named_args": {},
             "positional_args": []
           }

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -413,6 +413,8 @@ pub enum OverloadKind {
     /// paths which is a temporary thing (and we should change to Uses when
     /// correcting).
     UsesPaths,
+    /// Uses limit but based on lines.
+    UsesLines,
     FieldMemberUses,
     NodeLimit,
 }

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -37,6 +37,8 @@ pub struct IdentResult {
     pub symbol: Ustr,
 }
 
+// XXX commented out like the callsite; they can probably both be removed
+/*
 // TODO: switch to https://crates.io/crates/cpp_demangle which is probably what
 // pernosco uses (based on khuey being an owner) and so for consistency purposes
 // is probably the right call.
@@ -58,6 +60,7 @@ fn demangle_name(name: &str) -> String {
         }
     }
 }
+*/
 
 impl IdentMap {
     pub fn new(filename: &str) -> Option<IdentMap> {
@@ -160,7 +163,7 @@ impl IdentMap {
 
         for line in slice.lines() {
             let line = line.unwrap();
-            let (mut id, symbol) = match line.rsplit_once(' ') {
+            let (id, symbol) = match line.rsplit_once(' ') {
                 Some((id, symbol)) => (id.to_string(), symbol),
                 None => continue,
             };
@@ -178,10 +181,15 @@ impl IdentMap {
                 continue;
             }
 
+            // Note: I've commented out our use of demangling because this is
+            // arguably a legacy concept in the face of our having structured
+            // data available for all the cases where demangling would succeed.
+            /*
             let demangled = demangle_name(&symbol);
             if demangled != symbol {
                 id = demangled;
             }
+            */
 
             result.push(IdentResult {
                 id: ustr(&id),

--- a/tools/src/file_format/ontology_mapping.rs
+++ b/tools/src/file_format/ontology_mapping.rs
@@ -172,7 +172,13 @@ pub fn pointer_kind_to_badge_info(
 
 pub fn label_to_badge_info(label: &str) -> Option<(i32, &str)> {
     // Ignore all class-diagram directives, these are processed by cmd_traverse.
+    if label.starts_with("calls-diagram:") {
+        return None;
+    }
     if label.starts_with("class-diagram:") {
+        return None;
+    }
+    if label.starts_with("uses-diagram:") {
         return None;
     }
 

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -10,6 +10,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.calls-to.group.graph-symbols-default]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.calls-to.group.graph-traverse]]
 command = "traverse"
 args.edge = "uses"
@@ -30,6 +31,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.calls-between.group.graph-symbols-default]]
 command = "crossref-lookup"
+args.exact-match = true
 args.methods = true
 [[term.calls-between.group.graph-traverse]]
 command = "traverse"
@@ -44,6 +46,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.calls-between-source.group.graph-symbols-source]]
 command = "crossref-lookup"
+args.exact-match = true
 args.methods = true
 [[term.calls-between-source.group.graph-traverse]]
 command = "traverse"
@@ -57,15 +60,13 @@ args.positional = "$0"
 args.exact-match = true
 [[term.calls-between-target.group.graph-symbols-target]]
 command = "crossref-lookup"
+args.exact-match = true
 args.methods = true
 [[term.calls-between-target.group.graph-traverse]]
 command = "traverse"
 args.edge = "uses"
 args.paths-between = true
 
-# XXX I intentionally had not exposed this previously because of the potential
-# for way too many results as it could get lost in the weeds, but I want to
-# experiment with this for now...
 [term.calls-from]
 [[term.calls-from.group.graph-symbols-default]]
 command = "search-identifiers"
@@ -73,6 +74,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.calls-from.group.graph-symbols-default]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.calls-from.group.graph-traverse]]
 command = "traverse"
 args.edge = "callees"
@@ -87,6 +89,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.inheritance-diagram.group.graph-symbols-default]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.inheritance-diagram.group.graph-traverse]]
 command = "traverse"
 args.edge = "inheritance"
@@ -103,6 +106,7 @@ args.exact-match = true
 args.types-only = true
 [[term.class-diagram.group.graph-symbols-default]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.class-diagram.group.graph-traverse]]
 command = "traverse"
 args.edge = "class"
@@ -182,6 +186,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.field-layout.group.semantic-lookup]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.field-layout.group.semantic-format]]
 command = "format-symbols"
 args.mode = "field-layout"
@@ -211,6 +216,7 @@ args.positional = "$0"
 args.exact-match = true
 [[term.id.group.semantic-search]]
 command = "crossref-lookup"
+args.exact-match = true
 [[term.id.group.semantic-search]]
 command = "crossref-expand"
 


### PR DESCRIPTION
- Change identifiers lookup to report the identifier from the lookup row rather than demangling.  I believe the demangling decision to be obsolete in the era of structured records, but made sense in the router.py-consumed python implementation (and which still works that way).
- Change diagram crossref-lookup to require an absolute pretty rather than a pretty suffix.
  - This depends on the above change to identifiers; identifier search can avoid doing a prefix match, but because we emit all suffix variations, we need to apply a constraint in crossref-lookup to filter out false matches.
  - This allows, for example, diagramming on "abort" without getting "foo::abort".
- The pipeline-server now only instantiates the logged span if we are planning to consume the result.  This was done for memory usage concerns speculatively while addressing diagram overload cases.  It did have a meaningful impact but of course was not the source of the problems so could not fix the problems.
- Ensure that the newly introduces diagram stops are actually correct and don't show up in other modes; calls was supposed to be callees and a mapping to skip the commands needed to be added.
- The primary diagram overload problem was that we didn't do anything about very long hit lists.  In cases in MFBT for macrology related to NS_DebugBreak and similar, we would end up with literally thousands of hits on a single line which couldn't be merged because their contextsyms differed.  This has been addressed by processing the hit lists for potential overloads.