### PR TITLE
Bug 1900692 - Support multiple inheritance in the class field layout table

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1113,6 +1113,14 @@ public:
 
         J.attribute("sym", getMangledName(CurMangleContext, BaseDecl));
 
+        if (Base.isVirtual()) {
+          CharUnits superOffsetBytes = Layout.getVBaseClassOffset(BaseDecl);
+          J.attribute("offsetBytes", superOffsetBytes.getQuantity());
+        } else {
+          CharUnits superOffsetBytes = Layout.getBaseClassOffset(BaseDecl);
+          J.attribute("offsetBytes", superOffsetBytes.getQuantity());
+        }
+
         J.attributeBegin("props");
         J.arrayBegin();
         if (Base.isVirtual()) {

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -122,6 +122,21 @@ static bool isValidIdentifier(std::string Input) {
   return true;
 }
 
+template <size_t N>
+static bool stringStartsWith(const std::string& Input,
+                             const char (&Prefix)[N]) {
+  return Input.length() > N - 1 && memcmp(Input.c_str(), Prefix, N - 1) == 0;
+}
+
+static bool isASCII(const std::string& Input) {
+  for (char C : Input) {
+    if (C & 0x80) {
+      return false;
+    }
+  }
+  return true;
+}
+
 struct RAIITracer {
   RAIITracer(const char *log) : mLog(log) {
     printf("<%s>\n", mLog);
@@ -484,6 +499,10 @@ private:
       Filename = std::string(Platform ? Platform : "") + std::string("@") + Filename;
     }
     return Filename;
+  }
+
+  std::string mangleURL(std::string Url) {
+    return mangleFile(Url, FileType::Source);
   }
 
   std::string mangleQualifiedName(std::string Name) {
@@ -2247,6 +2266,35 @@ public:
     for (const NamedDecl *D : Resolver->resolveDeclRefExpr(E)) {
       visitHeuristicResult(Loc, D);
     }
+    return true;
+  }
+
+  bool VisitStringLiteral(StringLiteral *E) {
+    if (E->getCharByteWidth() != 1) {
+      return true;
+    }
+
+    StringRef sref = E->getString();
+    std::string s = sref.str();
+
+    if (!stringStartsWith(s, "chrome://") &&
+        !stringStartsWith(s, "resource://")) {
+      return true;
+    }
+
+    if (!isASCII(s)) {
+      return true;
+    }
+
+    SourceLocation Loc = E->getStrTokenLoc(0);
+    normalizeLocation(&Loc);
+
+    std::string symbol = std::string("URL_") + mangleURL(s);
+
+    visitIdentifier("use", "file", StringRef(s), Loc, symbol,
+                    QualType(), Context(),
+                    NotIdentifierToken | LocRangeEndValid);
+
     return true;
   }
 

--- a/tests/tests/checks/inputs/fancy/format-symbol/field-layout/multiple_inheritance.cpp/field_layout__multiple_inheritance__json
+++ b/tests/tests/checks/inputs/fancy/format-symbol/field-layout/multiple_inheritance.cpp/field_layout__multiple_inheritance__json
@@ -1,0 +1,1 @@
+search-identifiers field_layout::multiple_inheritance::SubSubSubA | crossref-lookup | format-symbols --mode="field-layout"

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_human__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_human__json.snap
@@ -13,6 +13,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
@@ -13,6 +13,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_superhero__json.snap
@@ -13,6 +13,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Human",
+        "offsetBytes": 0,
         "props": []
       }
     ],

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
@@ -23,7 +23,8 @@ expression: "&json_results"
         "sym": "S_jvm_sample/Interface#someFunction()."
       }
     ],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00016:21-33",
@@ -45,6 +46,7 @@ expression: "&json_results"
         "sym": "S_jvm_sample/Interface#someFunction()."
       }
     ],
-    "props": []
+    "props": [],
+    "variants": []
   }
 ]

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
@@ -23,7 +23,8 @@ expression: "&json_results"
         "sym": "S_jvm_sample/Interface#someOtherFunction()."
       }
     ],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00017:21-38",
@@ -45,6 +46,7 @@ expression: "&json_results"
         "sym": "S_jvm_sample/Interface#someOtherFunction()."
       }
     ],
-    "props": []
+    "props": [],
+    "variants": []
   }
 ]

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@abstractart__beart__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@abstractart__beart__json.snap
@@ -50,6 +50,7 @@ expression: "&to_value(scil).unwrap()"
           "overriddenBy": [
             "_ZN7outerNS12PracticalArt5beArtEv"
           ],
+          "variants": [],
           "args": []
         }
       },

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
@@ -81,7 +81,8 @@ expression: "&to_value(scil).unwrap()"
             }
           ],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
@@ -274,7 +274,8 @@ expression: "&to_value(scil).unwrap()"
             "T_outerNS::Couch",
             "T_outerNS::OuterCat",
             "T_outerNS::AbstractArt"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
@@ -71,6 +71,7 @@ expression: "&to_value(scil).unwrap()"
             "virtual",
             "user"
           ],
+          "variants": [],
           "args": [
             {
               "name": "aBooleanProperty",

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
@@ -71,6 +71,7 @@ expression: "&to_value(scil).unwrap()"
             "virtual",
             "user"
           ],
+          "variants": [],
           "args": [
             {
               "name": "aBooleanProperty",

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
@@ -53,7 +53,8 @@ expression: "&to_value(scil).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": "Queried",
@@ -132,6 +133,7 @@ expression: "&to_value(scil).unwrap()"
             "virtual",
             "user"
           ],
+          "variants": [],
           "args": [
             {
               "name": "a",

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -106,6 +106,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::Thing",
+              "offsetBytes": 0,
               "props": []
             }
           ],
@@ -703,6 +704,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::Thing",
+              "offsetBytes": 0,
               "props": []
             }
           ],
@@ -866,6 +868,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::Thing",
+              "offsetBytes": 0,
               "props": []
             }
           ],
@@ -994,6 +997,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::Thing",
+              "offsetBytes": 0,
               "props": []
             }
           ],
@@ -1155,6 +1159,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::Human",
+              "offsetBytes": 0,
               "props": []
             }
           ],
@@ -1325,6 +1330,7 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "T_outerNS::AbstractArt",
+              "offsetBytes": 0,
               "props": []
             }
           ],

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -288,7 +288,8 @@ expression: "&to_value(scil).unwrap()"
           "props": [],
           "labels": [
             "cc"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": "Queried",
@@ -565,7 +566,8 @@ expression: "&to_value(scil).unwrap()"
             "T_outerNS::Couch",
             "T_outerNS::OuterCat",
             "T_outerNS::AbstractArt"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": {
@@ -767,7 +769,8 @@ expression: "&to_value(scil).unwrap()"
           "props": [],
           "subclasses": [
             "T_outerNS::Superhero"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": {
@@ -906,7 +909,8 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": {
@@ -1066,7 +1070,8 @@ expression: "&to_value(scil).unwrap()"
           "props": [],
           "subclasses": [
             "T_outerNS::PracticalArt"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": {
@@ -1223,7 +1228,8 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": {
@@ -1372,7 +1378,8 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": {

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@links_to_java_library_constructor__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@links_to_java_library_constructor__json.snap
@@ -75,7 +75,8 @@ expression: "&to_value(scil).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
@@ -57,7 +57,8 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
@@ -40,10 +40,12 @@ expression: "&to_value(scil).unwrap()"
           "supers": [
             {
               "sym": "S_jvm_sample/JavaLibrary#I0#",
+              "offsetBytes": 0,
               "props": []
             },
             {
               "sym": "S_jvm_sample/JavaLibrary#I1#",
+              "offsetBytes": 0,
               "props": []
             }
           ],

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
@@ -62,7 +62,8 @@ expression: "&to_value(scil).unwrap()"
           "props": [],
           "subclasses": [
             "S_jvm_sample/JavaLibrary#B#"
-          ]
+          ],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/java/KotlinLibrary.kt/check_glob@links_to_kotlin_library_constructor__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/KotlinLibrary.kt/check_glob@links_to_kotlin_library_constructor__json.snap
@@ -75,7 +75,8 @@ expression: "&to_value(scil).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         }
       },
       "relation": "Queried",

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -3028,7 +3028,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00241:7-18",
@@ -3047,7 +3048,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00242:7-28",
@@ -3066,7 +3068,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00244:25-31",
@@ -3085,7 +3088,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00460:16-24",
@@ -3104,7 +3108,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00151:7-15",
@@ -3123,7 +3128,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00147:6-9",
@@ -3142,7 +3148,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00025:6-19",
@@ -3206,7 +3213,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00076:8-25",
@@ -3234,7 +3242,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00437:6-17",
@@ -3324,7 +3333,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00211:6-11",
@@ -3384,7 +3394,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00136:6-26",
@@ -3442,7 +3453,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00185:6-11",
@@ -3522,7 +3534,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00227:6-14",
@@ -3700,7 +3713,8 @@ expression: "&json_results"
       }
     ],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00349:8-26",
@@ -3763,7 +3777,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00447:6-18",
@@ -3833,7 +3848,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00459:6-20",
@@ -3871,7 +3887,8 @@ expression: "&json_results"
       }
     ],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00194:6-15",
@@ -3961,7 +3978,8 @@ expression: "&json_results"
     ],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00141:6-11",
@@ -4074,7 +4092,8 @@ expression: "&json_results"
       }
     ],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00474:6-13",
@@ -4092,7 +4111,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00468:6-14",
@@ -4110,7 +4130,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00486:6-21",
@@ -4128,7 +4149,8 @@ expression: "&json_results"
     "methods": [],
     "fields": [],
     "overrides": [],
-    "props": []
+    "props": [],
+    "variants": []
   },
   {
     "loc": "00088:4-25",
@@ -4151,6 +4173,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4174,6 +4197,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4197,6 +4221,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4220,6 +4245,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4243,6 +4269,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4266,6 +4293,7 @@ expression: "&json_results"
       "static",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4290,6 +4318,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4313,6 +4342,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4341,6 +4371,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4364,6 +4395,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4387,6 +4419,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "aArt",
@@ -4417,6 +4450,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "raw",
@@ -4445,6 +4479,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "couchHP",
@@ -4473,6 +4508,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4497,6 +4533,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "damage",
@@ -4525,6 +4562,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4548,6 +4586,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "baseHP",
@@ -4576,6 +4615,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4604,6 +4644,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "raw",
@@ -4632,6 +4673,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4655,6 +4697,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4678,6 +4721,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "couch",
@@ -4707,6 +4751,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "human",
@@ -4736,6 +4781,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "thing",
@@ -4765,6 +4811,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "thing",
@@ -4794,6 +4841,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "beFriendly",
@@ -4831,6 +4879,7 @@ expression: "&json_results"
       "virtual",
       "user"
     ],
+    "variants": [],
     "args": [
       {
         "name": "damage",
@@ -4859,6 +4908,7 @@ expression: "&json_results"
       "instance",
       "user"
     ],
+    "variants": [],
     "args": []
   },
   {
@@ -4878,6 +4928,7 @@ expression: "&json_results"
     "fields": [],
     "overrides": [],
     "props": [],
+    "variants": [],
     "args": []
   }
 ]

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -3260,6 +3260,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3351,6 +3352,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3471,6 +3473,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3552,6 +3555,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Thing",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3731,6 +3735,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::CycleCollectingMagic",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3795,6 +3800,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::AbstractArt",
+        "offsetBytes": 0,
         "props": []
       }
     ],
@@ -3905,6 +3911,7 @@ expression: "&json_results"
     "supers": [
       {
         "sym": "T_outerNS::Human",
+        "offsetBytes": 0,
         "props": []
       }
     ],

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
@@ -125,6 +125,7 @@ expression: sgc.to_json()
         "supers": [
           {
             "sym": "T_outerNS::Thing",
+            "offsetBytes": 0,
             "props": []
           }
         ],
@@ -192,6 +193,7 @@ expression: sgc.to_json()
         "supers": [
           {
             "sym": "T_outerNS::Thing",
+            "offsetBytes": 0,
             "props": []
           }
         ],

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
@@ -23,7 +23,8 @@ expression: sgc.to_json()
         "methods": [],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#241"
@@ -48,7 +49,8 @@ expression: sgc.to_json()
         "methods": [],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#242"
@@ -73,7 +75,8 @@ expression: sgc.to_json()
         "methods": [],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#151"
@@ -98,7 +101,8 @@ expression: sgc.to_json()
         "methods": [],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#147"
@@ -164,7 +168,8 @@ expression: sgc.to_json()
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#211"
@@ -253,7 +258,8 @@ expression: sgc.to_json()
         "props": [],
         "subclasses": [
           "T_outerNS::Superhero"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#185"
@@ -378,7 +384,8 @@ expression: sgc.to_json()
           "T_outerNS::Couch",
           "T_outerNS::OuterCat",
           "T_outerNS::AbstractArt"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#141"
@@ -411,6 +418,7 @@ expression: sgc.to_json()
         "overriddenBy": [
           "_ZN7outerNS9Superhero10takeDamageEi"
         ],
+        "variants": [],
         "args": [
           {
             "name": "damage",
@@ -445,6 +453,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -475,6 +484,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -504,6 +514,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -533,6 +544,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -562,6 +574,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "couch",
@@ -597,6 +610,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "human",
@@ -632,6 +646,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",
@@ -667,6 +682,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",
@@ -707,6 +723,7 @@ expression: sgc.to_json()
           "virtual",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "damage",

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
@@ -210,7 +210,8 @@ expression: sgc.to_json()
         "props": [],
         "labels": [
           "cc"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#227"
@@ -335,7 +336,8 @@ expression: sgc.to_json()
           "T_outerNS::Couch",
           "T_outerNS::OuterCat",
           "T_outerNS::AbstractArt"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#141"
@@ -368,6 +370,7 @@ expression: sgc.to_json()
         "overriddenBy": [
           "_ZN7outerNS9Superhero10takeDamageEi"
         ],
+        "variants": [],
         "args": [
           {
             "name": "damage",
@@ -402,6 +405,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "couch",
@@ -437,6 +441,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",
@@ -472,6 +477,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
@@ -28,6 +28,7 @@ expression: sgc.to_json()
         "supers": [
           {
             "sym": "T_outerNS::Thing",
+            "offsetBytes": 0,
             "props": []
           }
         ],

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__json.snap
@@ -31,6 +31,7 @@ expression: sgc.to_json()
         "overriddenBy": [
           "_ZN7outerNS9Superhero10takeDamageEi"
         ],
+        "variants": [],
         "args": [
           {
             "name": "damage",
@@ -65,6 +66,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "couch",
@@ -100,6 +102,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",
@@ -135,6 +138,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/lots_of_calls.cpp/check_glob@paths_between__four_left_one_right__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/lots_of_calls.cpp/check_glob@paths_between__four_left_one_right__json.snap
@@ -27,6 +27,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -56,6 +57,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "four",
@@ -92,6 +94,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -138,6 +141,7 @@ expression: sgc.to_json()
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#245"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#241"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#242"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#244"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#151"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#147"
@@ -355,7 +361,8 @@ expression: "&to_value(sttl).unwrap()"
             "props": [],
             "labels": [
               "cc"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#227"
@@ -480,7 +487,8 @@ expression: "&to_value(sttl).unwrap()"
               "T_outerNS::Couch",
               "T_outerNS::OuterCat",
               "T_outerNS::AbstractArt"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#141"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -179,6 +179,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
                 "props": []
               }
             ],

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#8"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#9"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#10"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#11"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#12"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#13"
@@ -277,7 +283,8 @@ expression: "&to_value(sttl).unwrap()"
               }
             ],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/bitfields.cpp#7"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
@@ -55,7 +55,8 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/empty.cpp#7"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#8"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#9"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#10"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#11"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#15"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#16"
@@ -253,7 +259,8 @@ expression: "&to_value(sttl).unwrap()"
             "props": [],
             "subclasses": [
               "T_field_layout::holes::Sub"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#7"
@@ -331,7 +338,8 @@ expression: "&to_value(sttl).unwrap()"
               }
             ],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/holes.cpp#14"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -283,6 +283,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_field_layout::holes::Base",
+                "offsetBytes": 0,
                 "props": []
               }
             ],

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -1,0 +1,2666 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(sttl).unwrap()"
+---
+{
+  "tables": [
+    {
+      "jumprefs": {
+        "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
+          "pretty": "field_layout::multiple_inheritance::SubA::sub_a_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubA::sub_a_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubA",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#11"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
+          "pretty": "field_layout::multiple_inheritance::SubA::sub_a_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubA::sub_a_2",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubA",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#12"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+          "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubB",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#16"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
+          "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubB",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#17"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
+          "pretty": "field_layout::multiple_inheritance::SubB::sub_b_3",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubB::sub_b_3",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubB",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#19"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
+          "pretty": "field_layout::multiple_inheritance::SubC::sub_c_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubC::sub_c_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubC",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#24"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
+          "pretty": "field_layout::multiple_inheritance::SubC::sub_c_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubC::sub_c_2",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubC",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#25"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
+          "pretty": "field_layout::multiple_inheritance::SubD::sub_d_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubD::sub_d_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubD",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#29"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
+          "pretty": "field_layout::multiple_inheritance::SubD::sub_d_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubD::sub_d_2",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubD",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#30"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
+          "pretty": "field_layout::multiple_inheritance::SubE::sub_e_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubE::sub_e_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubE",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#34"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
+          "pretty": "field_layout::multiple_inheritance::SubE::sub_e_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubE::sub_e_2",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubE",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#35"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+          "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubSubA",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#42"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
+          "pretty": "field_layout::multiple_inheritance::SubSubB::sub_sub_b_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubB::sub_sub_b_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubSubB",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#46"
+          }
+        },
+        "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1": {
+          "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+          "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
+            "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::multiple_inheritance::SubSubSubA",
+            "implKind": "",
+            "sizeBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#51"
+          }
+        },
+        "T_field_layout::multiple_inheritance::BaseEmpty": {
+          "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+          "pretty": "field_layout::multiple_inheritance::BaseEmpty",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::BaseEmpty",
+            "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 1,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::BaseEmpty::BaseEmpty",
+                "sym": "_ZN12field_layout20multiple_inheritance9BaseEmptyC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::BaseEmpty::~BaseEmpty",
+                "sym": "_ZN12field_layout20multiple_inheritance9BaseEmptyD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::BaseEmpty::BaseEmpty",
+                "sym": "_ZN12field_layout20multiple_inheritance9BaseEmptyC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::BaseEmpty::BaseEmpty",
+                "sym": "_ZN12field_layout20multiple_inheritance9BaseEmptyC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubA",
+              "T_field_layout::multiple_inheritance::SubB",
+              "T_field_layout::multiple_inheritance::SubC",
+              "T_field_layout::multiple_inheritance::SubE"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#7"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubA": {
+          "sym": "T_field_layout::multiple_inheritance::SubA",
+          "pretty": "field_layout::multiple_inheritance::SubA",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubA",
+            "sym": "T_field_layout::multiple_inheritance::SubA",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 8,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::SubA",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubAC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::~SubA",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubAD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::SubA",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubAC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::SubA",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubAC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::sub_a_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 4
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubA::sub_a_2",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
+                "type": "short",
+                "typesym": "",
+                "offsetBytes": 4,
+                "bitPositions": null,
+                "sizeBytes": 2
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubA"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#10"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubB": {
+          "sym": "T_field_layout::multiple_inheritance::SubB",
+          "pretty": "field_layout::multiple_inheritance::SubB",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubB",
+            "sym": "T_field_layout::multiple_inheritance::SubB",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubBC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::~SubB",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubBD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubBC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubBC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 4
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
+                "type": "signed char",
+                "typesym": "",
+                "offsetBytes": 4,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubB::sub_b_3",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
+                "type": "long",
+                "typesym": "",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 8
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubA"
+            ],
+            "variants": [
+              {
+                "structured": 1,
+                "pretty": "field_layout::multiple_inheritance::SubB",
+                "sym": "T_field_layout::multiple_inheritance::SubB",
+                "type_pretty": null,
+                "kind": "struct",
+                "subsystem": null,
+                "implKind": "",
+                "sizeBytes": 8,
+                "bindingSlots": [],
+                "ontologySlots": [],
+                "supers": [
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+                    "offsetBytes": 0,
+                    "props": []
+                  }
+                ],
+                "methods": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                    "sym": "_ZN12field_layout20multiple_inheritance4SubBC1Ev",
+                    "props": [
+                      "instance",
+                      "defaulted"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::~SubB",
+                    "sym": "_ZN12field_layout20multiple_inheritance4SubBD1Ev",
+                    "props": [
+                      "instance",
+                      "defaulted"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                    "sym": "_ZN12field_layout20multiple_inheritance4SubBC1ERKS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::SubB",
+                    "sym": "_ZN12field_layout20multiple_inheritance4SubBC1EOS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  }
+                ],
+                "fields": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
+                    "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+                    "type": "int",
+                    "typesym": "",
+                    "offsetBytes": 0,
+                    "bitPositions": null,
+                    "sizeBytes": 4
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
+                    "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
+                    "type": "signed char",
+                    "typesym": "",
+                    "offsetBytes": 4,
+                    "bitPositions": null,
+                    "sizeBytes": 1
+                  }
+                ],
+                "overrides": [],
+                "props": [],
+                "variants": [],
+                "platforms": [
+                  "linux64",
+                  "macosx64"
+                ]
+              }
+            ],
+            "platforms": [
+              "win64"
+            ]
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#15"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubC": {
+          "sym": "T_field_layout::multiple_inheritance::SubC",
+          "pretty": "field_layout::multiple_inheritance::SubC",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubC",
+            "sym": "T_field_layout::multiple_inheritance::SubC",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 8,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::SubC",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubCC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::~SubC",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubCD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::SubC",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubCC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::SubC",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubCC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::sub_c_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
+                "type": "signed char",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubC::sub_c_2",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 4,
+                "bitPositions": null,
+                "sizeBytes": 4
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubD"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#23"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubD": {
+          "sym": "T_field_layout::multiple_inheritance::SubD",
+          "pretty": "field_layout::multiple_inheritance::SubD",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubD",
+            "sym": "T_field_layout::multiple_inheritance::SubD",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubC",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::SubD",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubDC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::~SubD",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubDD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::SubD",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubDC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::SubD",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubDC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::sub_d_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 4
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubD::sub_d_2",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
+                "type": "signed char",
+                "typesym": "",
+                "offsetBytes": 12,
+                "bitPositions": null,
+                "sizeBytes": 1
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubA"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#28"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubE": {
+          "sym": "T_field_layout::multiple_inheritance::SubE",
+          "pretty": "field_layout::multiple_inheritance::SubE",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubE",
+            "sym": "T_field_layout::multiple_inheritance::SubE",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::SubE",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubEC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::~SubE",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubED1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::SubE",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubEC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::SubE",
+                "sym": "_ZN12field_layout20multiple_inheritance4SubEC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::sub_e_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
+                "type": "long",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 8
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubE::sub_e_2",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 4
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubB"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#33"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubSubA": {
+          "sym": "T_field_layout::multiple_inheritance::SubSubA",
+          "pretty": "field_layout::multiple_inheritance::SubSubA",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubA",
+            "sym": "T_field_layout::multiple_inheritance::SubSubA",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 48,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubA",
+                "offsetBytes": 0,
+                "props": []
+              },
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubB",
+                "offsetBytes": 8,
+                "props": []
+              },
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubD",
+                "offsetBytes": 24,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubA::~SubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubAD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 40,
+                "bitPositions": null,
+                "sizeBytes": 4
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubSubA"
+            ],
+            "variants": [
+              {
+                "structured": 1,
+                "pretty": "field_layout::multiple_inheritance::SubSubA",
+                "sym": "T_field_layout::multiple_inheritance::SubSubA",
+                "type_pretty": null,
+                "kind": "struct",
+                "subsystem": null,
+                "implKind": "",
+                "sizeBytes": 36,
+                "bindingSlots": [],
+                "ontologySlots": [],
+                "supers": [
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::SubA",
+                    "offsetBytes": 0,
+                    "props": []
+                  },
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::SubB",
+                    "offsetBytes": 8,
+                    "props": []
+                  },
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::SubD",
+                    "offsetBytes": 16,
+                    "props": []
+                  }
+                ],
+                "methods": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1Ev",
+                    "props": [
+                      "instance",
+                      "defaulted"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubA::~SubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance7SubSubAD1Ev",
+                    "props": [
+                      "instance",
+                      "defaulted"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1ERKS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubA::SubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance7SubSubAC1EOS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  }
+                ],
+                "fields": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
+                    "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+                    "type": "int",
+                    "typesym": "",
+                    "offsetBytes": 32,
+                    "bitPositions": null,
+                    "sizeBytes": 4
+                  }
+                ],
+                "overrides": [],
+                "props": [],
+                "variants": [],
+                "platforms": [
+                  "linux64",
+                  "macosx64"
+                ]
+              }
+            ],
+            "platforms": [
+              "win64"
+            ]
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#39"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubSubB": {
+          "sym": "T_field_layout::multiple_inheritance::SubSubB",
+          "pretty": "field_layout::multiple_inheritance::SubSubB",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubB",
+            "sym": "T_field_layout::multiple_inheritance::SubSubB",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 16,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubE",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubB::SubSubB",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubBC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubB::~SubSubB",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubBD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubB::SubSubB",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubBC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubB::SubSubB",
+                "sym": "_ZN12field_layout20multiple_inheritance7SubSubBC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubB::sub_sub_b_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 12,
+                "bitPositions": null,
+                "sizeBytes": 4
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_field_layout::multiple_inheritance::SubSubSubA"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#45"
+          }
+        },
+        "T_field_layout::multiple_inheritance::SubSubSubA": {
+          "sym": "T_field_layout::multiple_inheritance::SubSubSubA",
+          "pretty": "field_layout::multiple_inheritance::SubSubSubA",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::multiple_inheritance::SubSubSubA",
+            "sym": "T_field_layout::multiple_inheritance::SubSubSubA",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 72,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubSubA",
+                "offsetBytes": 0,
+                "props": []
+              },
+              {
+                "sym": "T_field_layout::multiple_inheritance::SubSubB",
+                "offsetBytes": 48,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
+                "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+                "type": "int",
+                "typesym": "",
+                "offsetBytes": 64,
+                "bitPositions": null,
+                "sizeBytes": 4
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "variants": [
+              {
+                "structured": 1,
+                "pretty": "field_layout::multiple_inheritance::SubSubSubA",
+                "sym": "T_field_layout::multiple_inheritance::SubSubSubA",
+                "type_pretty": null,
+                "kind": "struct",
+                "subsystem": null,
+                "implKind": "",
+                "sizeBytes": 64,
+                "bindingSlots": [],
+                "ontologySlots": [],
+                "supers": [
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::SubSubA",
+                    "offsetBytes": 0,
+                    "props": []
+                  },
+                  {
+                    "sym": "T_field_layout::multiple_inheritance::SubSubB",
+                    "offsetBytes": 40,
+                    "props": []
+                  }
+                ],
+                "methods": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1Ev",
+                    "props": [
+                      "instance",
+                      "defaulted"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1ERKS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  },
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubSubA::SubSubSubA",
+                    "sym": "_ZN12field_layout20multiple_inheritance10SubSubSubAC1EOS1_",
+                    "props": [
+                      "instance",
+                      "defaulted",
+                      "constexpr"
+                    ],
+                    "args": []
+                  }
+                ],
+                "fields": [
+                  {
+                    "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
+                    "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+                    "type": "int",
+                    "typesym": "",
+                    "offsetBytes": 56,
+                    "bitPositions": null,
+                    "sizeBytes": 4
+                  }
+                ],
+                "overrides": [],
+                "props": [],
+                "variants": [],
+                "platforms": [
+                  "linux64",
+                  "macosx64"
+                ]
+              }
+            ],
+            "platforms": [
+              "win64"
+            ]
+          },
+          "jumps": {
+            "def": "field-layout/multiple_inheritance.cpp#49"
+          }
+        }
+      },
+      "columns": [
+        {
+          "label": [
+            {
+              "Heading": "Name"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "Type"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "win64"
+            }
+          ],
+          "colspan": 2
+        },
+        {
+          "label": [
+            {
+              "Heading": "macosx64 linux64"
+            }
+          ],
+          "colspan": 2
+        }
+      ],
+      "sub_columns": [
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Offset"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Size"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Offset"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Size"
+            }
+          ],
+          "colspan": 1
+        }
+      ],
+      "rows": [
+        {
+          "label": [
+            {
+              "Heading": "field_layout::multiple_inheritance::SubSubSubA"
+            }
+          ],
+          "sym": "T_field_layout::multiple_inheritance::SubSubSubA",
+          "colVals": [],
+          "children": [
+            {
+              "label": [
+                {
+                  "Text": "sub_sub_sub_a_1"
+                }
+              ],
+              "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "int"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x40"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "4"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x38"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "4"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": [],
+              "colspan": 1
+            },
+            {
+              "label": [],
+              "sym": null,
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "ItalicText": "4 bytes padding"
+                    }
+                  ],
+                  "colspan": 2
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "ItalicText": "4 bytes padding"
+                    }
+                  ],
+                  "colspan": 2
+                }
+              ],
+              "children": [],
+              "colspan": 1
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubSubA (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubSubA",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_sub_c_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x28"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x20"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "4 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubSubB (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubSubB",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_sub_b_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x3c"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x34"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubA (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubA",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_a_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x0"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x0"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_a_2"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "short"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "2"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "2"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "2 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "2 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubB (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubB",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_b_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x8"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x8"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_b_2"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "signed char"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0xc"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0xc"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes hole"
+                        }
+                      ],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_b_3"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "long"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x10"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "8"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubD (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubD",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_d_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x20"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x18"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_d_2"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "signed char"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x24"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x1c"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes padding"
+                        }
+                      ],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubE (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubE",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "4 bytes hole after base class"
+                        }
+                      ],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_e_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "long"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x30"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "8"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x28"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "8"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_e_2"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x38"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x30"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+              "colVals": [],
+              "children": [],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+              "colVals": [],
+              "children": [],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::SubC (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::SubC",
+              "colVals": [],
+              "children": [
+                {
+                  "label": [
+                    {
+                      "Text": "sub_c_1"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "signed char"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x18"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x10"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "1"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [],
+                  "sym": null,
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes hole"
+                        }
+                      ],
+                      "colspan": 2
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "ItalicText": "3 bytes hole"
+                        }
+                      ],
+                      "colspan": 2
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                },
+                {
+                  "label": [
+                    {
+                      "Text": "sub_c_2"
+                    }
+                  ],
+                  "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
+                  "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "int"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x1c"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "@ 0x14"
+                        }
+                      ],
+                      "colspan": 1
+                    },
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "4"
+                        }
+                      ],
+                      "colspan": 1
+                    }
+                  ],
+                  "children": [],
+                  "colspan": 1
+                }
+              ],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+              "colVals": [],
+              "children": [],
+              "colspan": 6
+            },
+            {
+              "label": [
+                {
+                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                }
+              ],
+              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
+              "colVals": [],
+              "children": [],
+              "colspan": 6
+            }
+          ],
+          "colspan": 6
+        }
+      ]
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -349,6 +349,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_field_layout::platform_specific_field::S1",
+                "offsetBytes": 0,
                 "props": []
               }
             ],
@@ -423,6 +424,7 @@ expression: "&to_value(sttl).unwrap()"
                 "supers": [
                   {
                     "sym": "T_field_layout::platform_specific_field::S1",
+                    "offsetBytes": 0,
                     "props": []
                   }
                 ],
@@ -520,6 +522,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_field_layout::platform_specific_field::S2",
+                "offsetBytes": 0,
                 "props": []
               }
             ],
@@ -582,6 +585,7 @@ expression: "&to_value(sttl).unwrap()"
                 "supers": [
                   {
                     "sym": "T_field_layout::platform_specific_field::S2",
+                    "offsetBytes": 0,
                     "props": []
                   }
                 ],

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#8"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#11"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#15"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#20"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#23"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#28"
@@ -311,6 +317,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "linux64",
                   "macosx64"
@@ -481,6 +488,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "linux64"
                 ]
@@ -621,6 +629,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "linux64"
                 ]

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#32"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#36"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#39"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#41"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#46"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#49"
@@ -175,7 +181,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#53"
@@ -251,7 +258,8 @@ expression: "&to_value(sttl).unwrap()"
             "props": [],
             "subclasses": [
               "T_field_layout::platform_specific_field::T2"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_field.cpp#31"
@@ -422,6 +430,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "macosx64"
                 ]
@@ -580,6 +589,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "linux64",
                   "macosx64"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -282,6 +282,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_field_layout::platform_specific_field::T1",
+                "offsetBytes": 0,
                 "props": []
               }
             ],
@@ -365,6 +366,7 @@ expression: "&to_value(sttl).unwrap()"
                 "supers": [
                   {
                     "sym": "T_field_layout::platform_specific_field::T1",
+                    "offsetBytes": 0,
                     "props": []
                   }
                 ],
@@ -462,6 +464,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_field_layout::platform_specific_field::T2",
+                "offsetBytes": 0,
                 "props": []
               }
             ],
@@ -533,6 +536,7 @@ expression: "&to_value(sttl).unwrap()"
                 "supers": [
                   {
                     "sym": "T_field_layout::platform_specific_field::T2",
+                    "offsetBytes": 0,
                     "props": []
                   }
                 ],

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "field-layout/platform_specific_size.cpp#20"
@@ -147,6 +148,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "overrides": [],
                 "props": [],
+                "variants": [],
                 "platforms": [
                   "linux64",
                   "macosx64"

--- a/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@abstractart__beart__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@abstractart__beart__lookup__json.snap
@@ -32,6 +32,7 @@ expression: "&to_value(jvl).unwrap()"
           "overriddenBy": [
             "_ZN7outerNS12PracticalArt5beArtEv"
           ],
+          "variants": [],
           "args": []
         },
         "jumps": {

--- a/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@big_header__h__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@big_header__h__lookup__json.snap
@@ -23,7 +23,8 @@ expression: "&to_value(jvl).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         },
         "jumps": {
           "def": "big_cpp.cpp#1"

--- a/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@header_declared_func__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@header_declared_func__lookup__json.snap
@@ -24,6 +24,7 @@ expression: "&to_value(jvl).unwrap()"
           "fields": [],
           "overrides": [],
           "props": [],
+          "variants": [],
           "args": []
         },
         "jumps": {

--- a/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@practicalart__beart__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/big_cpp.cpp/check_glob@practicalart__beart__lookup__json.snap
@@ -33,6 +33,7 @@ expression: "&to_value(jvl).unwrap()"
             "virtual",
             "user"
           ],
+          "variants": [],
           "args": []
         },
         "jumps": {

--- a/tests/tests/checks/snapshots/jumpref/jumpref/simple.rs/check_glob@loader__needs_hard_reload__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/simple.rs/check_glob@loader__needs_hard_reload__lookup__json.snap
@@ -24,7 +24,8 @@ expression: "&to_value(jvl).unwrap()"
           "methods": [],
           "fields": [],
           "overrides": [],
-          "props": []
+          "props": [],
+          "variants": []
         },
         "jumps": {
           "def": "simple.rs#45"

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -25,7 +25,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#245"
@@ -50,7 +51,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#241"
@@ -75,7 +77,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#242"
@@ -100,7 +103,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#244"
@@ -125,7 +129,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#151"
@@ -150,7 +155,8 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [],
             "overrides": [],
-            "props": []
+            "props": [],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#147"
@@ -355,7 +361,8 @@ expression: "&to_value(sttl).unwrap()"
             "props": [],
             "labels": [
               "cc"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#227"
@@ -480,7 +487,8 @@ expression: "&to_value(sttl).unwrap()"
               "T_outerNS::Couch",
               "T_outerNS::OuterCat",
               "T_outerNS::AbstractArt"
-            ]
+            ],
+            "variants": []
           },
           "jumps": {
             "def": "big_cpp.cpp#141"

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -179,6 +179,7 @@ expression: "&to_value(sttl).unwrap()"
             "supers": [
               {
                 "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
                 "props": []
               }
             ],

--- a/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
@@ -128,6 +128,7 @@ expression: "&to_value(grb).unwrap()"
         "supers": [
           {
             "sym": "T_outerNS::Thing",
+            "offsetBytes": 0,
             "props": []
           }
         ],

--- a/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
@@ -310,7 +310,8 @@ expression: "&to_value(grb).unwrap()"
         "props": [],
         "labels": [
           "cc"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#227"
@@ -435,7 +436,8 @@ expression: "&to_value(grb).unwrap()"
           "T_outerNS::Couch",
           "T_outerNS::OuterCat",
           "T_outerNS::AbstractArt"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "big_cpp.cpp#141"
@@ -468,6 +470,7 @@ expression: "&to_value(grb).unwrap()"
         "overriddenBy": [
           "_ZN7outerNS9Superhero10takeDamageEi"
         ],
+        "variants": [],
         "args": [
           {
             "name": "damage",
@@ -502,6 +505,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "couch",
@@ -537,6 +541,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",
@@ -572,6 +577,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "thing",

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_left_one_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_left_one_right__svg.snap
@@ -158,7 +158,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#28"
@@ -231,7 +232,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#8"
@@ -295,7 +297,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#23"
@@ -368,7 +371,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#16"
@@ -397,6 +401,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -426,6 +431,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "four",
@@ -462,6 +468,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -508,6 +515,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_one__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_one__svg.snap
@@ -223,7 +223,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#28"
@@ -296,7 +297,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#8"
@@ -360,7 +362,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#23"
@@ -433,7 +436,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#16"
@@ -462,6 +466,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -491,6 +496,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -520,6 +526,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "four",
@@ -556,6 +563,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -602,6 +610,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -648,6 +657,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",
@@ -689,6 +699,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_to__four_left_and_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_to__four_left_and_right__svg.snap
@@ -213,6 +213,7 @@ expression: "&to_value(grb).unwrap()"
         "fields": [],
         "overrides": [],
         "props": [],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -286,7 +287,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#28"
@@ -359,7 +361,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#8"
@@ -423,7 +426,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#23"
@@ -496,7 +500,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "lots_of_calls.cpp#16"
@@ -525,6 +530,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -554,6 +560,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -583,6 +590,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "four",
@@ -619,6 +627,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -665,6 +674,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "two",
@@ -711,6 +721,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",
@@ -752,6 +763,7 @@ expression: "&to_value(grb).unwrap()"
           "instance",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "three",

--- a/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
@@ -228,6 +228,7 @@ expression: "&to_value(grb).unwrap()"
         "fields": [],
         "overrides": [],
         "props": [],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -325,7 +326,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "runnables.cpp#45"
@@ -425,7 +427,8 @@ expression: "&to_value(grb).unwrap()"
         "props": [],
         "subclasses": [
           "T_SandalRunnable"
-        ]
+        ],
+        "variants": []
       },
       "jumps": {
         "def": "runnables.cpp#33"
@@ -522,7 +525,8 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [],
         "overrides": [],
-        "props": []
+        "props": [],
+        "variants": []
       },
       "jumps": {
         "def": "runnables.cpp#22"
@@ -547,6 +551,7 @@ expression: "&to_value(grb).unwrap()"
         "fields": [],
         "overrides": [],
         "props": [],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -591,6 +596,7 @@ expression: "&to_value(grb).unwrap()"
         "overriddenBy": [
           "_ZN14SandalRunnable3RunEP10Dispatcher"
         ],
+        "variants": [],
         "args": [
           {
             "name": "aDispatcher",
@@ -634,6 +640,7 @@ expression: "&to_value(grb).unwrap()"
           "defaulted",
           "constexpr"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -675,6 +682,7 @@ expression: "&to_value(grb).unwrap()"
           "virtual",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "aDispatcher",
@@ -718,6 +726,7 @@ expression: "&to_value(grb).unwrap()"
           "defaulted",
           "constexpr"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {
@@ -759,6 +768,7 @@ expression: "&to_value(grb).unwrap()"
           "virtual",
           "user"
         ],
+        "variants": [],
         "args": [
           {
             "name": "aDispatcher",
@@ -802,6 +812,7 @@ expression: "&to_value(grb).unwrap()"
           "defaulted",
           "constexpr"
         ],
+        "variants": [],
         "args": []
       },
       "jumps": {

--- a/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
@@ -252,6 +252,7 @@ expression: "&to_value(grb).unwrap()"
         "supers": [
           {
             "sym": "T_ShoeRunnable",
+            "offsetBytes": 0,
             "props": []
           }
         ],
@@ -350,6 +351,7 @@ expression: "&to_value(grb).unwrap()"
         "supers": [
           {
             "sym": "T_nsIRunnable",
+            "offsetBytes": 0,
             "props": []
           }
         ],
@@ -451,6 +453,7 @@ expression: "&to_value(grb).unwrap()"
         "supers": [
           {
             "sym": "T_nsIRunnable",
+            "offsetBytes": 0,
             "props": []
           }
         ],

--- a/tests/tests/files/field-layout/multiple_inheritance.cpp
+++ b/tests/tests/files/field-layout/multiple_inheritance.cpp
@@ -1,0 +1,61 @@
+#include <stdint.h>
+
+namespace field_layout {
+
+namespace multiple_inheritance {
+
+struct BaseEmpty {
+};
+
+struct SubA : public BaseEmpty {
+  int32_t sub_a_1;
+  int16_t sub_a_2;
+};
+
+struct SubB : public BaseEmpty {
+  int32_t sub_b_1;
+  int8_t sub_b_2;
+#ifdef TARGET_win64
+  int64_t sub_b_3;
+#endif
+};
+
+struct SubC : public BaseEmpty {
+  int8_t sub_c_1;
+  int32_t sub_c_2;
+};
+
+struct SubD : public SubC {
+  int32_t sub_d_1;
+  int8_t sub_d_2;
+};
+
+struct SubE : public BaseEmpty {
+  int64_t sub_e_1;
+  int32_t sub_e_2;
+};
+
+
+struct SubSubA : public SubA,
+                 public SubB,
+                 public SubD {
+  int32_t sub_sub_c_1;
+};
+
+struct SubSubB : public SubE {
+  int32_t sub_sub_b_1;
+};
+
+struct SubSubSubA : public SubSubA,
+                    public SubSubB {
+  int32_t sub_sub_sub_a_1;
+};
+
+SubSubSubA f() {
+  SubSubSubA s;
+  return s;
+}
+
+}
+
+}

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -231,6 +231,7 @@ fn make_subsystem(path: &Ustr, file_sym: &Ustr,
             idl_sym: None,
             subclass_syms: vec![],
             overridden_by_syms: vec![],
+            variants: vec![],
             extra: Map::default(),
         };
         meta_table.insert(file_structured.sym.clone(), file_structured);

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -873,6 +873,7 @@ fn analyze_using_scip(
                         Some("class") => {
                             supers.push(StructuredSuperInfo {
                                 sym: ustr(&parent_symbol_info.norm_sym),
+                                offset_bytes: 0,
                                 props: vec![],
                             });
                         }

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -916,6 +916,7 @@ fn analyze_using_scip(
                     idl_sym: None,
                     subclass_syms: vec![],
                     overridden_by_syms: vec![],
+                    variants: vec![],
                     extra: Map::default(),
                 };
                 // for local symbols we use our own symbol because the SCIP symbol is not
@@ -1143,6 +1144,7 @@ fn analyze_using_scip(
                         idl_sym: None,
                         subclass_syms: vec![],
                         overridden_by_syms: vec![],
+                        variants: vec![],
                         extra: Map::default(),
                     };
                     scip_symbol_to_structured.insert(norm_scip_sym.to_owned(), fake);

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -552,10 +552,10 @@ impl SupersMap {
 
 struct ClassMap {
     // All processed classes.
-    class_map: HashMap<ClassId, Class>,
+    class_map: HashMap<TraversalId, Class>,
 
     // The list of classes, in the traverse order.
-    class_list: Vec<ClassId>,
+    class_list: Vec<TraversalId>,
 
     // All platforms appeared inside the analysis.
     platform_map: PlatformMap,
@@ -619,8 +619,8 @@ impl ClassMap {
 
             traversal_index += 1;
 
-            self.class_list.push(cls.id.clone());
-            self.class_map.insert(cls.id.clone(), cls);
+            self.class_list.push(traversal_id.clone());
+            self.class_map.insert(traversal_id.clone(), cls);
 
             let mut supers = SupersMap::new();
 
@@ -699,7 +699,7 @@ impl ClassMap {
         for (group_id, platforms) in &self.groups {
             if let Some(fields) = fields_per_platform.get_fields_for_platforms(platforms) {
                 for field in fields {
-                    let cls = self.class_map.get_mut(&field.class_id).unwrap();
+                    let cls = self.class_map.get_mut(&field.class_traversal_id).unwrap();
                     cls.add_field(group_id.clone(), field.clone());
                 }
             }
@@ -795,8 +795,8 @@ impl ClassMap {
 
         let mut root_node: Option<SymbolTreeTableNode> = None;
 
-        for class_id in &self.class_list {
-            let cls = self.class_map.get(&class_id).unwrap();
+        for traversal_id in &self.class_list {
+            let cls = self.class_map.get(&traversal_id).unwrap();
 
             let is_root = cls.id == self.root_class_id.as_ref().unwrap().clone();
 

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -620,8 +620,7 @@ impl ClassMap {
                 }
             }
 
-            let variants = structured.variants();
-            for v in variants {
+            for v in &structured.variants {
                 if let Some(size) = &v.size_bytes {
                     let platforms = v.platforms();
                     for platform in platforms {

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -244,7 +244,6 @@ impl FieldsWithHash {
 struct Class {
     id: SymbolGraphNodeId,
     name: String,
-    supers: Vec<SymbolGraphNodeId>,
     fields: HashMap<SymbolGraphNodeId, HashMap<PlatformGroupId, Field>>,
     merged_fields: Vec<Vec<Option<Field>>>,
 }
@@ -254,7 +253,6 @@ impl Class {
         Self {
             id: id,
             name: name,
-            supers: vec![],
             fields: HashMap::new(),
             merged_fields: vec![],
         }
@@ -554,7 +552,7 @@ impl ClassMap {
             let depth = sym_info.depth;
             let structured = sym_info.get_structured().unwrap();
 
-            let mut cls = Class::new(
+            let cls = Class::new(
                 class_id.clone(),
                 structured.pretty.to_string(),
             );
@@ -568,7 +566,6 @@ impl ClassMap {
                     .node_set
                     .ensure_symbol(&super_info.sym, server, depth + 1)
                     .await?;
-                cls.supers.push(super_id.clone());
                 pending_ids.push_back(super_id);
             }
             self.class_list.push(cls.id.clone());

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -80,7 +80,7 @@ struct TraversalId(u32);
 struct Field {
     class_id: ClassId,
     class_traversal_id: TraversalId,
-    class_size: Option<u32>,
+    class_end_offset: Option<u32>,
     field_id: FieldId,
     type_pretty: String,
     pretty: String,
@@ -100,7 +100,7 @@ impl Field {
         Self {
             class_id: class_id,
             class_traversal_id: class_traversal_id,
-            class_size: class_size,
+            class_end_offset: class_size.map(|size| class_offset + size),
             field_id: field_id,
             type_pretty: info.type_pretty.to_string(),
             pretty: info.pretty.to_string(),
@@ -155,11 +155,11 @@ impl FieldsWithHash {
             if self.fields[index].offset_bytes > last_end_offset {
                 if index != last_index {
                     if self.fields[last_index].class_traversal_id != self.fields[index].class_traversal_id {
-                        if let Some(size) = &self.fields[last_index].class_size.clone() {
-                            if last_end_offset < *size {
-                                self.fields[last_index].end_padding_bytes = Some(size - last_end_offset);
+                        if let Some(end_offset) = &self.fields[last_index].class_end_offset.clone() {
+                            if last_end_offset < *end_offset {
+                                self.fields[last_index].end_padding_bytes = Some(end_offset - last_end_offset);
                             }
-                            last_end_offset = *size;
+                            last_end_offset = *end_offset;
                         }
 
                         self.fields[index].hole_after_base = true;
@@ -187,9 +187,9 @@ impl FieldsWithHash {
         }
 
         if !self.fields.is_empty() {
-            if let Some(size) = &self.fields[last_index].class_size {
-                if last_end_offset < *size {
-                    self.fields[last_index].end_padding_bytes = Some(size - last_end_offset);
+            if let Some(end_offset) = &self.fields[last_index].class_end_offset {
+                if last_end_offset < *end_offset {
+                    self.fields[last_index].end_padding_bytes = Some(end_offset - last_end_offset);
                 }
             }
         }

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -218,6 +218,8 @@ where
 {
     #[serde(default)]
     pub sym: StrT,
+    #[serde(rename = "offsetBytes", default)]
+    pub offset_bytes: u32,
     #[serde(default)]
     pub props: Vec<StrT>,
 }


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1900692

This does the following:
  * Sync clang plugin with m-c, including [bug 1900465](https://bugzilla.mozilla.org/show_bug.cgi?id=1900465)
  * Cleanup the variant handling not to rely in "main vs variants" groups
    * populate the list of all platforms appears in the class hierarchy as first step
    * perform the remaining steps based on the list of all platforms
  * Reflect super class's offset to the field offset, for multiple inheritance case
  * Instead of tracking the class size, track the end offset of the class, so that it reflects the class offset as well
  * Add `TraveralId` to handle a class that appears multiple times in the class hierarchy, for multiple instance case
  * Reflect super classes in all variants

Result with nsGlobalWindowInner

![field-layout-nsGlobalWindowInner](https://github.com/mozsearch/mozsearch/assets/6299746/4f89baef-682e-425c-8f87-4c1bf00497e1)
