### PR TITLE
Bug 1873574 - Update mozsearch clang plugin to support clang-18

### DIFF
--- a/clang-plugin/BindingOperations.cpp
+++ b/clang-plugin/BindingOperations.cpp
@@ -8,6 +8,7 @@
 #include <clang/AST/Attr.h>
 #include <clang/AST/Expr.h>
 #include <clang/AST/RecursiveASTVisitor.h>
+#include <clang/Basic/Version.h>
 
 #include <algorithm>
 #include <array>
@@ -173,10 +174,15 @@ constexpr StringRef BoundAs::ANNOTATION;
 template<typename B>
 void setBindingAttr(ASTContext &C, Decl &decl, B binding)
 {
+#if CLANG_VERSION_MAJOR >= 18
+  auto utf8 = StringLiteralKind::UTF8;
+#else
+  auto utf8 = StringLiteral::UTF8;
+#endif
   // recent LLVM: CreateImplicit then setDelayedArgs
-  Expr *langExpr = StringLiteral::Create(C, AbstractBinding::stringFromLang(binding.lang), StringLiteral::UTF8, false, {}, {});
-  Expr *kindExpr = StringLiteral::Create(C, AbstractBinding::stringFromKind(binding.kind), StringLiteral::UTF8, false, {}, {});
-  Expr *symbolExpr = StringLiteral::Create(C, binding.symbol, StringLiteral::UTF8, false, {}, {});
+  Expr *langExpr = StringLiteral::Create(C, AbstractBinding::stringFromLang(binding.lang), utf8, false, {}, {});
+  Expr *kindExpr = StringLiteral::Create(C, AbstractBinding::stringFromKind(binding.kind), utf8, false, {}, {});
+  Expr *symbolExpr = StringLiteral::Create(C, binding.symbol, utf8, false, {}, {});
   auto **args = new (C, 16) Expr *[3]{langExpr, kindExpr, symbolExpr};
   auto *attr = AnnotateAttr::CreateImplicit(C, B::ANNOTATION, args, 3);
   decl.addAttr(attr);

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -138,6 +138,14 @@ struct RAIITracer {
 
 class IndexConsumer;
 
+bool isPure(FunctionDecl* D) {
+#if CLANG_VERSION_MAJOR >= 18
+  return D->isPureVirtual();
+#else
+  return D->isPure();
+#endif
+}
+
 // For each C++ file seen by the analysis (.cpp or .h), we track a
 // FileInfo. This object tracks whether the file is "interesting" (i.e., whether
 // it's in the source dir or the objdir). We also store the analysis output
@@ -1749,7 +1757,7 @@ public:
         D = D2->getTemplateInstantiationPattern();
       }
       // We treat pure virtual declarations as definitions.
-      Kind = (D2->isThisDeclarationADefinition() || D2->isPure()) ? "def" : "decl";
+      Kind = (D2->isThisDeclarationADefinition() || isPure(D2)) ? "def" : "decl";
       PrettyKind = "function";
       PeekRange = getFunctionPeekRange(D2);
 
@@ -1881,7 +1889,7 @@ public:
       }
     }
     if (FunctionDecl *D2 = dyn_cast<FunctionDecl>(D)) {
-      if ((D2->isThisDeclarationADefinition() || D2->isPure()) &&
+      if ((D2->isThisDeclarationADefinition() || isPure(D2)) &&
           // a clause at the top should have generalized and set wasTemplate so
           // it shouldn't be the case that isTemplateInstantiation() is true.
           !D2->isTemplateInstantiation() &&


### PR DESCRIPTION
(This is :asuth propagating the patch from
https://phabricator.services.mozilla.com/D208723 into mozsearch.)