### PR TITLE
Bug 1895316 - Linkify string literal with chrome:// and resource:// in JS files

### DIFF
--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -15,5 +15,5 @@ TREE_NAME=$2
 
 cat $INDEX_ROOT/js-files | \
     parallel --halt 2 js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- {#} \
-    $MOZSEARCH_PATH $FILES_ROOT/{} ">" $INDEX_ROOT/analysis/{}
+    $MOZSEARCH_PATH $FILES_ROOT/{} {} $INDEX_ROOT/url-map.json ">" $INDEX_ROOT/analysis/{}
 echo $?

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -66,6 +66,10 @@ $MOZSEARCH_PATH/scripts/objdir-mkdirs.sh
 
 date
 
+$MOZSEARCH_PATH/scripts/process-chrome-map.py $GIT_ROOT $INDEX_ROOT/chrome-map.json $INDEX_ROOT/url-map.json || handle_tree_error "process-chrome-map.py"
+
+date
+
 $MOZSEARCH_PATH/scripts/js-analyze.sh $CONFIG_FILE $TREE_NAME || handle_tree_error "js-analyze.sh"
 
 date

--- a/scripts/process-chrome-map.py
+++ b/scripts/process-chrome-map.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import glob
+import json
+import os
+import sys
+
+topsrcdir = sys.argv[1]
+chrome_map_path = sys.argv[2]
+url_map_path = sys.argv[3]
+
+# If chrome-map.json is not provided for the repository, create a dummy file.
+if not os.path.exists(chrome_map_path):
+    with open(url_map_path, "w") as f:
+        json.dump({}, f)
+    sys.exit(0)
+
+with open(chrome_map_path, "r") as f:
+    url_prefixes, overrides, install_info, buildconfig = json.load(f)
+
+# See mozilla-central/python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py.
+if "resource:///" not in url_prefixes:
+    url_prefixes["resource:///"] = ["dist/bin/browser"]
+if "resource://gre/" not in url_prefixes:
+    url_prefixes["resource://gre/"] = ["dist/bin"]
+
+reverse_prefixes = {}
+for from_prefix, to_prefixes in url_prefixes.items():
+    for to_prefix in to_prefixes:
+        reverse_prefixes[to_prefix] = from_prefix
+
+
+def map_path(path):
+    """Returns all mapped URLs for given path or URL."""
+    for from_prefix, to_prefix in reverse_prefixes.items():
+        if path.startswith(from_prefix):
+            mapped = to_prefix + path[len(from_prefix) + 1:]
+            yield mapped
+
+            yield from map_path(mapped)
+
+
+def get_overrides(url):
+    """Returns all overridden URLs for given URL."""
+    for to_name, from_name in overrides.items():
+        if from_name == url:
+            yield to_name
+
+            yield from get_overrides(to_name)
+
+
+def add_entries(url_map, src, obj):
+    urls = list(map_path(obj))
+    if len(urls) == 0:
+        return
+
+    overridden_urls = []
+    for url in urls:
+        overridden_urls += get_overrides(url)
+    urls += overridden_urls
+
+    for url in urls:
+        url_map[url] = src
+
+
+url_map = {}
+for obj, item in install_info.items():
+    src = item[0]
+
+    if "*" in src:
+        # The source path is written with glob.
+        # Handle all matching files.
+        for src_path in glob.glob(src, root_dir=topsrcdir):
+            obj_path = os.path.join(obj, os.path.basename(src_path))
+            add_entries(url_map, src_path, obj_path)
+    else:
+        add_entries(url_map, src, obj)
+
+with open(url_map_path, "w") as f:
+    json.dump(url_map, f)


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1895316
depends on https://github.com/mozsearch/mozsearch-mozilla/pull/232

This does the following:
  1. process the `chrome-map.json` into "URL to file path" map, and save it as `url-map.json`
  2. in `js-analyze.js`:
    1. add the link target at the top of the file, with the file path
    2. for each string literal with `chrome://` or `resource://`
      1. lazily load `url-map.json`, and lookup the file path for the URL
      2. add the link source for the string literal, with the target file path

with the today's m-c, the `chrome-map.json` is 1,685,516 bytes, and the processed `url-map.json` becomes 1,977,829 bytes.
So, for each JS file with `chrome://` or `resource://` string literal, the `js-analyze.js` loads and parses ~2MB JSON file.  If this is too problematic, I'll look into reducing the cost (e.g. use URL instead of file path, or split the JSON into smaller chunk, etc).
