### PR TITLE
Bug 1895160 - Reflect the forward declaration and the single-line function definition to the selected symbol

### DIFF
--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -303,7 +303,7 @@ var DocumentTitler = new (class DocumentTitler {
       containers.add(nestingContainer);
     }
 
-    for (let depth = maxDepth; depth > 0; depth--) {
+    for (let depth = maxDepth; depth >= 0; depth--) {
       if (!containersPerDepth.has(depth)) {
         continue;
       }

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -266,6 +266,9 @@ var DocumentTitler = new (class DocumentTitler {
     for (const line of [...lines].sort()) {
       const selectedLine = document.getElementById(`line-${line}`);
       const nestingContainer = selectedLine?.closest(".nesting-container");
+      if (!nestingContainer) {
+        continue;
+      }
 
       if (nestingContainer === lastContainer) {
         continue;


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1895160

This allows "Symbol Link" in the following case:
  * forward declaration  (e.g. `BoxNonStrictThis` line in https://searchfox.org/mozilla-central/source/js/src/vm/Interpreter.h#30 )
  * single-line function definition (e.g. `Breakpoint::nextInDebugger()` line in https://searchfox.org/mozilla-central/source/js/src/debugger/Debugger.cpp#474 )
  * a selection in nesting container with depth == 0 (e.g. lines in `js::BoxNonStrictThis` in https://searchfox.org/mozilla-central/source/js/src/vm/Interpreter.cpp#107) 
