### PR TITLE
Make analysis types generic over Ustr/String and use String variant from css_analyzer.

### DIFF
--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -9,15 +9,12 @@ tonic-build = "0.7.1"
 
 [dependencies]
 cssparser = "0.29"
-lazy_static = "1.1"
 itertools = "0.10"
 # Note that the "rc" feature as documented at https://serde.rs/feature-flags.html
 # does not make any effort to do interning
 serde = { version = "1.0.196", features = ["derive", "rc", "std"] }
 serde_json = { version = "1.0.113", features = ["preserve_order"] }
 serde_repr = "0.1.18"
-tracing = "0.1.37"
-ustr = { version = "1.0", features = ["serde"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-stream = "0.3.2"
@@ -41,6 +38,7 @@ include_dir = "0.7.2"
 insta = { version = "1.14.0", features = ["json"] }
 ipdl_parser = { path = "./ipdl_parser" }
 json-structural-diff = "0.1.0"
+lazy_static = "1.1"
 lexical-sort = "0.3"
 linkify = "0.2.0"
 liquid = "0.26.0"
@@ -70,6 +68,7 @@ tree-sitter-java = "0.20.2"
 tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin.git", rev = "5b7ca7a611eac3234cd0a38b6257effa8888f89d" }
 toml = "0.7.3"
 tonic = "0.7.1"
+tracing = "0.1.37"
 # We explicitly do not enable the "uuid" feature because by default it will be
 # serialized as a u128 in serde which will error out when attempting to convert
 # to a Value or via #flatten, which causes a problem.
@@ -77,6 +76,7 @@ tracing-forest = { version = "0.1.5", features = ["smallvec", "tokio", "uuid"] }
 tracing-subscriber = { version = "0.3.16", features = ["std", "env-filter", "fmt", "local-time", "registry", "json"] }
 url = "2.2.2"
 urlencoding = "2.1.2"
+ustr = { version = "1.0", features = ["serde"] }
 uuid = { version = "1.2.1", features = ["std", "v4"] }
 walkdir = "2.3.2"
 

--- a/tools/src/css_analyzer.rs
+++ b/tools/src/css_analyzer.rs
@@ -1,8 +1,8 @@
 use cssparser;
-use ustr::{Ustr, ustr};
 
 use crate::file_format::analysis::{
-    AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location, SourceRange, SourceTag, TargetTag, WithLocation
+    AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location,
+    SourceRange, SourceTag, TargetTag, WithLocation
 };
 
 // NOTE: This does the same as analysis_manglings::mangle_file without regex
@@ -37,7 +37,7 @@ fn to_loc(first_line: u32,
     }
 }
 
-fn to_source(loc: Location, syntax: Vec<Ustr>, pretty: Ustr, sym: Ustr) -> WithLocation<AnalysisSource> {
+fn to_source(loc: Location, syntax: Vec<String>, pretty: String, sym: String) -> WithLocation<AnalysisSource::<String>> {
     WithLocation {
         data: AnalysisSource {
             source: SourceTag::Source,
@@ -54,15 +54,15 @@ fn to_source(loc: Location, syntax: Vec<Ustr>, pretty: Ustr, sym: Ustr) -> WithL
     }
 }
 
-fn to_target(loc: Location, kind: AnalysisKind, pretty: Ustr, sym: Ustr) -> WithLocation<AnalysisTarget> {
+fn to_target(loc: Location, kind: AnalysisKind, pretty: String, sym: String) -> WithLocation<AnalysisTarget::<String>> {
     WithLocation {
         data: AnalysisTarget {
             target: TargetTag::Target,
             kind: kind,
             pretty: pretty,
             sym: sym,
-            context: ustr(""),
-            contextsym: ustr(""),
+            context: "".to_string(),
+            contextsym: "".to_string(),
             peek_range: LineRange {
                 start_lineno: 0,
                 end_lineno: 0,
@@ -75,7 +75,9 @@ fn to_target(loc: Location, kind: AnalysisKind, pretty: Ustr, sym: Ustr) -> With
 
 fn analyze_css_block<F>(input: &mut cssparser::Parser, first_line: u32,
                         is_var: bool, callback: &mut F)
-where F: FnMut(String) {
+where
+    F: FnMut(String)
+{
     use cssparser::Token::*;
     let mut start = input.current_source_location();
     while let Ok(token) = input.next_including_whitespace_and_comments().cloned() {
@@ -86,13 +88,13 @@ where F: FnMut(String) {
             Ident(name) => {
                 if name.starts_with("--") {
                     let loc = to_loc(first_line, &start, &end);
-                    let source_pretty = ustr(format!("property {}", name.as_ref()).as_str());
-                    let target_pretty = ustr(name.as_ref());
-                    let sym = ustr(format!("CSSPROP_{}", mangle_name(name.as_ref())).as_str());
+                    let source_pretty = format!("property {}", name.as_ref());
+                    let target_pretty = name.to_string();
+                    let sym = format!("CSSPROP_{}", mangle_name(name.as_ref()));
                     let (syntax, kind) = if is_var {
-                        (vec![ustr("use"), ustr("cssprop")], AnalysisKind::Use)
+                        (vec!["use".to_string(), "cssprop".to_string()], AnalysisKind::Use)
                     } else {
-                        (vec![ustr("def"), ustr("cssprop")], AnalysisKind::Def)
+                        (vec!["def".to_string(), "cssprop".to_string()], AnalysisKind::Def)
                     };
 
                     let source = to_source(loc.clone(), syntax, source_pretty, sym.clone());
@@ -104,10 +106,10 @@ where F: FnMut(String) {
             QuotedString(s) | UnquotedUrl(s) => {
                 if s.starts_with("chrome://") || s.starts_with("resource://") {
                     let loc = to_loc(first_line, &start, &end);
-                    let source_pretty = ustr(format!("file {}", s.as_ref()).as_str());
-                    let target_pretty = ustr(s.as_ref());
-                    let sym = ustr(format!("URL_{}", mangle_name(s.as_ref())).as_str());
-                    let syntax = vec![ustr("use"), ustr("file")];
+                    let source_pretty = format!("file {}", s.as_ref());
+                    let target_pretty = s.to_string();
+                    let sym = format!("URL_{}", mangle_name(s.as_ref()));
+                    let syntax = vec!["use".to_string(), "file".to_string()];
                     let kind = AnalysisKind::Use;
 
                     let source = to_source(loc.clone(), syntax, source_pretty, sym.clone());
@@ -141,7 +143,9 @@ where F: FnMut(String) {
 
 pub fn analyze_css<F>(path: String, first_line: u32,
                   text: String, callback: &mut F)
-where F: FnMut(String) {
+where
+    F: FnMut(String)
+{
     let mut input = cssparser::ParserInput::new(text.as_str());
     let mut input = cssparser::Parser::new(&mut input);
 
@@ -151,8 +155,8 @@ where F: FnMut(String) {
             col_start: 0,
             col_end: 0,
         };
-        let pretty = ustr(format!("file {}", path).as_str());
-        let sym = ustr(format!("FILE_{}", mangle_name(path.as_str())).as_str());
+        let pretty = format!("file {}", path);
+        let sym = format!("FILE_{}", mangle_name(path.as_str()));
         let kind = AnalysisKind::Def;
         let target = to_target(loc, kind, pretty, sym);
 

--- a/tools/src/file_format/merger.rs
+++ b/tools/src/file_format/merger.rs
@@ -9,6 +9,8 @@ extern crate regex;
 use serde_json::to_value;
 use serde_json::{from_value, json, to_string, Value};
 
+use ustr::Ustr;
+
 use super::analysis::AnalysisUnion;
 use super::analysis::{
     read_analyses, AnalysisSource, AnalysisStructured, Location, WithLocation,
@@ -36,7 +38,7 @@ pub fn merge_files<W: std::io::Write>(filenames: &[String],  platforms: &Vec<Str
   let mut structured_syms = BTreeMap::new();
 
   let src_data = read_analyses(filenames, &mut |obj: Value, loc: &Location, i_file: usize| {
-      if let Ok(unified) = from_value(obj) {
+      if let Ok(unified) = from_value::<AnalysisUnion<Ustr>>(obj) {
           match unified {
               AnalysisUnion::Source(src) => {
                   // return source objects so that they come out of `read_analyses` for

--- a/tools/src/file_format/mod.rs
+++ b/tools/src/file_format/mod.rs
@@ -1,5 +1,5 @@
 pub mod analysis;
-pub mod ontology_mapping;
+pub mod ontology_pointer_kind;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod history;
@@ -20,6 +20,8 @@ pub mod globbing_file_list;
 pub mod identifiers;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod merger;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod ontology_mapping;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod per_file_info;
 #[cfg(not(target_arch = "wasm32"))]

--- a/tools/src/file_format/ontology_mapping.rs
+++ b/tools/src/file_format/ontology_mapping.rs
@@ -1,7 +1,9 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use ustr::{ustr, Ustr, UstrMap};
 
 use crate::symbol_graph_edge_kind::EdgeKind;
+
+pub use super::ontology_pointer_kind::OntologyPointerKind;
 
 #[derive(Deserialize)]
 pub struct OntologyMappingConfig {
@@ -101,25 +103,10 @@ pub struct OntologyTypeDecorator {
     pub labels: Vec<Ustr>,
 }
 
-#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize)]
-#[serde(rename_all = "lowercase")]
-pub enum OntologyPointerKind {
-    Strong,
-    Unique,
-    Weak,
-    Raw,
-    Ref,
-    // Ex: JS::{Handle, Heap, MutableHandle, Rooted}.
-    GCRef,
-    Contains,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
 pub struct OntologyMappingIngestion {
     pub config: OntologyMappingConfig,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl OntologyMappingIngestion {
     pub fn new(config_str: &str) -> Result<Self, String> {
         let config: OntologyMappingConfig =
@@ -607,7 +594,6 @@ impl OntologyMappingConfig {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 #[test]
 fn test_type_parser() {
     let test_config = r#"

--- a/tools/src/file_format/ontology_pointer_kind.rs
+++ b/tools/src/file_format/ontology_pointer_kind.rs
@@ -1,0 +1,14 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Eq, PartialEq, Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OntologyPointerKind {
+    Strong,
+    Unique,
+    Weak,
+    Raw,
+    Ref,
+    // Ex: JS::{Handle, Heap, MutableHandle, Rooted}.
+    GCRef,
+    Contains,
+}

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -1,9 +1,5 @@
-#[macro_use]
-extern crate lazy_static;
 extern crate serde;
 extern crate serde_json;
-#[macro_use]
-extern crate tracing;
 
 #[cfg(not(target_arch = "wasm32"))]
 extern crate log;
@@ -18,6 +14,9 @@ extern crate include_dir;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate itertools;
 #[cfg(not(target_arch = "wasm32"))]
+#[macro_use]
+extern crate lazy_static;
+#[cfg(not(target_arch = "wasm32"))]
 extern crate linkify;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate regex;
@@ -27,6 +26,9 @@ extern crate lexical_sort;
 extern crate liquid;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate query_parser;
+#[cfg(not(target_arch = "wasm32"))]
+#[macro_use]
+extern crate tracing;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate tracing_subscriber;
 #[cfg(not(target_arch = "wasm32"))]
@@ -68,5 +70,5 @@ pub mod logging;
 pub mod output;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tokenize;
-
+#[cfg(not(target_arch = "wasm32"))]
 mod symbol_graph_edge_kind;


### PR DESCRIPTION
This does the following:
  * Make analysis structs and impl generic over string type (`StrT`), which can be `Ustr` or `String`
  * Make `css_analyzer` use `String` variant of analysis types
  * Move `OntologyPointerKind` into its own file, to avoid annotating `ontology_mapping.rs` much
  * Remove unnecessary dependencies from `Cargo.toml`, `lib.rs`, and `mod.rs`

This reduces the size of `wasm_css_analyzer.wasm` from 106kB to 88kB.