### PR TITLE
Perform batch processing in js-analyze.js.

### DIFF
--- a/scripts/html-analyze.sh
+++ b/scripts/html-analyze.sh
@@ -13,7 +13,8 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-cat $INDEX_ROOT/html-files | \
-    parallel --halt 2 js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- {#} \
-    $MOZSEARCH_PATH $FILES_ROOT/{} {} ">" $INDEX_ROOT/analysis/{}
+cat $INDEX_ROOT/html-files | nl -w1 -s " " | \
+    parallel --jobs 8 --pipe --halt 2 \
+    js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \
+    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis
 echo $?

--- a/scripts/html-analyze.sh
+++ b/scripts/html-analyze.sh
@@ -13,6 +13,10 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
+# Add line number for the file list with `nl`, which is used as a global
+# fileIndex and used for local variable symbols.
+#
+# See the comment in js-analyze.sh for more details.
 cat $INDEX_ROOT/html-files | nl -w1 -s " " | \
     parallel --jobs 8 --pipe --halt 2 \
     js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \

--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -13,7 +13,8 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-cat $INDEX_ROOT/js-files | \
-    parallel --halt 2 js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- {#} \
-    $MOZSEARCH_PATH $FILES_ROOT/{} {} ">" $INDEX_ROOT/analysis/{}
+cat $INDEX_ROOT/js-files | nl -w1 -s " " | \
+    parallel --jobs 8 --pipe --halt 2 \
+    js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \
+    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis
 echo $?

--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -13,6 +13,12 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
+# Add line number for the file list with `nl`, which is used as a global
+# fileIndex, and used for local variable symbols.
+#
+# NOTE: The index conflicts with html-analyze.sh.
+#       Currently this is not a problem because the index is used only for
+#       local variables with no_crossref symbols.
 cat $INDEX_ROOT/js-files | nl -w1 -s " " | \
     parallel --jobs 8 --pipe --halt 2 \
     js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \


### PR DESCRIPTION
JS shell has `os.file.redirect` which can redirect the `print`/`console.log` call to specified file.

https://searchfox.org/mozilla-central/rev/9508d23ab6de8b0734be2c95303515b08da1ce28/js/src/shell/OSObject.cpp#837-841
```cpp
    JS_FN_HELP("redirect", osfile_redirectOutput, 1, 0,
"redirect([path-or-object])",
"  Redirect print() output to the named file.\n"
"   Return an opaque object representing the previous destination, which\n"
"   may be passed into redirect() later to restore the output."),
```

Also JS shell has `readline` which can read from stdin.

https://searchfox.org/mozilla-central/rev/9508d23ab6de8b0734be2c95303515b08da1ce28/js/src/shell/js.cpp#9266-9268
```cpp
    JS_FN_HELP("readline", ReadLine, 0, 0,
"readline()",
"  Read a single line from stdin."),
```

This patch does the following:
  * Let parallel command to pass the list of files via stdin, with line numbers added, where the line number is the file index for local variables (the file index conflicts between js-analyze vs html-analyze.  I'll address it in another followup)
  * Let js-analyze.js read the list of files from stdin, and write the analysis to specified file instead of stdout
  * rewrite `loadSax` to `ensureSax` to avoid duplicate load
  * reset the global state for each file (maybe we could simplify this by adding global state class or object)

With this, `js-analyze.sh` takes 42 seconds, and `html-analyze.sh` takes 60 seconds on dev indexer instance.