### PR TITLE
Bug 1901279 - Show only classes/structs in field layout view

### DIFF
--- a/tests/tests/checks/inputs/fancy/format-symbol/field-layout/non-struct.cpp/field_layout__non_struct__json
+++ b/tests/tests/checks/inputs/fancy/format-symbol/field-layout/non-struct.cpp/field_layout__non_struct__json
@@ -1,0 +1,1 @@
+search-identifiers field_layout::non_struct::Proxy | crossref-lookup | format-symbols --mode="field-layout"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -1,0 +1,180 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(sttl).unwrap()"
+---
+{
+  "tables": [
+    {
+      "jumprefs": {
+        "F_<T_field_layout::non_struct::Proxy>_x": {
+          "sym": "F_<T_field_layout::non_struct::Proxy>_x",
+          "pretty": "field_layout::non_struct::Proxy::x",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::non_struct::Proxy::x",
+            "sym": "F_<T_field_layout::non_struct::Proxy>_x",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::non_struct::Proxy",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/non-struct.cpp#11"
+          }
+        },
+        "T_field_layout::non_struct::Proxy": {
+          "sym": "T_field_layout::non_struct::Proxy",
+          "pretty": "field_layout::non_struct::Proxy",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::non_struct::Proxy",
+            "sym": "T_field_layout::non_struct::Proxy",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 1,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [
+              {
+                "pretty": "field_layout::non_struct::Proxy::x",
+                "sym": "F_<T_field_layout::non_struct::Proxy>_x",
+                "type": "signed char",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 1
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/non-struct.cpp#10"
+          }
+        }
+      },
+      "columns": [
+        {
+          "label": [
+            {
+              "Heading": "Name"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "Type"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "All platforms"
+            }
+          ],
+          "colspan": 2
+        }
+      ],
+      "sub_columns": [
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Offset"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Size"
+            }
+          ],
+          "colspan": 1
+        }
+      ],
+      "rows": [
+        {
+          "label": [
+            {
+              "Heading": "field_layout::non_struct::Proxy"
+            }
+          ],
+          "sym": "T_field_layout::non_struct::Proxy",
+          "colVals": [],
+          "children": [
+            {
+              "label": [
+                {
+                  "Text": "x"
+                }
+              ],
+              "sym": "F_<T_field_layout::non_struct::Proxy>_x",
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "signed char"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x0"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": [],
+              "colspan": 1
+            }
+          ],
+          "colspan": 4
+        }
+      ]
+    }
+  ]
+}

--- a/tests/tests/files/field-layout/non-struct.cpp
+++ b/tests/tests/files/field-layout/non-struct.cpp
@@ -1,0 +1,16 @@
+#include <stdint.h>
+
+namespace field_layout {
+
+namespace non_struct {
+
+void proxy() {
+}
+
+class Proxy {
+  int8_t x;
+};
+
+}
+
+}

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -1077,8 +1077,8 @@ impl ClassMap {
 
         if let Some(node) = root_node {
             self.stt.rows.push(node);
+            tables.push(self.stt);
         }
-        tables.push(self.stt);
     }
 }
 


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1901279

This does the following:
  * While traversing, filter out structured record that doesn't correspond to struct-ish data (https://clang.llvm.org/doxygen/namespaceclang.html#a9237bdb3cf715b9bff8bcb3172635548 suggests there can be some more than struct/class)
  * Do not add a table if the table is empty (the table is non-empty even if the struct has no field, because the table has the class name row)
