### PR TITLE
Bug 1894860 - clang 19 clang-indexer updates

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -199,7 +199,12 @@ public:
 #endif
                                   StringRef SearchPath,
                                   StringRef RelativePath,
+#if CLANG_VERSION_MAJOR >= 19
+                                  const Module *SuggestedModule,
+                                  bool ModuleImported,
+#else
                                   const Module *Imported,
+#endif
                                   SrcMgr::CharacteristicKind FileType) override;
 
   virtual void MacroDefined(const Token &Tok,
@@ -2343,7 +2348,12 @@ void PreprocessorHook::InclusionDirective(SourceLocation HashLoc,
 #endif
                                           StringRef SearchPath,
                                           StringRef RelativePath,
+#if CLANG_VERSION_MAJOR >= 19
+                                          const Module *SuggestedModule,
+                                          bool ModuleImported,
+#else
                                           const Module *Imported,
+#endif
                                           SrcMgr::CharacteristicKind FileType) {
 #if CLANG_VERSION_MAJOR >= 15
   if (!File) {


### PR DESCRIPTION
(This is :asuth propagating the patch from
https://phabricator.services.mozilla.com/D209325 into mozsearch.)