### PR TITLE
Make HTML handling robust against invalid input

### DIFF
--- a/sax/sax.js
+++ b/sax/sax.js
@@ -938,6 +938,11 @@
       return '&' + parser.entity + ';'
     }
 
+    if (num < 0 || num > 0x10FFFF) {
+      strictFail(parser, 'Invalid character entity')
+      return '&' + parser.entity + ';'
+    }
+
     return String.fromCodePoint(num)
   }
 

--- a/sax/sax.patch
+++ b/sax/sax.patch
@@ -1,5 +1,5 @@
 --- ../../sax-js/lib/sax.js	2023-08-17 15:40:28.000000000 -0400
-+++ sax.js	2024-05-15 04:32:52.022807396 +0900
++++ sax.js	2024-05-17 02:02:31
 @@ -335,17 +335,20 @@
      ATTRIB_VALUE_QUOTED: S++, // <a foo="bar
      ATTRIB_VALUE_CLOSED: S++, // <a foo="bar"
@@ -96,7 +96,29 @@
        tagName = tagName[parser.looseCase]()
      }
      var closeTo = tagName
-@@ -1041,29 +1041,80 @@
+@@ -929,16 +929,21 @@
+       } else {
+         entity = entity.slice(1)
+         num = parseInt(entity, 10)
+         numStr = num.toString(10)
+       }
+     }
+     entity = entity.replace(/^0+/, '')
+     if (isNaN(num) || numStr.toLowerCase() !== entity) {
++      strictFail(parser, 'Invalid character entity')
++      return '&' + parser.entity + ';'
++    }
++
++    if (num < 0 || num > 0x10FFFF) {
+       strictFail(parser, 'Invalid character entity')
+       return '&' + parser.entity + ';'
+     }
+ 
+     return String.fromCodePoint(num)
+   }
+ 
+   function beginWhiteSpace (parser, c) {
+@@ -1041,30 +1046,81 @@
              }
            }
            continue
@@ -138,7 +160,7 @@
            }
            continue
 +        }
-+
+ 
 +        case S.SCRIPT_COMMENT_START: {
 +          parser.script += c
 +          parser.scriptCommentStart += c
@@ -174,7 +196,7 @@
 +          }
 +          continue
 +        }
- 
++
          case S.OPEN_WAKA:
            // either a /, ?, !, or text is coming next.
            if (c === '!') {
@@ -182,7 +204,8 @@
              parser.sgmlDecl = ''
            } else if (isWhitespace(c)) {
              // wait for it...
-@@ -1302,16 +1353,18 @@
+           } else if (isMatch(nameStart, c)) {
+@@ -1302,16 +1358,18 @@
            if (isWhitespace(c)) {
              continue
            } else if (c === '>') {
@@ -201,7 +224,7 @@
            continue
  
          case S.ATTRIB_NAME:
-@@ -1335,43 +1388,51 @@
+@@ -1335,43 +1393,51 @@
            if (c === '=') {
              parser.state = S.ATTRIB_VALUE
            } else if (isWhitespace(c)) {
@@ -253,7 +276,7 @@
              if (c === '&') {
                parser.state = S.ATTRIB_VALUE_ENTITY_Q
              } else {
-@@ -1389,16 +1450,18 @@
+@@ -1389,16 +1455,18 @@
              parser.state = S.ATTRIB
            } else if (c === '>') {
              openTag(parser)
@@ -272,7 +295,7 @@
            continue
  
          case S.ATTRIB_VALUE_UNQUOTED:
-@@ -1418,33 +1481,24 @@
+@@ -1418,33 +1486,24 @@
            }
            continue
  

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -110,6 +110,11 @@ const FILENAME_INTERVENTIONS = [
     prepend: "It may intentionally be illegal JS: ",
   },
   {
+    includes_list: ["parser/htmlparser/tests"],
+    severity: "INFO",
+    prepend: "It may be testing script tag handling: ",
+  },
+  {
     // Session Store has some JSON files with .js extensions.  .eslintignore
     // does already know about them, but until my work on file ingestion lands
     // we lack an easy way to filter the JS ingestion set.

--- a/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
+++ b/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
@@ -18,6 +18,19 @@ expression: "&to_value(fm).unwrap()"
       }
     },
     {
+      "path": "html/invalid-entity-ref.html",
+      "concise": {
+        "path_kind": "Normal",
+        "is_dir": false,
+        "file_size": 232,
+        "bugzilla_component": null,
+        "subsystem": null,
+        "tags": [],
+        "description": "Parser shouldn't fail with invalid entity references",
+        "info": {}
+      }
+    },
+    {
       "path": "html/script.html",
       "concise": {
         "path_kind": "Normal",

--- a/tests/tests/files/html/invalid-entity-ref.html
+++ b/tests/tests/files/html/invalid-entity-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Parser shouldn't fail with invalid entity references</title>
+  </head>
+  <body>
+    &#xFFFFFF;
+    &#x00FFFFFF;
+    &#16777215;
+    &something;
+  </body>
+</html>


### PR DESCRIPTION
 * `parser/htmlparser/tests` directory tends to contain invalid HTML, which includes malformed `<script>`.
 * Now that HTML files are fed to `sax.js`, there can be tests for entity references which contains invalid value
