### PR TITLE
Bug 1899363 - Check LHS vs RHS for CSS custom property, and support @property as declaration

### DIFF
--- a/tests/tests/checks/snapshots/analysis/css/test.css/check_glob@custom_prop__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/css/test.css/check_glob@custom_prop__json-2.snap
@@ -100,5 +100,89 @@ expression: "&json_results"
     "kind": "def",
     "pretty": "--色",
     "sym": "CSSPROP_@2D@2D@E8@89@B2"
+  },
+  {
+    "loc": "00021:10-19",
+    "source": 1,
+    "syntax": "decl,cssprop",
+    "pretty": "property --at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00021:10-19",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "--at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00025:2-11",
+    "source": 1,
+    "syntax": "def,cssprop",
+    "pretty": "property --at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00025:2-11",
+    "target": 1,
+    "kind": "def",
+    "pretty": "--at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00026:14-23",
+    "source": 1,
+    "syntax": "use,cssprop",
+    "pretty": "property --at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00026:14-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "--at-prop",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop"
+  },
+  {
+    "loc": "00028:12-23",
+    "source": 1,
+    "syntax": "decl,cssprop",
+    "pretty": "property --at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
+  },
+  {
+    "loc": "00028:12-23",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "--at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
+  },
+  {
+    "loc": "00030:2-13",
+    "source": 1,
+    "syntax": "def,cssprop",
+    "pretty": "property --at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
+  },
+  {
+    "loc": "00030:2-13",
+    "target": 1,
+    "kind": "def",
+    "pretty": "--at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
+  },
+  {
+    "loc": "00031:14-25",
+    "source": 1,
+    "syntax": "use,cssprop",
+    "pretty": "property --at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
+  },
+  {
+    "loc": "00031:14-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "--at-prop-2",
+    "sym": "CSSPROP_@2D@2Dat@2Dprop@2D2"
   }
 ]

--- a/tests/tests/files/css/test.css
+++ b/tests/tests/files/css/test.css
@@ -17,3 +17,16 @@ a {
 div {
   background-image: url(chrome://browser/skin/bookmark.svg);
 }
+
+@property --at-prop {
+}
+
+div {
+  --at-prop: 10;
+  transition: --at-prop 10s;
+
+  @property --at-prop-2 {
+  }
+  --at-prop-2: 10;
+  transition: --at-prop-2 10s;
+}


### PR DESCRIPTION
This does the following:
  * Treat custom property names in LHS of ":" as definition
  * Treat custom property names in RHS of ":" as use
  * Treat custom property name after `@property` as declaration