### PR TITLE
Use mode=hier for neato per graphviz forum suggestion

### DIFF
--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -751,7 +751,7 @@ impl SymbolGraphCollection {
         // somewhat reasonable for now.
         match graph_layout {
             GraphLayout::Neato => {
-                dot_graph.add_stmt(stmt!(node!("graph"; attr!("overlap","prism"))));
+                dot_graph.add_stmt(stmt!(node!("graph"; attr!("overlap","prism"), attr!("mode","hier"), attr!("sep",esc "+10"))));
             }
             _ => {}
         }
@@ -1612,7 +1612,6 @@ impl HierarchicalNode {
                     rows: vec![],
                     columns_needed: 0,
                 };
-                
 
                 table.rows.push(LabelRow {
                     cells: vec![LabelCell {
@@ -2012,7 +2011,7 @@ pub enum EdgeKind {
     Composition,    // solid line, closed diamond ("diamond")
     Aggregation,    // solid line, open diamond ("odiamond")
     // These are more specific searchfox concepts
-    IPC, // dotted line, weird vee arrow ("vee")
+    IPC,           // dotted line, weird vee arrow ("vee")
     CrossLanguage, // JNI-like; solid line, left-half-closed arrow ("lnormal")
 }
 


### PR DESCRIPTION
In a graphviz forum post it was mentioned that neato has a hier mode (see https://graphviz.org/docs/attrs/mode/) which attempts a top-down layout.  A notable piece of feedback for the neato/sfdp layouts versus the default dot layout was that they were much more stressful to look at, even if they provided potentially more useful density.  This was trivial to quickly hack in and A/B test thanks to previous efforts in this space.

In particular, this mode seems quite nice for larger inheritance diagrams, but one notable thing was self-edges for XPCOM interfaces where the pretty identifier for the XPCOM interface are the same for the C++ class overlapping adjacent nodes.  To this end, I also increased the "sep" margin (https://graphviz.org/docs/attrs/sep/).