### PR TITLE
Bug 1901146 - Add space between tables in field layout view for each class hierarchy

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1315,6 +1315,10 @@ g.true-diag g.node polygon {
   border-collapse: separate;
 }
 
+.symbol-tree-table + .symbol-tree-table {
+  margin-top: 2em;
+}
+
 .symbol-tree-table h3 {
   margin: 0;
 }


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1901146

This adds spacing (margin) before 2nd+ tables for field layout view.

<img width="634" alt="table-space" src="https://github.com/mozsearch/mozsearch/assets/6299746/7a499e63-db43-495c-8fa6-c77dda2cfac3">
