### PR TITLE
Bug 1896165 - Use chrome-map.json files from searchfox jobs

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1488,13 +1488,15 @@ let Analyzer = {
     if (!(expr.value in urlMap)) {
       return;
     }
-    const targetPath = urlMap[expr.value];
+    const targetPaths = urlMap[expr.value];
 
     const name = "\"" + expr.value + "\"";
     const loc = expr.loc;
-    const sym = "FILE_" + atEscape(targetPath);
-    this.source(loc, name, "file,use", "file " + targetPath, sym);
-    this.target(loc, name, "use", targetPath, sym);
+    for (const targetPath of targetPaths) {
+      const sym = "FILE_" + atEscape(targetPath);
+      this.source(loc, name, "file,use", "file " + targetPath, sym);
+      this.target(loc, name, "use", targetPath, sym);
+    }
   },
 };
 

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -66,7 +66,7 @@ $MOZSEARCH_PATH/scripts/objdir-mkdirs.sh
 
 date
 
-$MOZSEARCH_PATH/scripts/process-chrome-map.py $GIT_ROOT $INDEX_ROOT/chrome-map.json $INDEX_ROOT/url-map.json || handle_tree_error "process-chrome-map.py"
+$MOZSEARCH_PATH/scripts/process-chrome-map.py $GIT_ROOT $INDEX_ROOT/url-map.json $INDEX_ROOT/*.chrome-map.json || handle_tree_error "process-chrome-map.py"
 
 date
 

--- a/scripts/process-chrome-map.py
+++ b/scripts/process-chrome-map.py
@@ -5,76 +5,82 @@ import json
 import os
 import sys
 
-topsrcdir = sys.argv[1]
-chrome_map_path = sys.argv[2]
-url_map_path = sys.argv[3]
 
-# If chrome-map.json is not provided for the repository, create a dummy file.
-if not os.path.exists(chrome_map_path):
-    with open(url_map_path, "w") as f:
-        json.dump({}, f)
-    sys.exit(0)
-
-with open(chrome_map_path, "r") as f:
-    url_prefixes, overrides, install_info, buildconfig = json.load(f)
-
-# See mozilla-central/python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py.
-if "resource:///" not in url_prefixes:
-    url_prefixes["resource:///"] = ["dist/bin/browser"]
-if "resource://gre/" not in url_prefixes:
-    url_prefixes["resource://gre/"] = ["dist/bin"]
-
-reverse_prefixes = {}
-for from_prefix, to_prefixes in url_prefixes.items():
-    for to_prefix in to_prefixes:
-        reverse_prefixes[to_prefix] = from_prefix
-
-
-def map_path(path):
-    """Returns all mapped URLs for given path or URL."""
-    for from_prefix, to_prefix in reverse_prefixes.items():
-        if path.startswith(from_prefix):
-            mapped = to_prefix + path[len(from_prefix) + 1:]
-            yield mapped
-
-            yield from map_path(mapped)
-
-
-def get_overrides(url):
-    """Returns all overridden URLs for given URL."""
-    for to_name, from_name in overrides.items():
-        if from_name == url:
-            yield to_name
-
-            yield from get_overrides(to_name)
-
-
-def add_entries(url_map, src, obj):
-    urls = list(map_path(obj))
-    if len(urls) == 0:
+def process_chrome_map(url_map, chrome_map_path, topsrcdir):
+    if not os.path.exists(chrome_map_path):
         return
 
-    overridden_urls = []
-    for url in urls:
-        overridden_urls += get_overrides(url)
-    urls += overridden_urls
+    with open(chrome_map_path, "r") as f:
+        url_prefixes, overrides, install_info, buildconfig = json.load(f)
 
-    for url in urls:
-        url_map[url] = src
+    # See m-c/python/mozbuild/mozbuild/codecoverage/lcov_rewriter.py.
+    if "resource:///" not in url_prefixes:
+        url_prefixes["resource:///"] = ["dist/bin/browser"]
+    if "resource://gre/" not in url_prefixes:
+        url_prefixes["resource://gre/"] = ["dist/bin"]
 
+    reverse_prefixes = {}
+    for from_prefix, to_prefixes in url_prefixes.items():
+        for to_prefix in to_prefixes:
+            reverse_prefixes[to_prefix] = from_prefix
+
+
+    def map_path(path):
+        """Returns all mapped URLs for given path or URL."""
+        for from_prefix, to_prefix in reverse_prefixes.items():
+            if path.startswith(from_prefix):
+                mapped = to_prefix + path[len(from_prefix) + 1:]
+                yield mapped
+
+                yield from map_path(mapped)
+
+
+    def get_overrides(url):
+        """Returns all overridden URLs for given URL."""
+        for to_name, from_name in overrides.items():
+            if from_name == url:
+                yield to_name
+
+                yield from get_overrides(to_name)
+
+
+    def add_entries(url_map, src, obj):
+        urls = list(map_path(obj))
+        if len(urls) == 0:
+            return
+
+        overridden_urls = []
+        for url in urls:
+            overridden_urls += get_overrides(url)
+        urls += overridden_urls
+
+        for url in urls:
+            if url not in url_map:
+                url_map[url] = []
+            if src not in url_map[url]:
+                url_map[url].append(src)
+
+
+    for obj, item in install_info.items():
+        src = item[0]
+
+        if "*" in src:
+            # The source path is written with glob.
+            # Handle all matching files.
+            for src_path in glob.glob(src, root_dir=topsrcdir):
+                obj_path = os.path.join(obj, os.path.basename(src_path))
+                add_entries(url_map, src_path, obj_path)
+        else:
+            add_entries(url_map, src, obj)
+
+
+topsrcdir = sys.argv[1]
+url_map_path = sys.argv[2]
+chrome_map_paths = sys.argv[3:]
 
 url_map = {}
-for obj, item in install_info.items():
-    src = item[0]
-
-    if "*" in src:
-        # The source path is written with glob.
-        # Handle all matching files.
-        for src_path in glob.glob(src, root_dir=topsrcdir):
-            obj_path = os.path.join(obj, os.path.basename(src_path))
-            add_entries(url_map, src_path, obj_path)
-    else:
-        add_entries(url_map, src, obj)
+for path in chrome_map_paths:
+    process_chrome_map(url_map, path, topsrcdir)
 
 with open(url_map_path, "w") as f:
     json.dump(url_map, f)


### PR DESCRIPTION
depends on https://bugzilla.mozilla.org/show_bug.cgi?id=1895989 and https://github.com/mozsearch/mozsearch-mozilla/pull/234

bug 1895989 will add `chrome-map.json` to the artifact of searchfox(idx) job, for each OS.
This combines all `chrome-map.json` info into single `url-map.json`, with using array of strings instead of string for each mapping, so that single URL can be mapped to multiple files if it's conditional on OS.
e.g. `resource://passwordmgr/passwordstorage.sys.mjs` maps to `toolkit/components/passwordmgr/storage-desktop.sys.mjs` on desktop and `toolkit/components/passwordmgr/storage-geckoview.sys.mjs` on android.

The `js-analyze.js` is modified to use the array and generate source/target for each.

<img width="720" alt="resource-link-per-os" src="https://github.com/mozsearch/mozsearch/assets/6299746/451854e9-f4e1-4687-9d2d-a050726aaa10">
