### PR TITLE
Bug 1900120 - Add Symbol section with symbol selection mechanism, behind Fancy Bar setting.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -60,7 +60,6 @@ table {
   --syntax-string-color: green;
   --syntax-regex-color: #6d7b8d;
   --syntax-symbol-highlight: yellow;
-  --syntax-symbol-selected-outline: orange;
 
   /* Our red-blue color scheme is from
    * https://colorbrewer2.org/#type=diverging&scheme=RdBu&n=11 and was chosen
@@ -126,7 +125,6 @@ table {
 
     --syntax-comment-color: GrayText;
     --syntax-symbol-highlight: #5d4d1d;
-    --syntax-symbol-selected-outline: orange;
     /* Shamelessly taken from source.chromium.org's dark theme */
     --syntax-type-color: #79a9c4;
     --syntax-reserved-color: #d8884b;
@@ -747,11 +745,9 @@ tr.after-context-line + tr.before-context-line {
 span[data-symbols]:hover {
   cursor: pointer;
 }
-span[data-symbols].hovered {
-  background-color: var(--syntax-symbol-highlight);
-}
+span[data-symbols].hovered,
 span[data-symbols].selected {
-  outline: 1px dotted var(--syntax-symbol-selected-outline);
+  background-color: var(--syntax-symbol-highlight);
 }
 
 /* Help screen */

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -60,6 +60,7 @@ table {
   --syntax-string-color: green;
   --syntax-regex-color: #6d7b8d;
   --syntax-symbol-highlight: yellow;
+  --syntax-symbol-selected-outline: orange;
 
   /* Our red-blue color scheme is from
    * https://colorbrewer2.org/#type=diverging&scheme=RdBu&n=11 and was chosen
@@ -125,6 +126,7 @@ table {
 
     --syntax-comment-color: GrayText;
     --syntax-symbol-highlight: #5d4d1d;
+    --syntax-symbol-selected-outline: orange;
     /* Shamelessly taken from source.chromium.org's dark theme */
     --syntax-type-color: #79a9c4;
     --syntax-reserved-color: #d8884b;
@@ -674,6 +676,37 @@ tr.after-context-line + tr.before-context-line {
   cursor: not-allowed;
 }
 
+.panel .selected-symbol-section {
+  width: 240px;
+  display: grid;
+  grid-template-columns: 200px 30px;
+  gap: 10px;
+}
+
+.panel .selected-symbol-section .selected-symbol-box {
+  position: relative;
+}
+
+.panel .selected-symbol-section .selected-symbol-box .selected-symbol-ns {
+  position: absolute;
+  top: -1em;
+  padding-inline-start: 26px;
+  height: 0.8em;
+  font-size: 0.8em;
+  white-space: pre;
+}
+.panel .selected-symbol-section .selected-symbol-box .selected-symbol-local {
+  padding-inline-start: 30px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+
+.panel .selected-symbol-section .copy-box.disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
 /* Info Boxes */
 .info-box {
   border: 1px solid rgba(0, 0, 0, .5);
@@ -716,6 +749,9 @@ span[data-symbols]:hover {
 }
 span[data-symbols].hovered {
   background-color: var(--syntax-symbol-highlight);
+}
+span[data-symbols].selected {
+  outline: 1px dotted var(--syntax-symbol-selected-outline);
 }
 
 /* Help screen */

--- a/static/js/code-highlighter.js
+++ b/static/js/code-highlighter.js
@@ -201,10 +201,7 @@ var DocumentTitler = new (class DocumentTitler {
     // The pretty will include a descriptor prefix like "function " which we
     // don't care about.
     if (bestPretty) {
-      let idxSpace = bestPretty.indexOf(" ");
-      if (idxSpace !== -1) {
-        bestPretty = bestPretty.substring(idxSpace + 1);
-      }
+      bestPretty = bestPretty.replace(/[A-Za-z0-9]+ /, "");
 
       // Shorten any namespaces.
       bestShortPretty = this._shortenNamespaces(bestPretty);
@@ -668,12 +665,18 @@ var Highlighter = new (class Highlighter {
     DocumentTitler.processLineSelection(this.selectedLines);
   }
 
-  toHash() {
-    if (!this.selectedLines.size) {
+  // Convert the list of selected lines into a hash string.
+  // Passing extraLine makes that line also selected.
+  toHash(extraLine = undefined) {
+    if (extraLine === undefined && !this.selectedLines.size) {
       return "";
     }
     // Try to create ranges out of the lines.
-    let lines = [...this.selectedLines].sort((a, b) => a - b);
+    const unsortedLines = [...this.selectedLines];
+    if (extraLine !== undefined && !unsortedLines.includes(extraLine)) {
+      unsortedLines.push(extraLine);
+    }
+    let lines = unsortedLines.sort((a, b) => a - b);
     let ranges = [];
     let current = { start: lines[0], end: lines[0] };
     for (let i = 1; i < lines.length; ++i) {

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -6,6 +6,8 @@ var ContextMenu = new (class ContextMenu {
     this.menu.style.display = "none";
     document.body.appendChild(this.menu);
 
+    this.selectedToken = null;
+
     this.menu.addEventListener("mousedown", function (event) {
       // Prevent clicks on the menu to propagate
       // to the window, so that the menu is not
@@ -37,6 +39,16 @@ var ContextMenu = new (class ContextMenu {
   }
 
   tryShowOnClick(event) {
+    if (Settings.fancyBar.enabled) {
+      if (this.selectedToken) {
+        if (!Panel?.isOnPanel?.(event)) {
+          this.selectedToken.classList.remove("selected");
+          this.selectedToken = null;
+          Panel?.onSelectedTokenChanged?.();
+        }
+      }
+    }
+
     // Don't display the context menu if there's a selection.
     // User could be trying to select something and the context menu will undo it.
     if (!window.getSelection().isCollapsed) {
@@ -80,6 +92,12 @@ var ContextMenu = new (class ContextMenu {
 
     let symbolToken = event.target.closest("[data-symbols]");
     if (symbolToken) {
+      if (Settings.fancyBar.enabled) {
+        this.selectedToken = symbolToken;
+        this.selectedToken.classList.add("selected");
+        Panel?.onSelectedTokenChanged?.();
+      }
+
       const symbols = symbolToken.getAttribute("data-symbols").split(",");
 
       const seenSyms = new Set();


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1900120

This does the following, behind the "Fancy Bar" setting (the "Alpha" gate):
  * Add "Symbol" section inside the navigation bar, above the "Copy as Markdown" section [1]
    * this section shows the currently-selected symbol, which is used by the "Symbol Link" [2]
    * if no symbol is selected (no symbol inside selected line), this section shows "(no symbol clicked)" text
    * this section has copy button, which copies the raw text of the symbol's qualified name (the text part of the current "Symbol Link")
    * the selected symbol's namespace part (including class name etc) and the local name part are shown in separate line, in order to make sure the local name is visible
    * the symbol section has fixed-width (240px), in order to avoid changing the navigation box's size depending on the selected symbol's length
  * Add a new selection state "symbol is clicked"
    * In addition to selecting line numbers, clicking a symbol (non-local symbol) selects the symbol
    * ~~the clicked symbol has orange dotted outline~~
    * the clicked symbol has the same background color as hovered symbol [3]
    * the clicked symbol is kept selected while operating on the navigation box [4]
    * the clicked symbol is de-selected by clicking outside of the navigation box
    * the clicked symbol has higher priority than the current "symbol inside the selected lines".  If a symbol is clicked, it's used for the "Symbol" section and the "Copy as Markdown" section
    * the clicked symbol's line number is reflected to the "Copy as Markdown"'s URL and the "Code Block", even if the line is not selected

Currently available on the dev channel
https://dev.searchfox.org/mozilla-central/source/js/src/frontend/Parser.cpp#1083

[1] Symbol section (without selected symbol)
<img width="287" alt="symbol-section" src="https://github.com/mozsearch/mozsearch/assets/6299746/58f798a0-6397-4734-8e40-4d7f52109c98">

[2] Symbol section shows the selected symbol
<img width="280" alt="symbol-section-selected" src="https://github.com/mozsearch/mozsearch/assets/6299746/44f8e280-96e0-4f34-9b9b-c6d9e8850bbc">

[3] the clicked symbol
<img width="397" alt="clicked-symbol-3" src="https://github.com/mozsearch/mozsearch/assets/6299746/b6c9a6fd-0db8-4489-9fcf-810ef66c1485">

[4] the clicked symbol is kept selected while operating on the navigation box
<img width="263" alt="selected-symbol-3" src="https://github.com/mozsearch/mozsearch/assets/6299746/d627004f-c337-4412-94dc-b7f33256ec85">
