### PR TITLE
Fix chrome-map override direction

### DIFF
--- a/scripts/process-chrome-map.py
+++ b/scripts/process-chrome-map.py
@@ -38,10 +38,10 @@ def process_chrome_map(url_map, chrome_map_path, topsrcdir):
     def get_overrides(url):
         """Returns all overridden URLs for given URL."""
         for to_name, from_name in overrides.items():
-            if from_name == url:
-                yield to_name
+            if to_name == url:
+                yield from_name
 
-                yield from get_overrides(to_name)
+                yield from get_overrides(from_name)
 
 
     def add_entries(url_map, src, obj):

--- a/tests/tests/checks/snapshots/analysis/urlmap/root.html/check_glob@url_use_in_html__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/root.html/check_glob@url_use_in_html__json.snap
@@ -229,6 +229,36 @@ expression: "&json_results"
     "context": ""
   },
   {
+    "loc": "39:31-71",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome1.mjs",
+    "sym": "FILE_urlmap/chrome1@2Emjs"
+  },
+  {
+    "loc": "39:31-71",
+    "target": 1,
+    "kind": "use",
+    "pretty": "urlmap/chrome1.mjs",
+    "sym": "FILE_urlmap/chrome1@2Emjs",
+    "context": ""
+  },
+  {
+    "loc": "40:31-60",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/resource1.mjs",
+    "sym": "FILE_urlmap/resource1@2Emjs"
+  },
+  {
+    "loc": "40:31-60",
+    "target": 1,
+    "kind": "use",
+    "pretty": "urlmap/resource1.mjs",
+    "sym": "FILE_urlmap/resource1@2Emjs",
+    "context": ""
+  },
+  {
     "loc": "42:14-43",
     "source": 1,
     "syntax": "file,use",

--- a/tests/tests/checks/snapshots/analysis/urlmap/root.xhtml/check_glob@url_use_in_xhtml__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/root.xhtml/check_glob@url_use_in_xhtml__json.snap
@@ -229,6 +229,36 @@ expression: "&json_results"
     "context": ""
   },
   {
+    "loc": "44:31-71",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome1.mjs",
+    "sym": "FILE_urlmap/chrome1@2Emjs"
+  },
+  {
+    "loc": "44:31-71",
+    "target": 1,
+    "kind": "use",
+    "pretty": "urlmap/chrome1.mjs",
+    "sym": "FILE_urlmap/chrome1@2Emjs",
+    "context": ""
+  },
+  {
+    "loc": "45:31-60",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/resource1.mjs",
+    "sym": "FILE_urlmap/resource1@2Emjs"
+  },
+  {
+    "loc": "45:31-60",
+    "target": 1,
+    "kind": "use",
+    "pretty": "urlmap/resource1.mjs",
+    "sym": "FILE_urlmap/resource1@2Emjs",
+    "context": ""
+  },
+  {
     "loc": "46:14-54",
     "source": 1,
     "syntax": "file,use",


### PR DESCRIPTION
The chrome-map's override should've been handled in the opposite way.