### PR TITLE
Warning cleanup: allow dead_code for command args

### DIFF
--- a/tools/src/cmd_pipeline/cmd_fuse_crossrefs.rs
+++ b/tools/src/cmd_pipeline/cmd_fuse_crossrefs.rs
@@ -19,6 +19,7 @@ use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, S
 #[derive(Debug, Args)]
 pub struct FuseCrossrefs {}
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct FuseCrossrefsCommand {
     pub args: FuseCrossrefs,

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -21,6 +21,7 @@ use crate::{
 #[derive(Debug, Args)]
 pub struct ProductionFilter {}
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ProductionFilterCommand {
     pub args: ProductionFilter,

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -23,6 +23,7 @@ use crate::{
 #[derive(Debug, Args)]
 pub struct ShowHtml {}
 
+#[allow(dead_code)]
 #[derive(Debug)]
 pub struct ShowHtmlCommand {
     pub args: ShowHtml,


### PR DESCRIPTION
I realized I hadn't re-provisioned or run `rustup update` recently in the docker VM; these also existed but were very easy to make go away for a net time savings in terms of searchfox emails.