### PR TITLE
Bug 1899642 - Add ld wrapper to mitigate libtool issue in graphviz

### DIFF
--- a/scripts/indexer-setup.py
+++ b/scripts/indexer-setup.py
@@ -23,6 +23,11 @@ flags = [
 ]
 flags_str = " ".join([ '-Xclang {}'.format(flag) for flag in flags ])
 
+# See the comment in ld-wrapper for more details.
+if len(sys.argv) >= 2:
+    if sys.argv[1] == '--use-ld-wrapper':
+        flags_str += ' --ld-path={}'.format(os.path.join(mozSearchRoot, 'scripts', 'ld-wrapper'))
+
 env = {
     'CC': "clang %s" % flags_str,
     'CXX': "clang++ %s" % flags_str,

--- a/scripts/ld-wrapper
+++ b/scripts/ld-wrapper
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+import os
+
+# libtool doesn't understand "-Xclang" syntax and it passes some parameters
+# from CC/CXX set by indexer-setup.py into the linker command unexpectedly,
+# which causes ld command to fail. Filter them out here.
+args = []
+for a in sys.argv[1:]:
+    if a == '-load':
+        continue
+    if 'libclang-index-plugin.so' in a:
+        continue
+    args.append(a)
+
+ld = os.environ.get("WRAPPED_LD", "/usr/bin/ld")
+
+p = subprocess.run([ld] + args)
+sys.exit(p.returncode)


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1899642

The issue here is already explained in 
https://github.com/mozsearch/mozsearch-mozilla/blob/5fdf3904e04c39ad6957f42aeb918d19d742939d/graphviz/build#L12-L15
where libtool passes `-load` and `...*libclang-index-plugin.so` to linker command.

This patch does:
  * Add a wrapper command for ld, which filters these parameters out

graphviz config is going to use this.