### PR TITLE
Handle imported and exported symbols and related expressions

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -364,6 +364,13 @@ SymbolTable.Symbol.prototype = {
   },
 };
 
+function isSameLocation(loc1, loc2) {
+  return loc1.start.line == loc2.start.line &&
+    loc1.start.column == loc2.start.column &&
+    loc1.end.line == loc2.end.line &&
+    loc1.end.column == loc2.end.column;
+}
+
 function posBefore(pos1, pos2) {
   return pos1.line < pos2.line ||
          (pos1.line == pos2.line && pos1.column < pos2.column);
@@ -1057,6 +1064,18 @@ let Analyzer = {
     }
 
     case "ImportDeclaration": {
+      for (const spec of stmt.specifiers) {
+        if (spec.type === "ImportSpecifier" ||
+            spec.type === "ImportNamespaceSpecifier") {
+          this.pattern(spec.name);
+
+          if (spec.type === "ImportSpecifier" &&
+              !isSameLocation(spec.id.loc, spec.name.loc)) {
+            this.expression(spec.id);
+          }
+        }
+      }
+
       if (stmt.moduleRequest && stmt.moduleRequest.source &&
           stmt.moduleRequest.source.type === "Literal") {
         this.maybeLinkifyLiteral(stmt.moduleRequest.source);

--- a/tests/tests/checks/inputs/analysis/js/export.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export.mjs/exported_use__json
+++ b/tests/tests/checks/inputs/analysis/js/export.mjs/exported_use__json
@@ -1,0 +1,1 @@
+filter-analysis js/export.mjs -k use

--- a/tests/tests/checks/inputs/analysis/js/export2.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export2.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export2.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export2.mjs/exported_use__json
+++ b/tests/tests/checks/inputs/analysis/js/export2.mjs/exported_use__json
@@ -1,0 +1,1 @@
+filter-analysis js/export2.mjs -k use

--- a/tests/tests/checks/inputs/analysis/js/export3.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export3.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export3.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export4.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export4.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export4.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export5.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export5.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export5.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export6.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export6.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export6.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/export7.mjs/exported_decls__json
+++ b/tests/tests/checks/inputs/analysis/js/export7.mjs/exported_decls__json
@@ -1,0 +1,1 @@
+filter-analysis js/export7.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/import.mjs/imported_symbols__json
+++ b/tests/tests/checks/inputs/analysis/js/import.mjs/imported_symbols__json
@@ -1,0 +1,1 @@
+filter-analysis js/import.mjs -k def

--- a/tests/tests/checks/inputs/analysis/js/import.mjs/imported_symbols_use__json
+++ b/tests/tests/checks/inputs/analysis/js/import.mjs/imported_symbols_use__json
@@ -1,0 +1,1 @@
+filter-analysis js/import.mjs -k use

--- a/tests/tests/checks/snapshots/analysis/js/export.mjs/check_glob@exported_decls__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export.mjs/check_glob@exported_decls__json.snap
@@ -1,0 +1,255 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export.mjs",
+    "sym": "FILE_js/export@2Emjs"
+  },
+  {
+    "loc": "1:11-18",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property letDecl",
+    "sym": "#letDecl"
+  },
+  {
+    "loc": "1:11-18",
+    "target": 1,
+    "kind": "def",
+    "pretty": "letDecl",
+    "sym": "#letDecl",
+    "context": ""
+  },
+  {
+    "loc": "2:13-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property constDecl",
+    "sym": "#constDecl"
+  },
+  {
+    "loc": "2:13-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "constDecl",
+    "sym": "#constDecl",
+    "context": ""
+  },
+  {
+    "loc": "3:16-23",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property funDecl",
+    "sym": "#funDecl",
+    "nestingRange": "3:26-3:27"
+  },
+  {
+    "loc": "3:16-23",
+    "target": 1,
+    "kind": "def",
+    "pretty": "funDecl",
+    "sym": "#funDecl",
+    "context": ""
+  },
+  {
+    "loc": "4:13-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property classDecl",
+    "sym": "#classDecl",
+    "nestingRange": "4:22-4:24"
+  },
+  {
+    "loc": "4:13-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "classDecl",
+    "sym": "#classDecl",
+    "context": ""
+  },
+  {
+    "loc": "5:4-9",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "5:4-9",
+    "target": 1,
+    "kind": "def",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  },
+  {
+    "loc": "5:15-21",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property local1",
+    "sym": "#local1"
+  },
+  {
+    "loc": "5:15-21",
+    "target": 1,
+    "kind": "def",
+    "pretty": "local1",
+    "sym": "#local1",
+    "context": ""
+  },
+  {
+    "loc": "5:27-33",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property local2",
+    "sym": "#local2"
+  },
+  {
+    "loc": "5:27-33",
+    "target": 1,
+    "kind": "def",
+    "pretty": "local2",
+    "sym": "#local2",
+    "context": ""
+  },
+  {
+    "loc": "6:9-15",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property local1",
+    "sym": "#local1"
+  },
+  {
+    "loc": "6:9-15",
+    "target": 1,
+    "kind": "def",
+    "pretty": "local1",
+    "sym": "#local1",
+    "context": ""
+  },
+  {
+    "loc": "6:17-23",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property local2",
+    "sym": "#local2"
+  },
+  {
+    "loc": "6:17-23",
+    "target": 1,
+    "kind": "def",
+    "pretty": "local2",
+    "sym": "#local2",
+    "context": ""
+  },
+  {
+    "loc": "7:18-27",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportAs1",
+    "sym": "#exportAs1"
+  },
+  {
+    "loc": "7:18-27",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportAs1",
+    "sym": "#exportAs1",
+    "context": ""
+  },
+  {
+    "loc": "9:18-25",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property default",
+    "sym": "#default"
+  },
+  {
+    "loc": "9:18-25",
+    "target": 1,
+    "kind": "def",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  },
+  {
+    "loc": "12:12-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportNSAs",
+    "sym": "#exportNSAs"
+  },
+  {
+    "loc": "12:12-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportNSAs",
+    "sym": "#exportNSAs",
+    "context": ""
+  },
+  {
+    "loc": "13:9-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportedName1",
+    "sym": "#exportedName1"
+  },
+  {
+    "loc": "13:9-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportedName1",
+    "sym": "#exportedName1",
+    "context": ""
+  },
+  {
+    "loc": "13:24-37",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportedName2",
+    "sym": "#exportedName2"
+  },
+  {
+    "loc": "13:24-37",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportedName2",
+    "sym": "#exportedName2",
+    "context": ""
+  },
+  {
+    "loc": "14:26-35",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportAs2",
+    "sym": "#exportAs2"
+  },
+  {
+    "loc": "14:26-35",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportAs2",
+    "sym": "#exportAs2",
+    "context": ""
+  },
+  {
+    "loc": "15:20-29",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property defaultAs",
+    "sym": "#defaultAs"
+  },
+  {
+    "loc": "15:20-29",
+    "target": 1,
+    "kind": "def",
+    "pretty": "defaultAs",
+    "sym": "#defaultAs",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export.mjs/check_glob@exported_use__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export.mjs/check_glob@exported_use__json.snap
@@ -1,0 +1,81 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "7:9-14",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "7:9-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  },
+  {
+    "loc": "8:9-14",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "8:9-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  },
+  {
+    "loc": "9:9-14",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "9:9-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  },
+  {
+    "loc": "14:9-22",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property exportedName3",
+    "sym": "#exportedName3"
+  },
+  {
+    "loc": "14:9-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "exportedName3",
+    "sym": "#exportedName3",
+    "context": ""
+  },
+  {
+    "loc": "15:9-16",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property default",
+    "sym": "#default"
+  },
+  {
+    "loc": "15:9-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export2.mjs/check_glob@exported_decls__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export2.mjs/check_glob@exported_decls__json-2.snap
@@ -1,0 +1,28 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export2.mjs",
+    "sym": "FILE_js/export2@2Emjs"
+  },
+  {
+    "loc": "1:4-9",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "1:4-9",
+    "target": 1,
+    "kind": "def",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export2.mjs/check_glob@exported_use__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export2.mjs/check_glob@exported_use__json-2.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "2:15-20",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property dummy",
+    "sym": "#dummy"
+  },
+  {
+    "loc": "2:15-20",
+    "target": 1,
+    "kind": "use",
+    "pretty": "dummy",
+    "sym": "#dummy",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export3.mjs/check_glob@exported_decls__json-3.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export3.mjs/check_glob@exported_decls__json-3.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export3.mjs",
+    "sym": "FILE_js/export3@2Emjs"
+  },
+  {
+    "loc": "1:24-38",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property defaultFunDecl",
+    "sym": "#defaultFunDecl",
+    "nestingRange": "1:41-1:42"
+  },
+  {
+    "loc": "1:24-38",
+    "target": 1,
+    "kind": "def",
+    "pretty": "defaultFunDecl",
+    "sym": "#defaultFunDecl",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export4.mjs/check_glob@exported_decls__json-4.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export4.mjs/check_glob@exported_decls__json-4.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export4.mjs",
+    "sym": "FILE_js/export4@2Emjs"
+  },
+  {
+    "loc": "1:21-37",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property defaultClassDecl",
+    "sym": "#defaultClassDecl",
+    "nestingRange": "1:37-1:39"
+  },
+  {
+    "loc": "1:21-37",
+    "target": 1,
+    "kind": "def",
+    "pretty": "defaultClassDecl",
+    "sym": "#defaultClassDecl",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export5.mjs/check_glob@exported_decls__json-5.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export5.mjs/check_glob@exported_decls__json-5.snap
@@ -1,0 +1,28 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export5.mjs",
+    "sym": "FILE_js/export5@2Emjs"
+  },
+  {
+    "loc": "1:9-16",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property default",
+    "sym": "#default"
+  },
+  {
+    "loc": "1:9-16",
+    "target": 1,
+    "kind": "def",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export6.mjs/check_glob@exported_decls__json-6.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export6.mjs/check_glob@exported_decls__json-6.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export6.mjs",
+    "sym": "FILE_js/export6@2Emjs"
+  },
+  {
+    "loc": "1:15-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property default",
+    "sym": "#default",
+    "nestingRange": "1:27-1:28"
+  },
+  {
+    "loc": "1:15-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/export7.mjs/check_glob@exported_decls__json-7.snap
+++ b/tests/tests/checks/snapshots/analysis/js/export7.mjs/check_glob@exported_decls__json-7.snap
@@ -1,0 +1,29 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/export7.mjs",
+    "sym": "FILE_js/export7@2Emjs"
+  },
+  {
+    "loc": "1:15-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property default",
+    "sym": "#default",
+    "nestingRange": "1:20-1:22"
+  },
+  {
+    "loc": "1:15-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/import.mjs/check_glob@imported_symbols__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/import.mjs/check_glob@imported_symbols__json.snap
@@ -1,0 +1,118 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file js/import.mjs",
+    "sym": "FILE_js/import@2Emjs"
+  },
+  {
+    "loc": "1:7-9",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property ns",
+    "sym": "#ns"
+  },
+  {
+    "loc": "1:7-9",
+    "target": 1,
+    "kind": "def",
+    "pretty": "ns",
+    "sym": "#ns",
+    "context": ""
+  },
+  {
+    "loc": "2:12-16",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property nsAs",
+    "sym": "#nsAs"
+  },
+  {
+    "loc": "2:12-16",
+    "target": 1,
+    "kind": "def",
+    "pretty": "nsAs",
+    "sym": "#nsAs",
+    "context": ""
+  },
+  {
+    "loc": "3:9-22",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportedName1",
+    "sym": "#exportedName1"
+  },
+  {
+    "loc": "3:9-22",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportedName1",
+    "sym": "#exportedName1",
+    "context": ""
+  },
+  {
+    "loc": "3:24-37",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property exportedName2",
+    "sym": "#exportedName2"
+  },
+  {
+    "loc": "3:24-37",
+    "target": 1,
+    "kind": "def",
+    "pretty": "exportedName2",
+    "sym": "#exportedName2",
+    "context": ""
+  },
+  {
+    "loc": "4:26-34",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property importAs",
+    "sym": "#importAs"
+  },
+  {
+    "loc": "4:26-34",
+    "target": 1,
+    "kind": "def",
+    "pretty": "importAs",
+    "sym": "#importAs",
+    "context": ""
+  },
+  {
+    "loc": "5:20-29",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property defaultAs",
+    "sym": "#defaultAs"
+  },
+  {
+    "loc": "5:20-29",
+    "target": 1,
+    "kind": "def",
+    "pretty": "defaultAs",
+    "sym": "#defaultAs",
+    "context": ""
+  },
+  {
+    "loc": "6:26-34",
+    "source": 1,
+    "syntax": "def,prop",
+    "pretty": "property stringAs",
+    "sym": "#stringAs"
+  },
+  {
+    "loc": "6:26-34",
+    "target": 1,
+    "kind": "def",
+    "pretty": "stringAs",
+    "sym": "#stringAs",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/js/import.mjs/check_glob@imported_symbols_use__json.snap
+++ b/tests/tests/checks/snapshots/analysis/js/import.mjs/check_glob@imported_symbols_use__json.snap
@@ -1,0 +1,36 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "4:9-22",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property exportedName3",
+    "sym": "#exportedName3"
+  },
+  {
+    "loc": "4:9-22",
+    "target": 1,
+    "kind": "use",
+    "pretty": "exportedName3",
+    "sym": "#exportedName3",
+    "context": ""
+  },
+  {
+    "loc": "5:9-16",
+    "source": 1,
+    "syntax": "use,prop",
+    "pretty": "property default",
+    "sym": "#default"
+  },
+  {
+    "loc": "5:9-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "default",
+    "sym": "#default",
+    "context": ""
+  }
+]

--- a/tests/tests/files/js/export.mjs
+++ b/tests/tests/files/js/export.mjs
@@ -1,0 +1,15 @@
+export let letDecl;
+export const constDecl = 1;
+export function funDecl() {}
+export class classDecl {}
+let dummy = 0, local1 = 1, local2 = 2;
+export { local1, local2 };
+export { dummy as exportAs1 };
+export { dummy as "export as string" };
+export { dummy as default };
+
+export * from "./mod11.mjs";
+export * as exportNSAs from "./mod12.mjs";
+export { exportedName1, exportedName2 } from "./mod13.mjs";
+export { exportedName3 as exportAs2 } from "./mod14.mjs";
+export { default as defaultAs } from "./mod15.mjs";

--- a/tests/tests/files/js/export2.mjs
+++ b/tests/tests/files/js/export2.mjs
@@ -1,0 +1,2 @@
+let dummy = 0;
+export default dummy;

--- a/tests/tests/files/js/export3.mjs
+++ b/tests/tests/files/js/export3.mjs
@@ -1,0 +1,1 @@
+export default function defaultFunDecl() {}

--- a/tests/tests/files/js/export4.mjs
+++ b/tests/tests/files/js/export4.mjs
@@ -1,0 +1,1 @@
+export default class defaultClassDecl {}

--- a/tests/tests/files/js/export5.mjs
+++ b/tests/tests/files/js/export5.mjs
@@ -1,0 +1,1 @@
+export { default } from "./mod1.mjs";

--- a/tests/tests/files/js/export6.mjs
+++ b/tests/tests/files/js/export6.mjs
@@ -1,0 +1,1 @@
+export default function () {}

--- a/tests/tests/files/js/export7.mjs
+++ b/tests/tests/files/js/export7.mjs
@@ -1,0 +1,1 @@
+export default class {}

--- a/tests/tests/files/js/import.mjs
+++ b/tests/tests/files/js/import.mjs
@@ -1,0 +1,7 @@
+import ns from "./mod1.mjs";
+import * as nsAs from "./mod2.mjs";
+import { exportedName1, exportedName2 } from "./mod3.mjs";
+import { exportedName3 as importAs } from "./mod4.mjs";
+import { default as defaultAs } from "./mod5.mjs";
+import { "string name" as stringAs } from "./mod6.mjs";
+import "./mod7.mjs";


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1897787

This does the following:
  * Define imported symbols: `import { exportedName } from "...";`
  * Handle reference (exported name) inside import declarations:  `import { exportedName as localName } from "...";`
  * Define declarations inside exported declaration in more case: `export default function localName() {}`
  * Handle reference (local name) inside export declarations: `export { localName as exportedName };`
