### PR TITLE
Bug 1900823 - Linkify resource:// and chrome:// URLs in textual occurrences

### DIFF
--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -113,7 +113,7 @@ $MOZSEARCH_PATH/scripts/crossref.sh $CONFIG_FILE $TREE_NAME $ANALYSIS_FILES_PATH
 
 date
 
-$MOZSEARCH_PATH/scripts/output.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME || handle_tree_error "output.sh"
+$MOZSEARCH_PATH/scripts/output.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME $URL_MAP_PATH || handle_tree_error "output.sh"
 
 date
 

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -4,15 +4,16 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-if [ $# -ne 3 ]
+if [ $# -ne 4 ]
 then
-    echo "Usage: output.sh config_repo config-file.json tree_name"
+    echo "Usage: output.sh config_repo config-file.json tree_name url-map.json"
     exit 1
 fi
 
 CONFIG_REPO=$(realpath $1)
 CONFIG_FILE=$(realpath $2)
 TREE_NAME=$3
+URL_MAP_PATH=$4
 
 # let's put the "parallel" output in a new `diags` directory, as we're still
 # seeing really poor output-file performance in bug 1567724.
@@ -63,7 +64,7 @@ TMPDIR_PATH=${DIAGS_DIR}
 #   which is obviously suboptimal.
 parallel --jobs 8 --pipepart -a $INDEX_ROOT/all-files --files --joblog $JOBLOG_PATH --tmpdir $TMPDIR_PATH \
     --block -1 --halt 2 --env RUST_BACKTRACE \
-    "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME - 2>&1"
+    "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME $URL_MAP_PATH - 2>&1"
 
 TOOL_CMD="search-files --limit=0 --include-dirs --group-by=directory | batch-render dir"
 SEARCHFOX_SERVER=${CONFIG_FILE} \

--- a/scripts/process-chrome-map.py
+++ b/scripts/process-chrome-map.py
@@ -39,10 +39,10 @@ def process_chrome_map(url_map, chrome_map_path, topsrcdir):
     def get_overrides(url):
         """Returns all overridden URLs for given URL."""
         for to_name, from_name in overrides.items():
-            if to_name == url:
-                yield from_name
+            if from_name == url:
+                yield to_name
 
-                yield from get_overrides(from_name)
+                yield from get_overrides(to_name)
 
 
     def add_entries(url_map, src, obj):

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -1,3 +1,7 @@
+function atUnescape(text) {
+  return text.replace(/@([0-9A-F][0-9A-F])/g, (_, s) => String.fromCharCode(parseInt(s, 16)));
+}
+
 var ContextMenu = new (class ContextMenu {
   constructor() {
     this.menu = document.createElement("ul");
@@ -36,6 +40,17 @@ var ContextMenu = new (class ContextMenu {
         lang = "C++";
       }
       return lang;
+  }
+
+  generatePseudoFileSymInfo(sym) {
+    let file = atUnescape(sym.replace(/^FILE_/, ""));
+    return {
+      sym: sym,
+      pretty: file,
+      jumps: {
+        def: file + "#1",
+      },
+    };
   }
 
   tryShowOnClick(event) {
@@ -132,7 +147,14 @@ var ContextMenu = new (class ContextMenu {
           continue;
         }
 
-        const symInfo = SYM_INFO[sym];
+        let symInfo = SYM_INFO[sym];
+
+        if (!symInfo) {
+          if (sym.startsWith("FILE_")) {
+            symInfo = this.generatePseudoFileSymInfo(sym);
+          }
+        }
+
         // XXX Ignore no_crossref data that's currently not useful/used.
         if (!symInfo || !symInfo.sym || !symInfo.pretty) {
           continue;

--- a/tests/tests/checks/inputs/web/files/urlmap/links_in_comment__html
+++ b/tests/tests/checks/inputs/web/files/urlmap/links_in_comment__html
@@ -1,0 +1,1 @@
+cat-html urlmap/root.cpp --select ".syn_comment span"

--- a/tests/tests/checks/snapshots/web/files/urlmap/check_glob@links_in_comment__html.snap
+++ b/tests/tests/checks/snapshots/web/files/urlmap/check_glob@links_in_comment__html.snap
@@ -1,0 +1,8 @@
+---
+source: tests/test_check_insta.rs
+expression: "&fb.contents"
+---
+<span data-symbols="FILE_urlmap/chrome1@2Emjs,FILE_urlmap/chrome1b@2Emjs">chrome://global/content/test/chrome1.mjs</span>
+<span data-symbols="FILE_urlmap/resource1@2Emjs">resource://test/resource1.mjs</span>
+<span data-symbols="FILE_urlmap/chrome1@2Ecss">chrome://global/content/test/chrome1.css</span>
+<span data-symbols="FILE_urlmap/resource1@2Epng">resource://test/resource1.png</span>

--- a/tests/tests/files/urlmap/root.cpp
+++ b/tests/tests/files/urlmap/root.cpp
@@ -1,0 +1,9 @@
+/**
+ * chrome://global/content/test/chrome1.mjs
+ * https://bugzilla.mozilla.org/
+ * resource://test/resource1.mjs
+ */
+
+// chrome://global/content/test/chrome1.css
+// https://bugzilla.mozilla.org/
+// resource://test/resource1.png

--- a/tests/tests/metadata/test.chrome-map.json
+++ b/tests/tests/metadata/test.chrome-map.json
@@ -8,8 +8,8 @@
     ]
   },
   {
-    "chrome://global/content/test/chrome1.mjs": "chrome://global/content/test/chrome4.mjs",
-    "resource://test/resource1.mjs": "resource://test/resource4.mjs"
+    "chrome://global/content/test/chrome4.mjs": "chrome://global/content/test/chrome1.mjs",
+    "resource://test/resource4.mjs": "resource://test/resource1.mjs"
   },
   {
     "dist/bin/chrome/test/chrome1.mjs": [

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -56,6 +56,8 @@ reqwest = "0.11.3"
 rls-analysis = "0.18.1"
 rls-data = "0.19.1"
 scip = "0.3.3"
+# NOTE: serde_json dependency is also defined above, without "std" feature.
+#       The "std" feature should be enabled only for non-wasm case.
 serde_json = { version = "1.0.113", features = ["preserve_order", "std"] }
 shell-words = "1.0.0"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util", "signal"] }

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -56,6 +56,7 @@ reqwest = "0.11.3"
 rls-analysis = "0.18.1"
 rls-data = "0.19.1"
 scip = "0.3.3"
+serde_json = { version = "1.0.113", features = ["preserve_order", "std"] }
 shell-words = "1.0.0"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util", "signal"] }
 tokio-stream = "0.1.8"

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -32,6 +32,8 @@ use tools::languages;
 
 use tools::output::{PanelItem, PanelSection};
 
+use tools::url_map_handler::set_url_map_path;
+
 extern crate flate2;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -41,7 +43,7 @@ fn main() {
 
     let args: Vec<_> = env::args().collect();
     // TODO: refactor _fname_args out of existence; we now require paths to come via stdin.
-    let (base_args, _fname_args) = args.split_at(3);
+    let (base_args, _fname_args) = args.split_at(4);
 
     let mut stdout = io::stdout().lock();
 
@@ -54,6 +56,8 @@ fn main() {
         pre_config.elapsed().as_micros() as u64
     )
     .unwrap();
+
+    set_url_map_path(&base_args[3]);
 
     let tree_config = cfg.trees.get(tree_name).unwrap();
 

--- a/tools/src/file_format/mod.rs
+++ b/tools/src/file_format/mod.rs
@@ -26,3 +26,5 @@ pub mod ontology_mapping;
 pub mod per_file_info;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod repo_data_ingestion;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod url_map;

--- a/tools/src/file_format/url_map.rs
+++ b/tools/src/file_format/url_map.rs
@@ -32,8 +32,14 @@ impl URLMap {
 }
 
 pub fn read_url_map(
-    filename: &str,
+    maybe_filename: Option<&str>,
 ) -> URLMap {
+    if maybe_filename.is_none() {
+        return URLMap::new_empty();
+    }
+
+    let filename = maybe_filename.unwrap();
+
     let file = match File::open(filename) {
         Ok(f) => f,
         Err(_) => {

--- a/tools/src/file_format/url_map.rs
+++ b/tools/src/file_format/url_map.rs
@@ -1,0 +1,54 @@
+use std::collections::HashMap;
+use std::fs::File;
+use serde_json::from_reader;
+use serde::Deserialize;
+
+#[derive(Clone, Deserialize)]
+pub struct URLMapItem {
+    pub pretty: String,
+    pub sym: String,
+}
+
+pub struct URLMap {
+    data: HashMap<String, Vec<URLMapItem>>,
+}
+
+impl URLMap {
+    fn new(data: HashMap<String, Vec<URLMapItem>>) -> Self {
+        Self {
+            data: data,
+        }
+    }
+
+    fn new_empty() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, sym: &String) -> Option<Vec<URLMapItem>> {
+        self.data.get(sym).cloned()
+    }
+}
+
+pub fn read_url_map(
+    filename: &str,
+) -> URLMap {
+    let file = match File::open(filename) {
+        Ok(f) => f,
+        Err(_) => {
+            info!("Error trying to open URL map file [{}]", filename);
+            return URLMap::new_empty();
+        }
+    };
+
+    let data: HashMap<String, Vec<URLMapItem>> = match from_reader(file) {
+        Ok(result) => result,
+        Err(_) => {
+            info!("Error trying to read URL map file [{}]", filename);
+            return URLMap::new_empty();
+        }
+    };
+
+    URLMap::new(data)
+}

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -71,4 +71,6 @@ pub mod output;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tokenize;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod url_map_handler;
+#[cfg(not(target_arch = "wasm32"))]
 mod symbol_graph_edge_kind;

--- a/tools/src/links.rs
+++ b/tools/src/links.rs
@@ -20,6 +20,14 @@ pub fn linkify_comment(s: String) -> String {
 
         if link.as_str().starts_with("chrome://") || link.as_str().starts_with("resource://") {
             if let Some(items) = get_file_paths_for_url(link.as_str()) {
+                // The corresponding symbol data is not added to SYM_INFO.
+                // The context menu is supposed to generate a pseudo data
+                // for the file.
+                //
+                // If we want to make this a real reference, an extra linkify
+                // step should be performed before crossref, with generating
+                // extra analaysis records while not writing the resulting
+                // HTML to a file.
                 result.push_str(&format!(
                     "<span data-symbols=\"{}\">{}</span>",
                     items.iter().map(|item| &item.sym).join(","),

--- a/tools/src/url_map_handler.rs
+++ b/tools/src/url_map_handler.rs
@@ -12,7 +12,7 @@ pub fn set_url_map_path(path: &str) {
 pub fn get_file_paths_for_url(url: &str) -> Option<Vec<URLMapItem>> {
     lazy_static! {
         static ref URL_MAP: URLMap = unsafe {
-            read_url_map(URL_MAP_PATH.as_ref().unwrap().as_str())
+            read_url_map(URL_MAP_PATH.as_ref().map(|s| s.as_str()))
         };
     }
 

--- a/tools/src/url_map_handler.rs
+++ b/tools/src/url_map_handler.rs
@@ -16,6 +16,6 @@ pub fn get_file_paths_for_url(url: &str) -> Option<Vec<URLMapItem>> {
         };
     }
 
-    let sym = format!("URL_{}", mangle_file(url));
-    return URL_MAP.get(&sym)
+    let url_map_key = format!("URL_{}", mangle_file(url));
+    return URL_MAP.get(&url_map_key)
 }

--- a/tools/src/url_map_handler.rs
+++ b/tools/src/url_map_handler.rs
@@ -1,0 +1,21 @@
+use crate::file_format::url_map::{ URLMap, URLMapItem, read_url_map };
+use crate::file_format::analysis_manglings::mangle_file;
+
+static mut URL_MAP_PATH: Option<String> = None;
+
+pub fn set_url_map_path(path: &str) {
+    unsafe {
+        URL_MAP_PATH = Some(path.to_string());
+    }
+}
+
+pub fn get_file_paths_for_url(url: &str) -> Option<Vec<URLMapItem>> {
+    lazy_static! {
+        static ref URL_MAP: URLMap = unsafe {
+            read_url_map(URL_MAP_PATH.as_ref().unwrap().as_str())
+        };
+    }
+
+    let sym = format!("URL_{}", mangle_file(url));
+    return URL_MAP.get(&sym)
+}


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1900823

This does the following:
  * Fix the chrome-map handling (basically this reverts https://github.com/arai-a/mozsearch/commit/98654da28d200dd7dbf106c76d29602b3fc5033b .  the code was correct but the test data was wrong)
  * Make the output step to generate a `FILE_` symbols span for `chrome://` and `resource://` URLs inside comments, without reflecting it to `SYM_INFO`
  * Make the context menu handling to generate pseudo symbol info for unknown `FILE_` symbols

This linkifies URLs in `jar.mn` , and it discovered the chrome-map handling bug.

<img width="637" alt="link-chrome" src="https://github.com/mozsearch/mozsearch/assets/6299746/8d8cf6b9-9251-480a-ae4c-b5845a95f160">
