### PR TITLE
Bug 1895653 - Linkify relative path of import/export declaration

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1407,7 +1407,12 @@ let Analyzer = {
       break;
 
     case "MetaProperty": // Not sure what this is!
-    case "CallImport": // dynamic import statement, see e.g. https://hg.mozilla.org/mozilla-central/file/4df1ba9c741f/testing/web-platform/tests/html/semantics/scripting-1/the-script-element/module/dynamic-import/propagate-nonce-external.js#l3
+
+    case "CallImport":
+      if (expr.arguments && expr.arguments.length > 0 &&
+          expr.arguments[0].type === "Literal") {
+        this.maybeLinkifyLiteral(expr.arguments[0]);
+      }
       break;
 
     default:

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1494,7 +1494,7 @@ let Analyzer = {
     const loc = expr.loc;
     const url = expr.value;
     const sym = "URL_" + atEscape(url);
-    this.source(loc, name, "file,use", "type " + url, sym);
+    this.source(loc, name, "file,use", "file " + url, sym);
     this.target(loc, name, "use", url, sym);
   },
 };
@@ -1734,7 +1734,7 @@ class BaseParser {
 
     const locStr = `${line + 1}:${column}-${column + url.length}`;
     const sym = "URL_" + atEscape(url);
-    Analyzer.source(locStr, url, "file,use", "type " + url, sym);
+    Analyzer.source(locStr, url, "file,use", "file " + url, sym);
     Analyzer.target(locStr, url, "use", url, sym);
   }
 

--- a/scripts/replace-aliases.py
+++ b/scripts/replace-aliases.py
@@ -32,11 +32,10 @@ def replace_aliases(path, alias_map):
             datum = json.loads(line)
             sym = datum["sym"]
 
-            if sym not in alias_map:
-                lines.append(line)
-                continue
-
             has_alias = True
+
+            if sym not in alias_map:
+                continue
             
             for alias in alias_map[sym]:
                 datum["sym"] = alias["sym"]

--- a/scripts/replace-aliases.py
+++ b/scripts/replace-aliases.py
@@ -23,7 +23,7 @@ def resolve_relpath(url, relpath):
         prefix = "chrome:/"
         path = url[8:]
     elif url.startswith("resource://"):
-        prefix = "chrome:/"
+        prefix = "resource:/"
         path = url[10:]
 
     parent = os.path.dirname(path)

--- a/tests/tests/checks/inputs/analysis/css/embed_css.html/url__json
+++ b/tests/tests/checks/inputs/analysis/css/embed_css.html/url__json
@@ -1,1 +1,1 @@
-filter-analysis css/embed_css.html --symbol-prefix 'URL_'
+filter-analysis css/embed_css.html --symbol-prefix 'FILE_'

--- a/tests/tests/checks/inputs/analysis/css/test.css/url__json
+++ b/tests/tests/checks/inputs/analysis/css/test.css/url__json
@@ -1,1 +1,1 @@
-filter-analysis css/test.css --symbol-prefix 'URL_'
+filter-analysis css/test.css --symbol-prefix 'FILE_'

--- a/tests/tests/checks/inputs/analysis/urlmap/chrome1.mjs/no_stray_relpath__json
+++ b/tests/tests/checks/inputs/analysis/urlmap/chrome1.mjs/no_stray_relpath__json
@@ -1,0 +1,1 @@
+filter-analysis urlmap/chrome1.mjs -k def -s RELPATH

--- a/tests/tests/checks/inputs/analysis/urlmap/chrome1.mjs/url_use_with_relative__json
+++ b/tests/tests/checks/inputs/analysis/urlmap/chrome1.mjs/url_use_with_relative__json
@@ -1,0 +1,1 @@
+filter-analysis urlmap/chrome1.mjs -k use --symbol-prefix FILE_

--- a/tests/tests/checks/inputs/analysis/urlmap/resource1.mjs/url_use_with_relative__json
+++ b/tests/tests/checks/inputs/analysis/urlmap/resource1.mjs/url_use_with_relative__json
@@ -1,0 +1,1 @@
+filter-analysis urlmap/resource1.mjs -k use --symbol-prefix FILE_

--- a/tests/tests/checks/inputs/analysis/urlmap/root.js/no_stray_url__json
+++ b/tests/tests/checks/inputs/analysis/urlmap/root.js/no_stray_url__json
@@ -1,0 +1,1 @@
+filter-analysis urlmap/root.js --symbol-prefix URL_

--- a/tests/tests/checks/inputs/analysis/urlmap/subdir/sub.mjs/url_use_with_relative_parent__json
+++ b/tests/tests/checks/inputs/analysis/urlmap/subdir/sub.mjs/url_use_with_relative_parent__json
@@ -1,0 +1,1 @@
+filter-analysis urlmap/subdir/sub.mjs -k use --symbol-prefix FILE_

--- a/tests/tests/checks/snapshots/analysis/css/embed_css.html/check_glob@url__json.snap
+++ b/tests/tests/checks/snapshots/analysis/css/embed_css.html/check_glob@url__json.snap
@@ -4,45 +4,52 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00018:18-54",
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file css/embed_css.html",
+    "sym": "FILE_css/embed_css@2Ehtml"
+  },
+  {
+    "loc": "00018:18-60",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00018:18-54",
+    "loc": "00018:18-60",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00022:24-60",
+    "loc": "00022:24-66",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00022:24-60",
+    "loc": "00022:24-66",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00026:32-68",
+    "loc": "00026:32-74",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00026:32-68",
+    "loc": "00026:32-74",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   }
 ]

--- a/tests/tests/checks/snapshots/analysis/css/test.css/check_glob@url__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/css/test.css/check_glob@url__json-2.snap
@@ -4,45 +4,52 @@ expression: "&json_results"
 ---
 [
   {
-    "loc": "00010:18-54",
+    "loc": "00001:0",
+    "target": 1,
+    "kind": "def",
+    "pretty": "file /home/vagrant/index/tests/files/css/test.css",
+    "sym": "FILE_/home/vagrant/index/tests/files/css/test@2Ecss"
+  },
+  {
+    "loc": "00010:18-60",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00010:18-54",
+    "loc": "00010:18-60",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00014:24-60",
+    "loc": "00014:24-66",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00014:24-60",
+    "loc": "00014:24-66",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00018:20-59",
+    "loc": "00018:20-65",
     "source": 1,
     "syntax": "use,file",
-    "pretty": "file chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   },
   {
-    "loc": "00018:20-59",
+    "loc": "00018:20-65",
     "target": 1,
     "kind": "use",
-    "pretty": "chrome://browser/skin/bookmark.svg",
-    "sym": "URL_chrome@3A//browser/skin/bookmark@2Esvg"
+    "pretty": "file urlmap/chrome1.png",
+    "sym": "FILE_urlmap/chrome1@2Epng"
   }
 ]

--- a/tests/tests/checks/snapshots/analysis/urlmap/chrome1.mjs/check_glob@no_stray_relpath__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/chrome1.mjs/check_glob@no_stray_relpath__json.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[]

--- a/tests/tests/checks/snapshots/analysis/urlmap/chrome1.mjs/check_glob@url_use_with_relative__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/chrome1.mjs/check_glob@url_use_with_relative__json.snap
@@ -1,0 +1,51 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "3:24-39",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs"
+  },
+  {
+    "loc": "3:24-39",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs",
+    "context": ""
+  },
+  {
+    "loc": "4:24-39",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome3.mjs",
+    "sym": "FILE_urlmap/chrome3@2Emjs"
+  },
+  {
+    "loc": "4:24-39",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/chrome3.mjs",
+    "sym": "FILE_urlmap/chrome3@2Emjs",
+    "context": ""
+  },
+  {
+    "loc": "5:29-47",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/subdir/sub.mjs",
+    "sym": "FILE_urlmap/subdir/sub@2Emjs"
+  },
+  {
+    "loc": "5:29-47",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/subdir/sub.mjs",
+    "sym": "FILE_urlmap/subdir/sub@2Emjs",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/urlmap/resource1.mjs/check_glob@url_use_with_relative__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/resource1.mjs/check_glob@url_use_with_relative__json-2.snap
@@ -1,0 +1,36 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "3:26-43",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/resource2.mjs",
+    "sym": "FILE_urlmap/resource2@2Emjs"
+  },
+  {
+    "loc": "3:26-43",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/resource2.mjs",
+    "sym": "FILE_urlmap/resource2@2Emjs",
+    "context": ""
+  },
+  {
+    "loc": "4:26-43",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/resource3.mjs",
+    "sym": "FILE_urlmap/resource3@2Emjs"
+  },
+  {
+    "loc": "4:26-43",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/resource3.mjs",
+    "sym": "FILE_urlmap/resource3@2Emjs",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/urlmap/root.js/check_glob@no_stray_url__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/root.js/check_glob@no_stray_url__json.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[]

--- a/tests/tests/checks/snapshots/analysis/urlmap/root.js/check_glob@url_use_in_script__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/root.js/check_glob@url_use_in_script__json.snap
@@ -107,5 +107,35 @@ expression: "&json_results"
     "pretty": "file urlmap/resource1.html",
     "sym": "FILE_urlmap/resource1@2Ehtml",
     "context": ""
+  },
+  {
+    "loc": "14:35-77",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs"
+  },
+  {
+    "loc": "14:35-77",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs",
+    "context": "f"
+  },
+  {
+    "loc": "15:37-68",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/resource2.mjs",
+    "sym": "FILE_urlmap/resource2@2Emjs"
+  },
+  {
+    "loc": "15:37-68",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/resource2.mjs",
+    "sym": "FILE_urlmap/resource2@2Emjs",
+    "context": "f"
   }
 ]

--- a/tests/tests/checks/snapshots/analysis/urlmap/subdir/sub.mjs/check_glob@url_use_with_relative_parent__json.snap
+++ b/tests/tests/checks/snapshots/analysis/urlmap/subdir/sub.mjs/check_glob@url_use_with_relative_parent__json.snap
@@ -1,0 +1,21 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "3:24-40",
+    "source": 1,
+    "syntax": "file,use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs"
+  },
+  {
+    "loc": "3:24-40",
+    "target": 1,
+    "kind": "use",
+    "pretty": "file urlmap/chrome2.mjs",
+    "sym": "FILE_urlmap/chrome2@2Emjs",
+    "context": ""
+  }
+]

--- a/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
+++ b/tests/tests/checks/snapshots/search-files/check_glob@anchored_doublestar_html__json.snap
@@ -22,7 +22,7 @@ expression: "&to_value(fm).unwrap()"
       "concise": {
         "path_kind": "Normal",
         "is_dir": false,
-        "file_size": 580,
+        "file_size": 598,
         "bugzilla_component": null,
         "subsystem": null,
         "tags": [],

--- a/tests/tests/files/css/embed_css.html
+++ b/tests/tests/files/css/embed_css.html
@@ -15,14 +15,14 @@
 }
 
 body {
-  background: url("chrome://browser/skin/bookmark.svg");
+  background: url("chrome://global/content/test/chrome1.png");
 }
 
 a {
-  background-image: url("chrome://browser/skin/bookmark.svg");
+  background-image: url("chrome://global/content/test/chrome1.png");
 }
     </style>
     <div style="color: var(--text-color);">A</div>
-    <div style="background: url('chrome://browser/skin/bookmark.svg');">B</div>
+    <div style="background: url('chrome://global/content/test/chrome1.png');">B</div>
   </body>
 </html>

--- a/tests/tests/files/css/test.css
+++ b/tests/tests/files/css/test.css
@@ -7,15 +7,15 @@
 }
 
 body {
-  background: url("chrome://browser/skin/bookmark.svg");
+  background: url("chrome://global/content/test/chrome1.png");
 }
 
 a {
-  background-image: url("chrome://browser/skin/bookmark.svg");
+  background-image: url("chrome://global/content/test/chrome1.png");
 }
 
 div {
-  background-image: url(chrome://browser/skin/bookmark.svg);
+  background-image: url(chrome://global/content/test/chrome1.png);
 }
 
 @property --at-prop {

--- a/tests/tests/files/urlmap/chrome1.mjs
+++ b/tests/tests/files/urlmap/chrome1.mjs
@@ -1,1 +1,7 @@
 export const chrome1 = 11;
+
+import { chrome2 } from "./chrome2.mjs";
+export { chrome3 } from "./chrome3.mjs";
+const { sub } = await import("./subdir/sub.mjs");
+
+const ns2 = await import("./non-existent.mjs");

--- a/tests/tests/files/urlmap/resource1.mjs
+++ b/tests/tests/files/urlmap/resource1.mjs
@@ -1,1 +1,4 @@
 export const resource1 = 21;
+
+import { resource2 } from "./resource2.mjs";
+export { resource3 } from "./resource3.mjs";

--- a/tests/tests/files/urlmap/root.js
+++ b/tests/tests/files/urlmap/root.js
@@ -9,3 +9,8 @@ ChromeUtils.defineESModuleGetters(lazy, {
 
 window.open("chrome://global/content/test/chrome1.html");
 window.open("resource://test/resource1.html");
+
+async function f() {
+  const { chrome1 } = await import("chrome://global/content/test/chrome2.mjs");
+  const { resource1 } = await import("resource://test/resource2.mjs");
+}

--- a/tests/tests/files/urlmap/root.js
+++ b/tests/tests/files/urlmap/root.js
@@ -13,4 +13,7 @@ window.open("resource://test/resource1.html");
 async function f() {
   const { chrome1 } = await import("chrome://global/content/test/chrome2.mjs");
   const { resource1 } = await import("resource://test/resource2.mjs");
+
+  var ns = await import("chrome://global/content/test/non-existent.html");
+  var ns1 = await import("resource://test/non-existent.html");
 }

--- a/tests/tests/files/urlmap/subdir/sub.mjs
+++ b/tests/tests/files/urlmap/subdir/sub.mjs
@@ -1,0 +1,3 @@
+export const sub = 10;
+
+import { chrome2 } from "../chrome2.mjs";

--- a/tests/tests/metadata/test.chrome-map.json
+++ b/tests/tests/metadata/test.chrome-map.json
@@ -24,6 +24,10 @@
       "urlmap/chrome3.mjs",
       null
     ],
+    "dist/bin/chrome/test/subdir/sub.mjs": [
+      "urlmap/subdir/sub.mjs",
+      null
+    ],
     "dist/bin/chrome/test/chrome1.css": [
       "urlmap/chrome1.css",
       null


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1895653

This does the following:
  * Add support for dynamic `import()`
  * Use "file " prefix instead of "type " prefix for URL in `js-analysis.js` (this is going to be rewritten by `replace-aliases.py` tho
  * Make `replace-aliases.py` remove any unknown `URL_*` records, given the record is not going to be used by crossref, and it consumes unnecessary RAM
  * Add relative path support, by:
    * Make `js-analysis.js` generate a record with `sym: "RELPATH"` and `pretty` being the relative path
    * Calculate the reverse map of `url-map.json`, that is, file path to urls , in replace-aliases.py
    * Replace `RELPATH` records with corresponding `FILE_*` records, or remove it if there's no any file

I use `RELPATH` symbol instead of `RELPATH_*`, because the symbol is not actually used except for checking if it's relative path.

dynamic import

<img width="642" alt="dynamic-import" src="https://github.com/mozsearch/mozsearch/assets/6299746/073c5f27-6224-4e32-8b23-dccce635f12a">

relative path

<img width="712" alt="relpath" src="https://github.com/mozsearch/mozsearch/assets/6299746/81c2ad25-7f9f-4b4e-b4f7-4a50d3c5c6ef">