### PR TITLE
Update mozsearch.css to correct HCM/IC colors on Windows and Mac

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -151,7 +151,7 @@ table {
 }
 }
 
-@media (prefers-contrast) {
+@media (forced-colors) {
   :root {
     --blame-popup-background: Canvas;
     --blame-popup-color: CanvasText;
@@ -795,7 +795,7 @@ span[data-symbols].hovered {
   margin: 0;
   touch-action: none; /* fallback for FF pre-85 which didn't support touch-action:pinch-zoom */
   touch-action: pinch-zoom;
-  @media (prefers-contrast) {
+  @media (forced-colors) {
     border-inline: 1px solid ButtonText;
     &:hover {
       background-color: SelectedItem;
@@ -861,10 +861,10 @@ input::placeholder {
 #query {
   /* Leave room for spinner. */
   padding-right: 40px;
-  @media (prefers-contrast) {
-    background-color: ButtonFace;
+  @media (forced-colors) {
+    background-color: Field;
     border: 1px solid ButtonText;
-    color: ButtonText;
+    color: FieldText;
   }
 }
 .in-progress #spinner {


### PR DESCRIPTION
1. Moving most of the `prefers-contrast` queries to `forced-colors` to ensure the HCM only applies to WinOS. This would ensure the Increase Contrast mode on macOS is appearing as expected. 

2. Correcting the input field on `forced-colors` to use `Field`/`FieldText` color combination with `ButtonText` border, as recommended by @MReschenberg [in the comments to the original patch](https://github.com/mozsearch/mozsearch/pull/697#discussion_r1526755458)

3. I'm retaining the border for the blame dialog to be added on `prefers-contrast` modes across OSes to ensure the dialog is visually clearly discernible from the underlying page content.