### PR TITLE
Bug 1899967 - Add "Copy (symbol name)" menu item.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -77,6 +77,8 @@ var ContextMenu = new (class ContextMenu {
     // then these extra menu items which are for new/experimental features where
     // we don't want to mess with muscle memory at the top of the list.
     let extraMenuItems = [];
+    // Menu items for immediate action instead of link.
+    let actionItems = [];
 
     let symbolToken = event.target.closest("[data-symbols]");
     if (symbolToken) {
@@ -444,6 +446,25 @@ var ContextMenu = new (class ContextMenu {
             }
           }
         }
+
+        // Remove prefix.
+        const prettyName = symInfo.pretty.replace(/.* +/, "");
+        actionItems.push({
+          html: this.fmt("Copy <strong>_</strong>", prettyName),
+          icon: "docs",
+          section: "action",
+          action: () => {
+            try {
+              // NOTE: This is available only on secure context and
+              //       not compatible with local docker environment.
+              navigator.clipboard
+                .writeText(prettyName);
+            } catch (e) {
+              alert("Failed to copy: " + e.message);
+            }
+            this.hide();
+          },
+        });
       }
 
       const tokenText = symbolToken.textContent;
@@ -471,6 +492,8 @@ var ContextMenu = new (class ContextMenu {
     menuItems.push(...stickyItems);
 
     menuItems.push(...extraMenuItems);
+
+    menuItems.push(...actionItems);
 
     if (!menuItems.length) {
       return;


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1899967

This does the following:
  * Add a context menu item to copy the pretty/qualified name of the symbol, at the bottom of the context menu

I've added it to the bottom of the menu, to avoid breaking the existing workflow and muscle memory.
This feature works only on secure context (same as "Copy as Markdown"), and not available on local docker test.

<img width="404" alt="copy-symbol-name" src="https://github.com/mozsearch/mozsearch/assets/6299746/97d7eed8-234b-42e8-9d38-51460e9c00a6">
