### PR TITLE
Use -v option for the date command on macOS in indexer-logs-fetch.sh

### DIFF
--- a/scripts/indexer-logs-fetch.sh
+++ b/scripts/indexer-logs-fetch.sh
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 
+if [ $(uname) == "Darwin" ]; then
+    YESTERDAY=$(date -Idate -v -1d)
+else
+    YESTERDAY=$(date -Idate --date='1 days ago')
+fi
+
 # AFAICT in order to download a specific set of files, we need to use recursive
 # and exclude everything and then only include what we want.  The following
 # works:
-aws s3 cp s3://indexer-logs/ . --recursive --exclude '*' --include "index-$(date -Idate --date='1 days ago')*.gz"
+aws s3 cp s3://indexer-logs/ . --recursive --exclude '*' --include "index-${YESTERDAY}*.gz"
 # grep -z doesn't work on gzipped things, so de-gzip them
 gunzip *.gz
 


### PR DESCRIPTION
macOS's date command doesn't support `--date` option, but it has `-v` option to adjust the date