### PR TITLE
Copy config_repo to trypush and nss temporary config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ serve-trees: check-in-vagrant build-clang-plugin build-rust-tools
 # from config.json and puts the stripped version into trypush.json.
 trypush: check-in-vagrant build-clang-plugin build-rust-tools
 	[ -d ~/mozilla-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/mozilla-config
-	jq '{mozsearch_path, default_tree, trees: {"mozilla-central": .trees["mozilla-central"]}}' ~/mozilla-config/config1.json > ~/mozilla-config/trypush.json
+	jq '{mozsearch_path, config_repo, default_tree, trees: {"mozilla-central": .trees["mozilla-central"]}}' ~/mozilla-config/config1.json > ~/mozilla-config/trypush.json
 	mkdir -p ~/trypush-index
 	/vagrant/infrastructure/indexer-setup.sh ~/mozilla-config trypush.json ~/trypush-index
 	/vagrant/infrastructure/indexer-run.sh ~/mozilla-config ~/trypush-index
@@ -147,7 +147,7 @@ trypush: check-in-vagrant build-clang-plugin build-rust-tools
 
 nss-reblame: check-in-vagrant build-rust-tools
 	[ -d ~/mozilla-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/mozilla-config
-	jq '{mozsearch_path, default_tree, trees: {"nss": .trees["nss"]}}' ~/mozilla-config/config1.json > ~/mozilla-config/nss.json
+	jq '{mozsearch_path, config_repo, default_tree, trees: {"nss": .trees["nss"]}}' ~/mozilla-config/config1.json > ~/mozilla-config/nss.json
 	mkdir -p ~/reblame
 	/vagrant/infrastructure/reblame-run.sh ~/mozilla-config nss.json ~/reblame
 


### PR DESCRIPTION
missing `config_repo` in the copied config results in the following error while running `TRYPUSH_REV=... make trypush`

```
+ /vagrant/tools/target/release/scip-indexer /home/vagrant/trypush-index/config.json mozilla-central --subtree-root . --platform ios objdir-ios/rust.scip
thread 'main' panicked at src/file_format/config.rs:237:59:
called `Result::unwrap()` on an `Err` value: Error("missing field `config_repo`", line: 28, column: 1)
stack backtrace:
   0: rust_begin_unwind
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/std/src/panicking.rs:652:5
   1: core::panicking::panic_fmt
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/panicking.rs:72:14
   2: core::result::unwrap_failed
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/result.rs:1654:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/result.rs:1077:23
   4: tools::file_format::config::load
             at /vagrant/tools/src/file_format/config.rs:237:30
   5: scip_indexer::main
             at /vagrant/tools/src/bin/scip-indexer.rs:1332:15
   6: core::ops::function::FnOnce::call_once
             at /rustc/c987ad527540e8f1565f57c31204bde33f63df76/library/core/src/ops/function.rs:250:5
```