### PR TITLE
Bug 1416899 - Index WebIDL files

### DIFF
--- a/scripts/find-repo-files.py
+++ b/scripts/find-repo-files.py
@@ -36,6 +36,7 @@ js = []
 html = []
 css = []
 idl = []
+webidl = []
 ipdl = []
 
 dirs = collections.OrderedDict()
@@ -64,6 +65,13 @@ for line in lines:
                 continue
 
         idl.append(path + '\n')
+
+    if ext == '.webidl':
+        if 'filter_webidl' in repo_files:
+            if not repo_files['filter_webidl'](path):
+                continue
+
+        webidl.append(path + '\n')
 
     if ext in ['.ipdl', '.ipdlh']:
         if 'filter_ipdl' in repo_files:
@@ -103,5 +111,6 @@ open(os.path.join(index_path, 'js-files'), 'w').writelines(js)
 open(os.path.join(index_path, 'html-files'), 'w').writelines(html)
 open(os.path.join(index_path, 'css-files'), 'w').writelines(css)
 open(os.path.join(index_path, 'idl-files'), 'w').writelines(idl)
+open(os.path.join(index_path, 'webidl-files'), 'w').writelines(webidl)
 open(os.path.join(index_path, 'ipdl-files'), 'w').writelines(ipdl)
 open(os.path.join(index_path, 'ipdl-includes'), 'w').write(' '.join(['-I ' + d for d in ipdl_dirs]))

--- a/scripts/idl-analyze.sh
+++ b/scripts/idl-analyze.sh
@@ -13,17 +13,18 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
-if [ -f "${FILES_ROOT}/xpcom/idl-parser/xpidl/xpidl.py" ]; then
-    # The tree we're processing has an xpidl.py, so let's use that
+if [ -f "${FILES_ROOT}/xpcom/idl-parser/xpidl/xpidl.py" -a \
+     -f "${FILES_ROOT}/dom/bindings/parser/WebIDL.py" ]; then
+    # The tree we're processing has IDL parsers, so let's use that
     TREE_PYMODULES="/tmp/pymodules-${TREE_NAME}"
     PULL_FROM_MC=0
 else
-    # The tree we're processing doesn't have an xpidl.py, so we'll pull m-c's copy with wget
+    # The tree we're processing doesn't have IDL parsers, so we'll pull m-c's copy with wget
     TREE_PYMODULES="/tmp/pymodules"
     PULL_FROM_MC=1
 fi
 
-# Delete the temp dir if xpidl.py is older than a day (in minutes to avoid
+# Delete the temp dir if IDL parsers are older than a day (in minutes to avoid
 # quantization weirdness).  We'll also try and delete the dir if the file just
 # doesn't exist, which also means if the directory doesn't exist.  (We could
 # have instead done `-mmin +1440` for affirmative confirmation it's old, but
@@ -39,8 +40,10 @@ if [ ! -d "${TREE_PYMODULES}" ]; then
     pushd "${TREE_PYMODULES}"
     if [ $PULL_FROM_MC -eq 0 ]; then
         cp "${FILES_ROOT}/xpcom/idl-parser/xpidl/xpidl.py" ./
+        cp "${FILES_ROOT}/dom/bindings/parser/WebIDL.py" ./
     else
         wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/xpcom/idl-parser/xpidl/xpidl.py"
+        wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/dom/bindings/parser/WebIDL.py"
     fi
     mkdir ply
     pushd ply
@@ -60,4 +63,8 @@ export PYTHONPATH="${TREE_PYMODULES}"
 cat $INDEX_ROOT/idl-files | \
     parallel $MOZSEARCH_PATH/scripts/idl-analyze.py \
     $INDEX_ROOT $FILES_ROOT/{} ">" $INDEX_ROOT/analysis/{}
+
+cat $INDEX_ROOT/webidl-files | \
+    $MOZSEARCH_PATH/scripts/webidl-analyze.py \
+    $INDEX_ROOT $FILES_ROOT $INDEX_ROOT/analysis /tmp
 echo $?

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -411,9 +411,8 @@ def handle_maplike_or_setlike_or_iterable(records, iface_name, target):
     elif target.maplikeOrSetlikeOrIterableType == 'asynciterable':
         cpp_sym = f'NS_mozilla::dom::{iface_name}AsyncIterator_Binding'
     else:
-        print(f'WebIDL: Unknown maplikeOrSetlikeOrIterableType: {target.maplikeOrSetlikeOrIterableType}',
+        print(f'warning: WebIDL: Unknown maplikeOrSetlikeOrIterableType: {target.maplikeOrSetlikeOrIterableType}',
               file=sys.stderr)
-        sys.exit(1)
 
     emit_source(records, loc, 'idl', 'method', pretty, idl_sym)
     emit_target(records, loc, 'idl', pretty, idl_sym)
@@ -482,9 +481,8 @@ def handle_interface_or_namespace(records, target):
         elif isinstance(member, WebIDL.IDLAsyncIterable):
             handle_maplike_or_setlike_or_iterable(records, name, member)
         else:
-            print(f'WebIDL: Unknown member production: {member.__class__.__name__}',
+            print(f'warning: WebIDL: Unknown member production: {member.__class__.__name__}',
                   file=sys.stderr)
-            sys.exit(1)
 
     emit_structured(records, loc, 'class', pretty, idl_sym,
                     slots=slots, supers=supers,
@@ -548,9 +546,8 @@ def handle_dictionary(records, target):
             handle_dictionary_field(records, name, cpp_sym,
                                     fields, member)
         else:
-            print(f'WebIDL: Unknown member production: {member.__class__.__name__}',
+            print(f'warning: WebIDL: Unknown member production: {member.__class__.__name__}',
                   file=sys.stderr)
-            sys.exit(1)
 
     emit_structured(records, loc, 'class', pretty, idl_sym,
                     slots=slots, supers=supers,
@@ -713,9 +710,8 @@ def handle_productions(productions):
             records = get_records(target)
             handle_external_interface(records, target);
         else:
-            print(f'WebIDL: Unknown top-level production: {target.__class__.__name__}',
+            print(f'warning: WebIDL: Unknown top-level production: {target.__class__.__name__}',
                   file=sys.stderr)
-            sys.exit(1)
 
 
 def write_files(analysis_root):

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -408,10 +408,6 @@ def handle_maplike_or_setlike_or_iterable(records, iface_name, target):
     elif target.maplikeOrSetlikeOrIterableType == 'setlike':
         cpp_sym = f'NS_mozilla::dom::{iface_name}_Binding::SetlikeHelpers'
     elif target.maplikeOrSetlikeOrIterableType == 'iterable':
-        # NOTE: loc is wrong. it points '<' after 'iterable'.
-        # TODO: Fix the WebIDL parser.
-        location = target.identifier.location
-        loc = to_loc_with(location._lineno, location._colno - len(name), len(name))
         cpp_sym = f'NS_mozilla::dom::{iface_name}Iterator_Binding'
     elif target.maplikeOrSetlikeOrIterableType == 'asynciterable':
         cpp_sym = f'NS_mozilla::dom::{iface_name}AsyncIterator_Binding'
@@ -583,33 +579,11 @@ def handle_enum(records, target):
                     slots=slots)
 
 
-def get_typedef_loc(target, name):
-    '''Get the location string for the typedef identifier.
-
-    The IDLTypedef's identifier points the `typedef` token,
-    and we need to find the location from the line.
-
-    TODO: Fix the WebIDL parser.
-    '''
-
-    location = target.identifier.location
-    location.resolve()
-
-    line = location._line
-    index = line.find(f' {name};')
-    if index == -1:
-        return to_loc(target.identifier.location, name)
-
-    colno = index + 1
-
-    return to_loc_with(location._lineno, colno, len(name))
-
-
 def handle_typedef(records, target):
     '''Emit analysis record for IDLTypedef.'''
 
     name = target.identifier.name
-    loc = get_typedef_loc(target, name)
+    loc = to_loc(target.identifier.location, name)
     pretty = name
     idl_sym = f'WEBIDL_{name}'
 

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -1,0 +1,749 @@
+#!/usr/bin/env python3
+
+# See the comment at the top of idl-analyze.py file for the details about
+# how IDL indexing works.
+
+import json
+import os.path
+import re
+import sys
+
+import WebIDL
+
+# local path => records.
+analysis_map = {}
+
+# local path => interface name => member name => member symbols.
+cpp_analysis_map = {}
+
+
+def parse_mangled(mangled):
+    def parse_inner(idents, inner):
+        if inner[0] == 'E':
+            return True
+
+        m = re.match(r'L?([0-9]+)([a-zA-Z0-9_]+)', inner)
+        if not m:
+            return False
+
+        length = int(m.group(1))
+        idents.append(m.group(2)[:length])
+
+        return parse_inner(idents, m.group(2)[length:])
+
+    if mangled[:3] != '_ZN':
+        return
+
+    idents = []
+    if not parse_inner(idents, mangled[3:]):
+        return
+
+    return idents
+
+
+def read_cpp_analysis_one(path, cpp_symbols):
+    '''Read given analysis file and collect C++ symbols for generated code.'''
+
+    if not os.path.exists(path):
+        return
+
+    try:
+        lines = open(path).readlines()
+    except IOError as e:
+        return
+
+    for line in lines:
+        try:
+            j = json.loads(line.strip())
+        except ValueError as e:
+            print('Syntax error in JSON file', path, line.strip(), file=sys.stderr)
+            raise e
+
+        if 'target' in j and j['kind'] in ('decl', 'def'):
+            if not j['sym'].startswith('_Z'):
+                continue
+
+            idents = parse_mangled(j['sym'])
+            if not idents or len(idents) != 4:
+                continue
+
+            assert idents[0] == 'mozilla'
+            assert idents[1] == 'dom'
+            binding_name = idents[2].replace('_Binding', '')
+            member_name = idents[3]
+
+            cpp_symbols.setdefault(binding_name, {}).setdefault(member_name, []).append(j['sym'])
+
+
+def read_cpp_analysis(index_root, local_path):
+    '''Read analysis files for given WebIDL file and collect C++ symbols
+    for generated code.'''
+
+    base = os.path.basename(local_path)
+    (idl_name, suffix) = os.path.splitext(base)
+    header_name = idl_name + 'Binding.h'
+    cpp_name = idl_name + 'Binding.cpp'
+    cpp_symbols = {}
+
+    generated_dir = os.path.join(index_root, 'analysis', '__GENERATED__')
+    header_local_path = os.path.join('dist', 'include', 'mozilla', 'dom', header_name)
+    cpp_local_path = os.path.join('dom', 'bindings', cpp_name)
+
+    p = os.path.join(generated_dir, header_local_path)
+    read_cpp_analysis_one(p, cpp_symbols)
+    p = os.path.join(generated_dir, cpp_local_path)
+    read_cpp_analysis_one(p, cpp_symbols)
+
+    for name in os.listdir(generated_dir):
+        if name.startswith('__'):
+            p = os.path.join(generated_dir, name, header_local_path)
+            read_cpp_analysis_one(p, cpp_symbols)
+            p = os.path.join(generated_dir, name, cpp_local_path)
+            read_cpp_analysis_one(p, cpp_symbols)
+
+    return cpp_symbols
+
+
+def get_binary_name(target):
+    binary_name = target.getExtendedAttribute('BinaryName')
+    if not binary_name:
+        return None
+    return binary_name[0]
+
+
+def cpp_method_name(method, name):
+    '''Return the C++ pretty name for this method.'''
+    if isinstance(method, WebIDL.IDLConstructor):
+        return '_constructor'
+
+    binary_name = get_binary_name(method)
+    if binary_name:
+        return binary_name
+    return name
+
+
+def cpp_getter_name(attr, name):
+    '''Return the C++ pretty name for this getter.'''
+    binary_name = get_binary_name(attr)
+    if binary_name:
+        return 'get_' + binary_name
+    return 'get_' + name
+
+
+def cpp_setter_name(attr, name):
+    '''Return the C++ pretty name for this setter.'''
+    binary_name = get_binary_name(attr)
+    if binary_name:
+        return 'set_' + binary_name
+    return 'set_' + name
+
+
+def IDLToCIdentifier(name):
+    return name.replace('-', '_')
+
+
+def cpp_dictionary_field_name(name):
+    '''Return the C++ pretty name for this dictionary field.'''
+    return 'm' + name[0].upper() + IDLToCIdentifier(name[1:])
+
+
+def to_loc_with(lineno, colno, name_len):
+    return f'{lineno}:{colno}-{colno + name_len}'
+
+
+def to_loc(location, name):
+    location.resolve()
+    return to_loc_with(location._lineno, location._colno, len(name))
+
+
+def get_records(target):
+    '''Get the record list for given IDLObject's file.'''
+    local_path = target.location.filename
+    if local_path in analysis_map:
+        return analysis_map[local_path]
+
+    records = []
+    analysis_map[local_path] = records
+    return records
+
+
+def emit_source(records, loc, syntax, pretty_prefix, pretty, sym):
+    '''Emit AnalysisSource record.'''
+    records.append({
+        'loc': loc,
+        'source': 1,
+        'syntax': syntax,
+        'pretty': f'IDL {pretty_prefix} {pretty}',
+        'sym': sym,
+    })
+
+
+def emit_target(records, loc, kind, pretty, sym):
+    '''Emit AnalysisTarget record.'''
+    records.append({
+        'loc': loc,
+        'target': 1,
+        'kind': kind,
+        'pretty': pretty,
+        'sym': sym,
+    })
+
+
+def emit_structured(records, loc, kind, pretty, sym,
+                    slots=None, supers=None,
+                    methods=None, fields=None):
+    '''Emit AnalysisStructured record.'''
+    record = {
+        'loc': loc,
+        'structured': 1,
+        'pretty': pretty,
+        'sym': sym,
+        'kind': kind,
+        'implKind': 'idl',
+    }
+    if slots:
+        record['bindingSlots'] = slots
+    if supers:
+        record['supers'] = supers
+    if methods:
+        record['methods'] = methods
+    if fields:
+        record['fields']= fields
+
+    records.append(record)
+
+
+def handle_simple_type(records, target):
+    '''Emit analysis record for simple IDLType subclasses.'''
+
+    if isinstance(target.name, str):
+        name = target.name
+    else:
+        name = target.name.name
+    loc = to_loc(target.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'type', 'type', pretty, idl_sym)
+    emit_target(records, loc, 'use', pretty, idl_sym)
+
+
+def handle_type(records, target):
+    '''Emit analysis record for IDLType subclasses.'''
+
+    if isinstance(target, WebIDL.IDLNullableType):
+        handle_type(records, target.inner)
+        return
+    if isinstance(target, WebIDL.IDLSequenceType):
+        handle_type(records, target.inner)
+        return
+    if isinstance(target, WebIDL.IDLRecordType):
+        handle_type(records, target.keyType)
+        handle_type(records, target.inner)
+        return
+    if isinstance(target, WebIDL.IDLObservableArrayType):
+        handle_type(records, target.inner)
+        return
+    if isinstance(target, WebIDL.IDLPromiseType):
+        handle_type(records, target.inner)
+        return
+    if isinstance(target, WebIDL.IDLUnionType):
+        for m in target.memberTypes:
+            handle_type(records, m)
+        return
+    if isinstance(target, WebIDL.IDLBuiltinType):
+        return
+
+    assert isinstance(target, WebIDL.IDLUnresolvedType) or \
+        isinstance(target, WebIDL.IDLTypedefType) or \
+        isinstance(target, WebIDL.IDLCallbackType) or \
+        isinstance(target, WebIDL.IDLWrapperType)
+
+    handle_simple_type(records, target)
+
+
+def handle_argument(records, target):
+    '''Emit analysis record for IDLArgument in methods.'''
+
+    handle_type(records, target.type)
+
+
+def append_slot(slots, kind, lang, sym):
+    slots.append({
+        'slotKind': kind,
+        'slotLang': lang,
+        'ownerLang': 'idl',
+        'sym': sym,
+
+    })
+
+
+def handle_method(records, iface_name, methods, cpp_symbols, target):
+    '''Emit analysis record for IDLMethod in interface or namespace.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = f'{iface_name}::{name}'
+    idl_sym = f'WEBIDL_{iface_name}_{name}'
+    cpp_syms = cpp_symbols.get(cpp_method_name(target, name), [])
+    js_sym = f'#{name}'
+    is_constructor = name == 'constructor'
+
+    emit_source(records, loc, 'idl', 'method', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    for sym in cpp_syms:
+        append_slot(slots, 'method', 'cpp', sym)
+    append_slot(slots, 'method', 'js', js_sym)
+
+    emit_structured(records, loc, 'method', pretty, idl_sym,
+                    slots=slots)
+
+    for overload in target._overloads:
+        if not is_constructor:
+            handle_type(records, overload.returnType)
+        for arg in overload.arguments:
+            handle_argument(records, arg)
+
+    methods.append({
+        'pretty': pretty,
+        'sym': idl_sym,
+        'props': [],
+    })
+
+
+def handle_attribute(records, iface_name, fields, cpp_symbols, target):
+    '''Emit analysis record for IDLAttribute in interface or namespace.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = f'{iface_name}::{name}'
+    idl_sym = f'WEBIDL_{iface_name}_{name}'
+    getter_cpp_syms = cpp_symbols.get(cpp_getter_name(target, name), [])
+    js_sym = f'#{name}'
+
+    emit_source(records, loc, 'idl', 'attribute', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    for sym in getter_cpp_syms:
+        append_slot(slots, 'getter', 'cpp', sym)
+    if not target.readonly:
+        setter_cpp_syms = cpp_symbols.get(cpp_setter_name(target, name), [])
+        for sym in  setter_cpp_syms:
+            append_slot(slots, 'setter', 'cpp', sym)
+    append_slot(slots, 'attribute', 'js', js_sym)
+
+    emit_structured(records, loc, 'field', pretty, idl_sym,
+                    slots=slots)
+
+    handle_type(records, target.type)
+
+    fields.append({
+        'pretty': pretty,
+        'sym': idl_sym,
+        'props': [],
+    })
+
+
+def handle_const(records, iface_name, fields, cpp_symbols, target):
+    '''Emit analysis record for IDLConst in interface or namespace.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = f'{iface_name}::{name}'
+    idl_sym = f'WEBIDL_{iface_name}_{name}'
+    cpp_syms = cpp_symbols.get(name, [])
+    js_sym = f'#{name}'
+
+    emit_source(records, loc, 'idl', 'const', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    for sym in cpp_syms:
+        append_slot(slots, 'const', 'cpp', sym)
+    append_slot(slots, 'const', 'js', js_sym)
+
+    emit_structured(records, loc, 'field', pretty, idl_sym,
+                    slots=slots)
+
+    handle_type(records, target.type)
+
+    fields.append({
+        'pretty': pretty,
+        'sym': idl_sym,
+        'props': [],
+    })
+
+
+def handle_super(records, supers, target):
+    '''Emit analysis record for references in super interface
+    or super dictionary.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'type', 'class', pretty, idl_sym)
+    emit_target(records, loc, 'use', pretty, idl_sym)
+
+    supers.append({
+        'sym': idl_sym,
+    })
+
+
+def handle_maplike_or_setlike_or_iterable(records, iface_name, target):
+    '''Emit analysis record for IDLMaplikeOrSetlike, IDLIterable,
+    or IDLAsyncIterable in interface.'''
+
+    name = target.identifier.name.replace('__', '')
+    loc = to_loc(target.identifier.location, name)
+    pretty = f'{iface_name}::{target.maplikeOrSetlikeOrIterableType}'
+    idl_sym = f'WEBIDL_{iface_name}_{target.maplikeOrSetlikeOrIterableType}'
+
+    if target.maplikeOrSetlikeOrIterableType == 'maplike':
+        cpp_sym = f'NS_mozilla::dom::{iface_name}_Binding::MaplikeHelpers'
+    elif target.maplikeOrSetlikeOrIterableType == 'setlike':
+        cpp_sym = f'NS_mozilla::dom::{iface_name}_Binding::SetlikeHelpers'
+    elif target.maplikeOrSetlikeOrIterableType == 'iterable':
+        # NOTE: loc is wrong. it points '<' after 'iterable'.
+        # TODO: Fix the WebIDL parser.
+        location = target.identifier.location
+        loc = to_loc_with(location._lineno, location._colno - len(name), len(name))
+        cpp_sym = f'NS_mozilla::dom::{iface_name}Iterator_Binding'
+    elif target.maplikeOrSetlikeOrIterableType == 'asynciterable':
+        cpp_sym = f'NS_mozilla::dom::{iface_name}AsyncIterator_Binding'
+    else:
+        print(f'WebIDL: Unknown maplikeOrSetlikeOrIterableType: {target.maplikeOrSetlikeOrIterableType}',
+              file=sys.stderr)
+        sys.exit(1)
+
+    emit_source(records, loc, 'idl', 'method', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    append_slot(slots, 'class', 'cpp', cpp_sym)
+
+    emit_structured(records, loc, 'method', pretty, idl_sym,
+                    slots=slots)
+
+    if target.keyType:
+        handle_type(records, target.keyType)
+    if target.valueType:
+        handle_type(records, target.valueType)
+    if hasattr(target, 'argList'):
+        for arg in target.argList:
+            handle_argument(records, arg)
+
+
+def handle_interface_or_namespace(records, target):
+    '''Emit analysis record for IDLInterface, IDLInterfaceMixin, IDLNamespace,
+    or IDLPartialInterfaceOrNamespace.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+    cpp_sym = f'NS_mozilla::dom::{name}_Binding'
+    js_sym = f'#{name}'
+
+    local_path = target.location.filename
+    cpp_analysis = cpp_analysis_map.get(local_path, None)
+    if cpp_analysis is None:
+        print('warning: WebIDL: No C++ analysis data found for', local_path, file=sys.stderr)
+        cpp_symbols = {}
+    else:
+        cpp_symbols = cpp_analysis.get(name, {})
+
+    emit_source(records, loc, 'idl', 'class', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    append_slot(slots, 'class', 'cpp', cpp_sym)
+    append_slot(slots, 'interface_name', 'js', js_sym)
+
+    supers = []
+    if hasattr(target, 'parent') and target.parent:
+        handle_super(records, supers, target.parent)
+
+    methods = []
+    fields = []
+    for member in target.members:
+        if isinstance(member.identifier.location, WebIDL.BuiltinLocation):
+            continue
+
+        if isinstance(member, WebIDL.IDLMethod):
+            handle_method(records, name, methods, cpp_symbols, member)
+        elif isinstance(member, WebIDL.IDLAttribute):
+            handle_attribute(records, name, methods, cpp_symbols, member)
+        elif isinstance(member, WebIDL.IDLConst):
+            handle_const(records, name, methods, cpp_symbols, member)
+        elif isinstance(member, WebIDL.IDLMaplikeOrSetlike):
+            handle_maplike_or_setlike_or_iterable(records, name, member)
+        elif isinstance(member, WebIDL.IDLIterable):
+            handle_maplike_or_setlike_or_iterable(records, name, member)
+        elif isinstance(member, WebIDL.IDLAsyncIterable):
+            handle_maplike_or_setlike_or_iterable(records, name, member)
+        else:
+            print(f'WebIDL: Unknown member production: {member.__class__.__name__}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+    emit_structured(records, loc, 'class', pretty, idl_sym,
+                    slots=slots, supers=supers,
+                    methods=methods, fields=fields)
+
+
+def handle_dictionary_field(records, dictionary_name, dictionary_cpp_sym,
+                            fields, target):
+    '''Emit analysis record for IDLArgument in dictionary.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = f'{dictionary_name}.{name}'
+    idl_sym = f'WEBIDL_{dictionary_name}_{name}'
+    cpp_sym = f'F_<{dictionary_cpp_sym}>_{cpp_dictionary_field_name(name)}'
+    js_sym = f'#{name}'
+
+    emit_source(records, loc, 'idl', 'field', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    append_slot(slots, 'attribute', 'cpp', cpp_sym)
+    append_slot(slots, 'attribute', 'js', js_sym)
+
+    emit_structured(records, loc, 'field', pretty, idl_sym,
+                    slots=slots)
+
+    handle_type(records, target.type)
+
+    fields.append({
+        'pretty': pretty,
+        'sym': idl_sym,
+        'props': [],
+    })
+
+
+def handle_dictionary(records, target):
+    '''Emit analysis record for IDLDictionary or IDLPartialDictionary.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+    cpp_sym = f'T_mozilla::dom::{name}'
+    js_sym = f'#{name}'
+
+    emit_source(records, loc, 'idl', 'dictionary', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    append_slot(slots, 'class', 'cpp', cpp_sym)
+    append_slot(slots, 'class', 'js', js_sym)
+
+    supers = []
+    if hasattr(target, 'parent') and target.parent:
+        handle_super(records, supers, target.parent)
+
+    fields = []
+    for member in target.members:
+        if isinstance(member, WebIDL.IDLArgument):
+            handle_dictionary_field(records, name, cpp_sym,
+                                    fields, member)
+        else:
+            print(f'WebIDL: Unknown member production: {member.__class__.__name__}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+    emit_structured(records, loc, 'class', pretty, idl_sym,
+                    slots=slots, supers=supers,
+                    fields=fields)
+
+
+def handle_enum(records, target):
+    '''Emit analysis record for IDLEnum.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+    cpp_sym = f'T_mozilla::dom::{name}'
+    js_sym = f'#{name}'
+
+    emit_source(records, loc, 'idl', 'enum', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    slots = []
+    append_slot(slots, 'const', 'cpp', cpp_sym)
+    append_slot(slots, 'const', 'js', js_sym)
+
+    emit_structured(records, loc, 'const', pretty, idl_sym,
+                    slots=slots)
+
+
+def get_typedef_loc(target, name):
+    '''Get the location string for the typedef identifier.
+
+    The IDLTypedef's identifier points the `typedef` token,
+    and we need to find the location from the line.
+
+    TODO: Fix the WebIDL parser.
+    '''
+
+    location = target.identifier.location
+    location.resolve()
+
+    line = location._line
+    index = line.find(f' {name};')
+    if index == -1:
+        return to_loc(target.identifier.location, name)
+
+    colno = index + 1
+
+    return to_loc_with(location._lineno, colno, len(name))
+
+
+def handle_typedef(records, target):
+    '''Emit analysis record for IDLTypedef.'''
+
+    name = target.identifier.name
+    loc = get_typedef_loc(target, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'idl', 'type', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    handle_type(records, target.innerType)
+
+
+def handle_callback(records, target):
+    '''Emit analysis record for IDLCallback.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'idl', 'callback', pretty, idl_sym)
+    emit_target(records, loc, 'idl', pretty, idl_sym)
+
+    handle_type(records, target._returnType)
+    for arg in target._arguments:
+        handle_argument(records, arg)
+
+
+def handle_external_interface(records, target):
+    '''Emit analysis record for IDLExternalInterface.'''
+
+    name = target.identifier.name
+    loc = to_loc(target.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'type', 'class', pretty, idl_sym)
+    emit_target(records, loc, 'use', pretty, idl_sym)
+
+
+def preprocess(lines):
+    '''Remove macros from the input.
+
+    This expects the macro doesn't have conflicting then-clause vs else-clause.'''
+    result = []
+    for line in lines:
+        if line.startswith('#'):
+            result.append('\n')
+        else:
+            result.append(line)
+    return result
+
+
+def parse_files(index_root, files_root, cache_dir):
+    '''Parse all WebIDL files and load corresponding C++ analysis files.'''
+
+    parser = WebIDL.Parser(cache_dir)
+
+    for local_path in sys.stdin:
+        local_path = local_path.strip()
+
+        if local_path.startswith('__GENERATED__/'):
+            fname = os.path.join(index_root, 'objdir', local_path.replace('__GENERATED__/', ''))
+        else:
+            fname = os.path.join(files_root, local_path)
+
+        lines = preprocess(open(fname).readlines())
+        text = ''.join(lines)
+        cpp_analysis_map[local_path] = read_cpp_analysis(index_root, local_path)
+
+        try:
+            parser.parse(text, local_path)
+        except WebIDL.WebIDLError as e:
+            print('WebIDL: Syntax error in IDL', fname, file=sys.stderr)
+            raise e
+
+    # NOTE: Do not call parser.finish() here because we need raw identifiers and
+    #       raw productions, and we don't need auto-generated items.
+    return parser._productions
+
+
+def handle_productions(productions):
+    '''Emit analysis records for all productions.'''
+
+    for target in productions:
+        if isinstance(target, WebIDL.IDLInterfaceOrInterfaceMixinOrNamespace):
+            records = get_records(target)
+            handle_interface_or_namespace(records, target)
+        elif isinstance(target, WebIDL.IDLPartialInterfaceOrNamespace):
+            records = get_records(target)
+            handle_interface_or_namespace(records, target)
+        elif isinstance(target, WebIDL.IDLDictionary):
+            records = get_records(target)
+            handle_dictionary(records, target)
+        elif isinstance(target, WebIDL.IDLPartialDictionary):
+            records = get_records(target)
+            handle_dictionary(records, target)
+        elif isinstance(target, WebIDL.IDLEnum):
+            records = get_records(target)
+            handle_enum(records, target)
+        elif isinstance(target, WebIDL.IDLTypedef):
+            records = get_records(target)
+            handle_typedef(records, target)
+        elif isinstance(target, WebIDL.IDLCallback):
+            records = get_records(target)
+            handle_callback(records, target)
+        elif isinstance(target, WebIDL.IDLIncludesStatement):
+            pass
+        elif isinstance(target, WebIDL.IDLExternalInterface):
+            records = get_records(target)
+            handle_external_interface(records, target);
+        else:
+            print(f'WebIDL: Unknown top-level production: {target.__class__.__name__}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+
+def write_files(analysis_root):
+    '''Write analysis records for each file.'''
+
+    for local_path, records in analysis_map.items():
+        analysis_path = os.path.join(analysis_root, local_path)
+        print('WebIDL: Generating', analysis_path, file=sys.stderr)
+
+        parent = os.path.dirname(analysis_path)
+        os.makedirs(parent, exist_ok=True)
+
+        with open(analysis_path, 'w') as fh:
+            for r in records:
+                print(json.dumps(r), file=fh)
+
+
+index_root = sys.argv[1]
+files_root = sys.argv[2]
+analysis_root = sys.argv[3]
+cache_dir = sys.argv[4]
+
+productions = parse_files(index_root, files_root, cache_dir)
+handle_productions(productions)
+write_files(analysis_root)

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -635,6 +635,26 @@ def handle_callback(records, target):
         handle_argument(records, arg)
 
 
+def handle_includes(records, target):
+    '''Emit analysis record for IDLIncludesStatement.'''
+
+    name = target.interface.identifier.name
+    loc = to_loc(target.interface.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'type', 'class', pretty, idl_sym)
+    emit_target(records, loc, 'use', pretty, idl_sym)
+
+    name = target.mixin.identifier.name
+    loc = to_loc(target.mixin.identifier.location, name)
+    pretty = name
+    idl_sym = f'WEBIDL_{name}'
+
+    emit_source(records, loc, 'type', 'class', pretty, idl_sym)
+    emit_target(records, loc, 'use', pretty, idl_sym)
+
+
 def handle_external_interface(records, target):
     '''Emit analysis record for IDLExternalInterface.'''
 
@@ -714,7 +734,8 @@ def handle_productions(productions):
             records = get_records(target)
             handle_callback(records, target)
         elif isinstance(target, WebIDL.IDLIncludesStatement):
-            pass
+            records = get_records(target)
+            handle_includes(records, target)
         elif isinstance(target, WebIDL.IDLExternalInterface):
             records = get_records(target)
             handle_external_interface(records, target);

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -274,7 +274,6 @@ def append_slot(slots, kind, lang, sym):
         'slotLang': lang,
         'ownerLang': 'idl',
         'sym': sym,
-
     })
 
 

--- a/tests/tests/checks/inputs/analysis/webidl/asynciterable.webidl/webidl_asynciterable__json
+++ b/tests/tests/checks/inputs/analysis/webidl/asynciterable.webidl/webidl_asynciterable__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/asynciterable.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/attribute.webidl/webidl_attribute__json
+++ b/tests/tests/checks/inputs/analysis/webidl/attribute.webidl/webidl_attribute__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/attribute.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/callback.webidl/webidl_callback__json
+++ b/tests/tests/checks/inputs/analysis/webidl/callback.webidl/webidl_callback__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/callback.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/const.webidl/webidl_const__json
+++ b/tests/tests/checks/inputs/analysis/webidl/const.webidl/webidl_const__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/const.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/dictionary.webidl/webidl_dictionary__json
+++ b/tests/tests/checks/inputs/analysis/webidl/dictionary.webidl/webidl_dictionary__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/dictionary.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/enum.webidl/webidl_enum__json
+++ b/tests/tests/checks/inputs/analysis/webidl/enum.webidl/webidl_enum__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/enum.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/external-interface.webidl/webidl_external_interface__json
+++ b/tests/tests/checks/inputs/analysis/webidl/external-interface.webidl/webidl_external_interface__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/external-interface.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/includes.webidl/webidl_asynciterable__json
+++ b/tests/tests/checks/inputs/analysis/webidl/includes.webidl/webidl_asynciterable__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/includes.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/interface-mixin.webidl/webidl_interface_mixin__json
+++ b/tests/tests/checks/inputs/analysis/webidl/interface-mixin.webidl/webidl_interface_mixin__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/interface-mixin.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/iterable.webidl/webidl_iterable__json
+++ b/tests/tests/checks/inputs/analysis/webidl/iterable.webidl/webidl_iterable__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/iterable.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/maplike.webidl/webidl_maplike__json
+++ b/tests/tests/checks/inputs/analysis/webidl/maplike.webidl/webidl_maplike__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/maplike.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/method.webidl/webidl_method__json
+++ b/tests/tests/checks/inputs/analysis/webidl/method.webidl/webidl_method__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/method.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/namespace.webidl/webidl_namespace__json
+++ b/tests/tests/checks/inputs/analysis/webidl/namespace.webidl/webidl_namespace__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/namespace.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/overload.webidl/webidl_overload__json
+++ b/tests/tests/checks/inputs/analysis/webidl/overload.webidl/webidl_overload__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/overload.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/partial-dictionary.webidl/webidl_partial_dictionary__json
+++ b/tests/tests/checks/inputs/analysis/webidl/partial-dictionary.webidl/webidl_partial_dictionary__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/partial-dictionary.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/partial-interface.webidl/webidl_partial_interface__json
+++ b/tests/tests/checks/inputs/analysis/webidl/partial-interface.webidl/webidl_partial_interface__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/partial-interface.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/partial-namespace.webidl/webidl_partial_namespace__json
+++ b/tests/tests/checks/inputs/analysis/webidl/partial-namespace.webidl/webidl_partial_namespace__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/partial-namespace.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/setlike.webidl/webidl_setlike__json
+++ b/tests/tests/checks/inputs/analysis/webidl/setlike.webidl/webidl_setlike__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/setlike.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/super-dictionary.webidl/webidl_super_dictionary__json
+++ b/tests/tests/checks/inputs/analysis/webidl/super-dictionary.webidl/webidl_super_dictionary__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/super-dictionary.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/super-interface.webidl/webidl_super_interface__json
+++ b/tests/tests/checks/inputs/analysis/webidl/super-interface.webidl/webidl_super_interface__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/super-interface.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/type.webidl/webidl_type__json
+++ b/tests/tests/checks/inputs/analysis/webidl/type.webidl/webidl_type__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/type.webidl

--- a/tests/tests/checks/inputs/analysis/webidl/typedef.webidl/webidl_typedef__json
+++ b/tests/tests/checks/inputs/analysis/webidl/typedef.webidl/webidl_typedef__json
@@ -1,0 +1,1 @@
+filter-analysis webidl/typedef.webidl

--- a/tests/tests/checks/snapshots/analysis/webidl/asynciterable.webidl/check_glob@webidl_asynciterable__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/asynciterable.webidl/check_glob@webidl_asynciterable__json.snap
@@ -1,0 +1,114 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-39",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForAsyncIterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable"
+  },
+  {
+    "loc": "1:10-39",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForAsyncIterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable"
+  },
+  {
+    "loc": "2:8-16",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForAsyncIterable::asynciterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable_asynciterable"
+  },
+  {
+    "loc": "2:8-16",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForAsyncIterable::asynciterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable_asynciterable"
+  },
+  {
+    "loc": "2:8-16",
+    "structured": 1,
+    "pretty": "TestInterfaceForAsyncIterable::asynciterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable_asynciterable",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForAsyncIterableAsyncIterator_Binding"
+      }
+    ]
+  },
+  {
+    "loc": "2:17-24",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:17-24",
+    "target": 1,
+    "kind": "use",
+    "pretty": "KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:26-35",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:26-35",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:46-54",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "2:46-54",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "1:10-39",
+    "structured": 1,
+    "pretty": "TestInterfaceForAsyncIterable",
+    "sym": "WEBIDL_TestInterfaceForAsyncIterable",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForAsyncIterable_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForAsyncIterable"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/attribute.webidl/check_glob@webidl_attribute__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/attribute.webidl/check_glob@webidl_attribute__json.snap
@@ -1,0 +1,142 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-35",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForAttribute",
+    "sym": "WEBIDL_TestInterfaceForAttribute"
+  },
+  {
+    "loc": "1:10-35",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForAttribute",
+    "sym": "WEBIDL_TestInterfaceForAttribute"
+  },
+  {
+    "loc": "2:22-27",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL attribute TestInterfaceForAttribute::attr1",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr1"
+  },
+  {
+    "loc": "2:22-27",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForAttribute::attr1",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr1"
+  },
+  {
+    "loc": "2:22-27",
+    "structured": 1,
+    "pretty": "TestInterfaceForAttribute::attr1",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr1",
+    "kind": "field",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "attribute",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#attr1"
+      }
+    ]
+  },
+  {
+    "loc": "2:12-21",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type AttrType1",
+    "sym": "WEBIDL_AttrType1"
+  },
+  {
+    "loc": "2:12-21",
+    "target": 1,
+    "kind": "use",
+    "pretty": "AttrType1",
+    "sym": "WEBIDL_AttrType1"
+  },
+  {
+    "loc": "3:31-36",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL attribute TestInterfaceForAttribute::attr2",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr2"
+  },
+  {
+    "loc": "3:31-36",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForAttribute::attr2",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr2"
+  },
+  {
+    "loc": "3:31-36",
+    "structured": 1,
+    "pretty": "TestInterfaceForAttribute::attr2",
+    "sym": "WEBIDL_TestInterfaceForAttribute_attr2",
+    "kind": "field",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "attribute",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#attr2"
+      }
+    ]
+  },
+  {
+    "loc": "3:21-30",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type AttrType2",
+    "sym": "WEBIDL_AttrType2"
+  },
+  {
+    "loc": "3:21-30",
+    "target": 1,
+    "kind": "use",
+    "pretty": "AttrType2",
+    "sym": "WEBIDL_AttrType2"
+  },
+  {
+    "loc": "1:10-35",
+    "structured": 1,
+    "pretty": "TestInterfaceForAttribute",
+    "sym": "WEBIDL_TestInterfaceForAttribute",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForAttribute_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForAttribute"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceForAttribute::attr1",
+        "sym": "WEBIDL_TestInterfaceForAttribute_attr1",
+        "props": []
+      },
+      {
+        "pretty": "TestInterfaceForAttribute::attr2",
+        "sym": "WEBIDL_TestInterfaceForAttribute_attr2",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/callback.webidl/check_glob@webidl_callback__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/callback.webidl/check_glob@webidl_callback__json.snap
@@ -1,0 +1,62 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:9-21",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL callback TestCallback",
+    "sym": "WEBIDL_TestCallback"
+  },
+  {
+    "loc": "1:9-21",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestCallback",
+    "sym": "WEBIDL_TestCallback"
+  },
+  {
+    "loc": "1:24-31",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type RetType",
+    "sym": "WEBIDL_RetType"
+  },
+  {
+    "loc": "1:24-31",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RetType",
+    "sym": "WEBIDL_RetType"
+  },
+  {
+    "loc": "1:33-41",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "1:33-41",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "1:48-56",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType2",
+    "sym": "WEBIDL_ArgType2"
+  },
+  {
+    "loc": "1:48-56",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType2",
+    "sym": "WEBIDL_ArgType2"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/const.webidl/check_glob@webidl_const__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/const.webidl/check_glob@webidl_const__json.snap
@@ -1,0 +1,93 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-31",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForConst",
+    "sym": "WEBIDL_TestInterfaceForConst"
+  },
+  {
+    "loc": "1:10-31",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForConst",
+    "sym": "WEBIDL_TestInterfaceForConst"
+  },
+  {
+    "loc": "2:19-25",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL const TestInterfaceForConst::const1",
+    "sym": "WEBIDL_TestInterfaceForConst_const1"
+  },
+  {
+    "loc": "2:19-25",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForConst::const1",
+    "sym": "WEBIDL_TestInterfaceForConst_const1"
+  },
+  {
+    "loc": "2:19-25",
+    "structured": 1,
+    "pretty": "TestInterfaceForConst::const1",
+    "sym": "WEBIDL_TestInterfaceForConst_const1",
+    "kind": "field",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "const",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#const1"
+      }
+    ]
+  },
+  {
+    "loc": "2:8-18",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ConstType1",
+    "sym": "WEBIDL_ConstType1"
+  },
+  {
+    "loc": "2:8-18",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ConstType1",
+    "sym": "WEBIDL_ConstType1"
+  },
+  {
+    "loc": "1:10-31",
+    "structured": 1,
+    "pretty": "TestInterfaceForConst",
+    "sym": "WEBIDL_TestInterfaceForConst",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForConst_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForConst"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceForConst::const1",
+        "sym": "WEBIDL_TestInterfaceForConst_const1",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/dictionary.webidl/check_glob@webidl_dictionary__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/dictionary.webidl/check_glob@webidl_dictionary__json.snap
@@ -1,0 +1,99 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:11-25",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL dictionary TestDictionary",
+    "sym": "WEBIDL_TestDictionary"
+  },
+  {
+    "loc": "1:11-25",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestDictionary",
+    "sym": "WEBIDL_TestDictionary"
+  },
+  {
+    "loc": "2:14-21",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL field TestDictionary.member1",
+    "sym": "WEBIDL_TestDictionary_member1"
+  },
+  {
+    "loc": "2:14-21",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestDictionary.member1",
+    "sym": "WEBIDL_TestDictionary_member1"
+  },
+  {
+    "loc": "2:14-21",
+    "structured": 1,
+    "pretty": "TestDictionary.member1",
+    "sym": "WEBIDL_TestDictionary_member1",
+    "kind": "field",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "attribute",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "F_<T_mozilla::dom::TestDictionary>_mMember1"
+      },
+      {
+        "slotKind": "attribute",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#member1"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-13",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type MemberType1",
+    "sym": "WEBIDL_MemberType1"
+  },
+  {
+    "loc": "2:2-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "MemberType1",
+    "sym": "WEBIDL_MemberType1"
+  },
+  {
+    "loc": "1:11-25",
+    "structured": 1,
+    "pretty": "TestDictionary",
+    "sym": "WEBIDL_TestDictionary",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "T_mozilla::dom::TestDictionary"
+      },
+      {
+        "slotKind": "class",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestDictionary"
+      }
+    ],
+    "fields": [
+      {
+        "pretty": "TestDictionary.member1",
+        "sym": "WEBIDL_TestDictionary_member1",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/enum.webidl/check_glob@webidl_enum__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/enum.webidl/check_glob@webidl_enum__json.snap
@@ -1,0 +1,42 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:5-13",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL enum TestEnum",
+    "sym": "WEBIDL_TestEnum"
+  },
+  {
+    "loc": "1:5-13",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestEnum",
+    "sym": "WEBIDL_TestEnum"
+  },
+  {
+    "loc": "1:5-13",
+    "structured": 1,
+    "pretty": "TestEnum",
+    "sym": "WEBIDL_TestEnum",
+    "kind": "const",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "const",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "T_mozilla::dom::TestEnum"
+      },
+      {
+        "slotKind": "const",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestEnum"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/external-interface.webidl/check_glob@webidl_external_interface__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/external-interface.webidl/check_glob@webidl_external_interface__json.snap
@@ -1,0 +1,20 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-31",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL class TestExternalInterface",
+    "sym": "WEBIDL_TestExternalInterface"
+  },
+  {
+    "loc": "1:10-31",
+    "target": 1,
+    "kind": "use",
+    "pretty": "TestExternalInterface",
+    "sym": "WEBIDL_TestExternalInterface"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/includes.webidl/check_glob@webidl_asynciterable__json-2.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/includes.webidl/check_glob@webidl_asynciterable__json-2.snap
@@ -1,0 +1,34 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:0-13",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL class TestInterface",
+    "sym": "WEBIDL_TestInterface"
+  },
+  {
+    "loc": "1:0-13",
+    "target": 1,
+    "kind": "use",
+    "pretty": "TestInterface",
+    "sym": "WEBIDL_TestInterface"
+  },
+  {
+    "loc": "1:23-41",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL class TestInterfaceMixin",
+    "sym": "WEBIDL_TestInterfaceMixin"
+  },
+  {
+    "loc": "1:23-41",
+    "target": 1,
+    "kind": "use",
+    "pretty": "TestInterfaceMixin",
+    "sym": "WEBIDL_TestInterfaceMixin"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/interface-mixin.webidl/check_glob@webidl_interface_mixin__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/interface-mixin.webidl/check_glob@webidl_interface_mixin__json.snap
@@ -1,0 +1,93 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:16-34",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceMixin",
+    "sym": "WEBIDL_TestInterfaceMixin"
+  },
+  {
+    "loc": "1:16-34",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceMixin",
+    "sym": "WEBIDL_TestInterfaceMixin"
+  },
+  {
+    "loc": "2:7-18",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceMixin::MixinMethod",
+    "sym": "WEBIDL_TestInterfaceMixin_MixinMethod"
+  },
+  {
+    "loc": "2:7-18",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceMixin::MixinMethod",
+    "sym": "WEBIDL_TestInterfaceMixin_MixinMethod"
+  },
+  {
+    "loc": "2:7-18",
+    "structured": 1,
+    "pretty": "TestInterfaceMixin::MixinMethod",
+    "sym": "WEBIDL_TestInterfaceMixin_MixinMethod",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#MixinMethod"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-6",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:2-6",
+    "target": 1,
+    "kind": "use",
+    "pretty": "void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "1:16-34",
+    "structured": 1,
+    "pretty": "TestInterfaceMixin",
+    "sym": "WEBIDL_TestInterfaceMixin",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceMixin_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceMixin"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceMixin::MixinMethod",
+        "sym": "WEBIDL_TestInterfaceMixin_MixinMethod",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/iterable.webidl/check_glob@webidl_iterable__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/iterable.webidl/check_glob@webidl_iterable__json.snap
@@ -1,0 +1,100 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-34",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForIterable",
+    "sym": "WEBIDL_TestInterfaceForIterable"
+  },
+  {
+    "loc": "1:10-34",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForIterable",
+    "sym": "WEBIDL_TestInterfaceForIterable"
+  },
+  {
+    "loc": "2:2-10",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForIterable::iterable",
+    "sym": "WEBIDL_TestInterfaceForIterable_iterable"
+  },
+  {
+    "loc": "2:2-10",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForIterable::iterable",
+    "sym": "WEBIDL_TestInterfaceForIterable_iterable"
+  },
+  {
+    "loc": "2:2-10",
+    "structured": 1,
+    "pretty": "TestInterfaceForIterable::iterable",
+    "sym": "WEBIDL_TestInterfaceForIterable_iterable",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForIterableIterator_Binding"
+      }
+    ]
+  },
+  {
+    "loc": "2:11-18",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:11-18",
+    "target": 1,
+    "kind": "use",
+    "pretty": "KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:20-29",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:20-29",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "1:10-34",
+    "structured": 1,
+    "pretty": "TestInterfaceForIterable",
+    "sym": "WEBIDL_TestInterfaceForIterable",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForIterable_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForIterable"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/maplike.webidl/check_glob@webidl_maplike__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/maplike.webidl/check_glob@webidl_maplike__json.snap
@@ -1,0 +1,100 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-33",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForMaplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike"
+  },
+  {
+    "loc": "1:10-33",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForMaplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike"
+  },
+  {
+    "loc": "2:2-9",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForMaplike::maplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike_maplike"
+  },
+  {
+    "loc": "2:2-9",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForMaplike::maplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike_maplike"
+  },
+  {
+    "loc": "2:2-9",
+    "structured": 1,
+    "pretty": "TestInterfaceForMaplike::maplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike_maplike",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForMaplike_Binding::MaplikeHelpers"
+      }
+    ]
+  },
+  {
+    "loc": "2:10-17",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:10-17",
+    "target": 1,
+    "kind": "use",
+    "pretty": "KeyType",
+    "sym": "WEBIDL_KeyType"
+  },
+  {
+    "loc": "2:19-28",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:19-28",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "1:10-33",
+    "structured": 1,
+    "pretty": "TestInterfaceForMaplike",
+    "sym": "WEBIDL_TestInterfaceForMaplike",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForMaplike_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForMaplike"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/method.webidl/check_glob@webidl_method__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/method.webidl/check_glob@webidl_method__json.snap
@@ -1,0 +1,121 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-32",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForMethod",
+    "sym": "WEBIDL_TestInterfaceForMethod"
+  },
+  {
+    "loc": "1:10-32",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForMethod",
+    "sym": "WEBIDL_TestInterfaceForMethod"
+  },
+  {
+    "loc": "2:10-20",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForMethod::MethodName",
+    "sym": "WEBIDL_TestInterfaceForMethod_MethodName"
+  },
+  {
+    "loc": "2:10-20",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForMethod::MethodName",
+    "sym": "WEBIDL_TestInterfaceForMethod_MethodName"
+  },
+  {
+    "loc": "2:10-20",
+    "structured": 1,
+    "pretty": "TestInterfaceForMethod::MethodName",
+    "sym": "WEBIDL_TestInterfaceForMethod_MethodName",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#MethodName"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-9",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type RetType",
+    "sym": "WEBIDL_RetType"
+  },
+  {
+    "loc": "2:2-9",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RetType",
+    "sym": "WEBIDL_RetType"
+  },
+  {
+    "loc": "2:21-29",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "2:21-29",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "2:36-44",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType2",
+    "sym": "WEBIDL_ArgType2"
+  },
+  {
+    "loc": "2:36-44",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType2",
+    "sym": "WEBIDL_ArgType2"
+  },
+  {
+    "loc": "1:10-32",
+    "structured": 1,
+    "pretty": "TestInterfaceForMethod",
+    "sym": "WEBIDL_TestInterfaceForMethod",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForMethod_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForMethod"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceForMethod::MethodName",
+        "sym": "WEBIDL_TestInterfaceForMethod_MethodName",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/namespace.webidl/check_glob@webidl_namespace__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/namespace.webidl/check_glob@webidl_namespace__json.snap
@@ -1,0 +1,93 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestNamespace",
+    "sym": "WEBIDL_TestNamespace"
+  },
+  {
+    "loc": "1:10-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestNamespace",
+    "sym": "WEBIDL_TestNamespace"
+  },
+  {
+    "loc": "2:7-12",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestNamespace::Func1",
+    "sym": "WEBIDL_TestNamespace_Func1"
+  },
+  {
+    "loc": "2:7-12",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestNamespace::Func1",
+    "sym": "WEBIDL_TestNamespace_Func1"
+  },
+  {
+    "loc": "2:7-12",
+    "structured": 1,
+    "pretty": "TestNamespace::Func1",
+    "sym": "WEBIDL_TestNamespace_Func1",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#Func1"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-6",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:2-6",
+    "target": 1,
+    "kind": "use",
+    "pretty": "void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "1:10-23",
+    "structured": 1,
+    "pretty": "TestNamespace",
+    "sym": "WEBIDL_TestNamespace",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestNamespace_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestNamespace"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestNamespace::Func1",
+        "sym": "WEBIDL_TestNamespace_Func1",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/overload.webidl/check_glob@webidl_overload__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/overload.webidl/check_glob@webidl_overload__json.snap
@@ -1,0 +1,275 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-34",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForOverload",
+    "sym": "WEBIDL_TestInterfaceForOverload"
+  },
+  {
+    "loc": "1:10-34",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForOverload",
+    "sym": "WEBIDL_TestInterfaceForOverload"
+  },
+  {
+    "loc": "2:11-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "2:11-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "2:11-23",
+    "structured": 1,
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#OverloadFunc"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-10",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type RetType1",
+    "sym": "WEBIDL_RetType1"
+  },
+  {
+    "loc": "2:2-10",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RetType1",
+    "sym": "WEBIDL_RetType1"
+  },
+  {
+    "loc": "2:24-32",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "2:24-32",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType1",
+    "sym": "WEBIDL_ArgType1"
+  },
+  {
+    "loc": "3:11-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "3:11-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "3:11-23",
+    "structured": 1,
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#OverloadFunc"
+      }
+    ]
+  },
+  {
+    "loc": "3:2-10",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type RetType2",
+    "sym": "WEBIDL_RetType2"
+  },
+  {
+    "loc": "3:2-10",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RetType2",
+    "sym": "WEBIDL_RetType2"
+  },
+  {
+    "loc": "3:24-34",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType2_1",
+    "sym": "WEBIDL_ArgType2_1"
+  },
+  {
+    "loc": "3:24-34",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType2_1",
+    "sym": "WEBIDL_ArgType2_1"
+  },
+  {
+    "loc": "3:41-51",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType2_2",
+    "sym": "WEBIDL_ArgType2_2"
+  },
+  {
+    "loc": "3:41-51",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType2_2",
+    "sym": "WEBIDL_ArgType2_2"
+  },
+  {
+    "loc": "4:11-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "4:11-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc"
+  },
+  {
+    "loc": "4:11-23",
+    "structured": 1,
+    "pretty": "TestInterfaceForOverload::OverloadFunc",
+    "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#OverloadFunc"
+      }
+    ]
+  },
+  {
+    "loc": "4:2-10",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type RetType3",
+    "sym": "WEBIDL_RetType3"
+  },
+  {
+    "loc": "4:2-10",
+    "target": 1,
+    "kind": "use",
+    "pretty": "RetType3",
+    "sym": "WEBIDL_RetType3"
+  },
+  {
+    "loc": "4:24-34",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType3_1",
+    "sym": "WEBIDL_ArgType3_1"
+  },
+  {
+    "loc": "4:24-34",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType3_1",
+    "sym": "WEBIDL_ArgType3_1"
+  },
+  {
+    "loc": "4:41-51",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType3_2",
+    "sym": "WEBIDL_ArgType3_2"
+  },
+  {
+    "loc": "4:41-51",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType3_2",
+    "sym": "WEBIDL_ArgType3_2"
+  },
+  {
+    "loc": "4:58-68",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ArgType3_3",
+    "sym": "WEBIDL_ArgType3_3"
+  },
+  {
+    "loc": "4:58-68",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ArgType3_3",
+    "sym": "WEBIDL_ArgType3_3"
+  },
+  {
+    "loc": "1:10-34",
+    "structured": 1,
+    "pretty": "TestInterfaceForOverload",
+    "sym": "WEBIDL_TestInterfaceForOverload",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForOverload_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForOverload"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceForOverload::OverloadFunc",
+        "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+        "props": []
+      },
+      {
+        "pretty": "TestInterfaceForOverload::OverloadFunc",
+        "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+        "props": []
+      },
+      {
+        "pretty": "TestInterfaceForOverload::OverloadFunc",
+        "sym": "WEBIDL_TestInterfaceForOverload_OverloadFunc",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/partial-dictionary.webidl/check_glob@webidl_partial_dictionary__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/partial-dictionary.webidl/check_glob@webidl_partial_dictionary__json.snap
@@ -1,0 +1,85 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:19-33",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL dictionary TestDictionary",
+    "sym": "WEBIDL_TestDictionary"
+  },
+  {
+    "loc": "1:19-33",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestDictionary",
+    "sym": "WEBIDL_TestDictionary"
+  },
+  {
+    "loc": "2:16-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL field TestDictionary.Member2",
+    "sym": "WEBIDL_TestDictionary_Member2"
+  },
+  {
+    "loc": "2:16-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestDictionary.Member2",
+    "sym": "WEBIDL_TestDictionary_Member2"
+  },
+  {
+    "loc": "2:16-23",
+    "structured": 1,
+    "pretty": "TestDictionary.Member2",
+    "sym": "WEBIDL_TestDictionary_Member2",
+    "kind": "field",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "attribute",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "F_<T_mozilla::dom::TestDictionary>_mMember2"
+      },
+      {
+        "slotKind": "attribute",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#Member2"
+      }
+    ]
+  },
+  {
+    "loc": "1:19-33",
+    "structured": 1,
+    "pretty": "TestDictionary",
+    "sym": "WEBIDL_TestDictionary",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "T_mozilla::dom::TestDictionary"
+      },
+      {
+        "slotKind": "class",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestDictionary"
+      }
+    ],
+    "fields": [
+      {
+        "pretty": "TestDictionary.Member2",
+        "sym": "WEBIDL_TestDictionary_Member2",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/partial-interface.webidl/check_glob@webidl_partial_interface__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/partial-interface.webidl/check_glob@webidl_partial_interface__json.snap
@@ -1,0 +1,93 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:18-31",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterface",
+    "sym": "WEBIDL_TestInterface"
+  },
+  {
+    "loc": "1:18-31",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterface",
+    "sym": "WEBIDL_TestInterface"
+  },
+  {
+    "loc": "2:7-20",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterface::PartialMethod",
+    "sym": "WEBIDL_TestInterface_PartialMethod"
+  },
+  {
+    "loc": "2:7-20",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterface::PartialMethod",
+    "sym": "WEBIDL_TestInterface_PartialMethod"
+  },
+  {
+    "loc": "2:7-20",
+    "structured": 1,
+    "pretty": "TestInterface::PartialMethod",
+    "sym": "WEBIDL_TestInterface_PartialMethod",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#PartialMethod"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-6",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:2-6",
+    "target": 1,
+    "kind": "use",
+    "pretty": "void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "1:18-31",
+    "structured": 1,
+    "pretty": "TestInterface",
+    "sym": "WEBIDL_TestInterface",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterface_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterface"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterface::PartialMethod",
+        "sym": "WEBIDL_TestInterface_PartialMethod",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/partial-namespace.webidl/check_glob@webidl_partial_namespace__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/partial-namespace.webidl/check_glob@webidl_partial_namespace__json.snap
@@ -1,0 +1,93 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:18-31",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestNamespace",
+    "sym": "WEBIDL_TestNamespace"
+  },
+  {
+    "loc": "1:18-31",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestNamespace",
+    "sym": "WEBIDL_TestNamespace"
+  },
+  {
+    "loc": "2:7-18",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestNamespace::PartialFunc",
+    "sym": "WEBIDL_TestNamespace_PartialFunc"
+  },
+  {
+    "loc": "2:7-18",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestNamespace::PartialFunc",
+    "sym": "WEBIDL_TestNamespace_PartialFunc"
+  },
+  {
+    "loc": "2:7-18",
+    "structured": 1,
+    "pretty": "TestNamespace::PartialFunc",
+    "sym": "WEBIDL_TestNamespace_PartialFunc",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#PartialFunc"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-6",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:2-6",
+    "target": 1,
+    "kind": "use",
+    "pretty": "void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "1:18-31",
+    "structured": 1,
+    "pretty": "TestNamespace",
+    "sym": "WEBIDL_TestNamespace",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestNamespace_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestNamespace"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestNamespace::PartialFunc",
+        "sym": "WEBIDL_TestNamespace_PartialFunc",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/setlike.webidl/check_glob@webidl_setlike__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/setlike.webidl/check_glob@webidl_setlike__json.snap
@@ -1,0 +1,100 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-33",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForSetlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike"
+  },
+  {
+    "loc": "1:10-33",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForSetlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike"
+  },
+  {
+    "loc": "2:2-9",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForSetlike::setlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike_setlike"
+  },
+  {
+    "loc": "2:2-9",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForSetlike::setlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike_setlike"
+  },
+  {
+    "loc": "2:2-9",
+    "structured": 1,
+    "pretty": "TestInterfaceForSetlike::setlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike_setlike",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForSetlike_Binding::SetlikeHelpers"
+      }
+    ]
+  },
+  {
+    "loc": "2:10-19",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:10-19",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:10-19",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "2:10-19",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "1:10-33",
+    "structured": 1,
+    "pretty": "TestInterfaceForSetlike",
+    "sym": "WEBIDL_TestInterfaceForSetlike",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForSetlike_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForSetlike"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/super-dictionary.webidl/check_glob@webidl_super_dictionary__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/super-dictionary.webidl/check_glob@webidl_super_dictionary__json.snap
@@ -1,0 +1,61 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:11-28",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL dictionary TestSubDictionary",
+    "sym": "WEBIDL_TestSubDictionary"
+  },
+  {
+    "loc": "1:11-28",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestSubDictionary",
+    "sym": "WEBIDL_TestSubDictionary"
+  },
+  {
+    "loc": "1:31-50",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL class TestSuperDictionary",
+    "sym": "WEBIDL_TestSuperDictionary"
+  },
+  {
+    "loc": "1:31-50",
+    "target": 1,
+    "kind": "use",
+    "pretty": "TestSuperDictionary",
+    "sym": "WEBIDL_TestSuperDictionary"
+  },
+  {
+    "loc": "1:11-28",
+    "structured": 1,
+    "pretty": "TestSubDictionary",
+    "sym": "WEBIDL_TestSubDictionary",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "T_mozilla::dom::TestSubDictionary"
+      },
+      {
+        "slotKind": "class",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestSubDictionary"
+      }
+    ],
+    "supers": [
+      {
+        "sym": "WEBIDL_TestSuperDictionary"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/super-interface.webidl/check_glob@webidl_super_interface__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/super-interface.webidl/check_glob@webidl_super_interface__json.snap
@@ -1,0 +1,61 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-26",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestSubInterface",
+    "sym": "WEBIDL_TestSubInterface"
+  },
+  {
+    "loc": "1:10-26",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestSubInterface",
+    "sym": "WEBIDL_TestSubInterface"
+  },
+  {
+    "loc": "1:29-47",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL class TestSuperInterface",
+    "sym": "WEBIDL_TestSuperInterface"
+  },
+  {
+    "loc": "1:29-47",
+    "target": 1,
+    "kind": "use",
+    "pretty": "TestSuperInterface",
+    "sym": "WEBIDL_TestSuperInterface"
+  },
+  {
+    "loc": "1:10-26",
+    "structured": 1,
+    "pretty": "TestSubInterface",
+    "sym": "WEBIDL_TestSubInterface",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestSubInterface_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestSubInterface"
+      }
+    ],
+    "supers": [
+      {
+        "sym": "WEBIDL_TestSuperInterface"
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/type.webidl/check_glob@webidl_type__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/type.webidl/check_glob@webidl_type__json.snap
@@ -1,0 +1,205 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:10-30",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL class TestInterfaceForType",
+    "sym": "WEBIDL_TestInterfaceForType"
+  },
+  {
+    "loc": "1:10-30",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForType",
+    "sym": "WEBIDL_TestInterfaceForType"
+  },
+  {
+    "loc": "2:7-12",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL method TestInterfaceForType::Func1",
+    "sym": "WEBIDL_TestInterfaceForType_Func1"
+  },
+  {
+    "loc": "2:7-12",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "TestInterfaceForType::Func1",
+    "sym": "WEBIDL_TestInterfaceForType_Func1"
+  },
+  {
+    "loc": "2:7-12",
+    "structured": 1,
+    "pretty": "TestInterfaceForType::Func1",
+    "sym": "WEBIDL_TestInterfaceForType_Func1",
+    "kind": "method",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "method",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#Func1"
+      }
+    ]
+  },
+  {
+    "loc": "2:2-6",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:2-6",
+    "target": 1,
+    "kind": "use",
+    "pretty": "void",
+    "sym": "WEBIDL_void"
+  },
+  {
+    "loc": "2:13-25",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type NullableType",
+    "sym": "WEBIDL_NullableType"
+  },
+  {
+    "loc": "2:13-25",
+    "target": 1,
+    "kind": "use",
+    "pretty": "NullableType",
+    "sym": "WEBIDL_NullableType"
+  },
+  {
+    "loc": "3:22-31",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ItemType1",
+    "sym": "WEBIDL_ItemType1"
+  },
+  {
+    "loc": "3:22-31",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ItemType1",
+    "sym": "WEBIDL_ItemType1"
+  },
+  {
+    "loc": "4:31-40",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "4:31-40",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ValueType",
+    "sym": "WEBIDL_ValueType"
+  },
+  {
+    "loc": "5:29-38",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type ItemType2",
+    "sym": "WEBIDL_ItemType2"
+  },
+  {
+    "loc": "5:29-38",
+    "target": 1,
+    "kind": "use",
+    "pretty": "ItemType2",
+    "sym": "WEBIDL_ItemType2"
+  },
+  {
+    "loc": "6:21-37",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type PromiseValueType",
+    "sym": "WEBIDL_PromiseValueType"
+  },
+  {
+    "loc": "6:21-37",
+    "target": 1,
+    "kind": "use",
+    "pretty": "PromiseValueType",
+    "sym": "WEBIDL_PromiseValueType"
+  },
+  {
+    "loc": "7:14-28",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type UnionItemType1",
+    "sym": "WEBIDL_UnionItemType1"
+  },
+  {
+    "loc": "7:14-28",
+    "target": 1,
+    "kind": "use",
+    "pretty": "UnionItemType1",
+    "sym": "WEBIDL_UnionItemType1"
+  },
+  {
+    "loc": "7:32-46",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type UnionItemType2",
+    "sym": "WEBIDL_UnionItemType2"
+  },
+  {
+    "loc": "7:32-46",
+    "target": 1,
+    "kind": "use",
+    "pretty": "UnionItemType2",
+    "sym": "WEBIDL_UnionItemType2"
+  },
+  {
+    "loc": "7:50-64",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type UnionItemType3",
+    "sym": "WEBIDL_UnionItemType3"
+  },
+  {
+    "loc": "7:50-64",
+    "target": 1,
+    "kind": "use",
+    "pretty": "UnionItemType3",
+    "sym": "WEBIDL_UnionItemType3"
+  },
+  {
+    "loc": "1:10-30",
+    "structured": 1,
+    "pretty": "TestInterfaceForType",
+    "sym": "WEBIDL_TestInterfaceForType",
+    "kind": "class",
+    "implKind": "idl",
+    "bindingSlots": [
+      {
+        "slotKind": "class",
+        "slotLang": "cpp",
+        "ownerLang": "idl",
+        "sym": "NS_mozilla::dom::TestInterfaceForType_Binding"
+      },
+      {
+        "slotKind": "interface_name",
+        "slotLang": "js",
+        "ownerLang": "idl",
+        "sym": "#TestInterfaceForType"
+      }
+    ],
+    "methods": [
+      {
+        "pretty": "TestInterfaceForType::Func1",
+        "sym": "WEBIDL_TestInterfaceForType_Func1",
+        "props": []
+      }
+    ]
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/webidl/typedef.webidl/check_glob@webidl_typedef__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/typedef.webidl/check_glob@webidl_typedef__json.snap
@@ -1,0 +1,34 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:17-23",
+    "source": 1,
+    "syntax": "idl",
+    "pretty": "IDL type ToType",
+    "sym": "WEBIDL_ToType"
+  },
+  {
+    "loc": "1:17-23",
+    "target": 1,
+    "kind": "idl",
+    "pretty": "ToType",
+    "sym": "WEBIDL_ToType"
+  },
+  {
+    "loc": "1:8-16",
+    "source": 1,
+    "syntax": "type",
+    "pretty": "IDL type FromType",
+    "sym": "WEBIDL_FromType"
+  },
+  {
+    "loc": "1:8-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "FromType",
+    "sym": "WEBIDL_FromType"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -667,6 +667,12 @@ Spread over multiple lines.
         </tr>
 
         <tr>
+          <td><a href="/tests/source/webidl" class="mimetype-fixed-container mimetype-icon-folder">webidl</a></td>
+          <td class="description"><a href="/tests/source/webidl" title=""></td>
+          <td><a href="/tests/source/webidl"></a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/xpidl" class="mimetype-fixed-container mimetype-icon-folder">xpidl</a></td>
           <td class="description"><a href="/tests/source/xpidl" title=""></td>
           <td><a href="/tests/source/xpidl"></a></td>

--- a/tests/tests/files/webidl/asynciterable.webidl
+++ b/tests/tests/files/webidl/asynciterable.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForAsyncIterable {
+  async iterable<KeyType, ValueType>(optional ArgType1 arg1);
+};

--- a/tests/tests/files/webidl/attribute.webidl
+++ b/tests/tests/files/webidl/attribute.webidl
@@ -1,0 +1,4 @@
+interface TestInterfaceForAttribute {
+  attribute AttrType1 attr1;
+  readonly attribute AttrType2 attr2;
+};

--- a/tests/tests/files/webidl/callback.webidl
+++ b/tests/tests/files/webidl/callback.webidl
@@ -1,0 +1,1 @@
+callback TestCallback = RetType (ArgType1 arg1, ArgType2 arg2);

--- a/tests/tests/files/webidl/const.webidl
+++ b/tests/tests/files/webidl/const.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForConst {
+  const ConstType1 const1 = 1;
+};

--- a/tests/tests/files/webidl/dictionary.webidl
+++ b/tests/tests/files/webidl/dictionary.webidl
@@ -1,0 +1,3 @@
+dictionary TestDictionary {
+  MemberType1 member1;
+};

--- a/tests/tests/files/webidl/enum.webidl
+++ b/tests/tests/files/webidl/enum.webidl
@@ -1,0 +1,5 @@
+enum TestEnum {
+  "variant1",
+  "variant2",
+  "variant3",
+};

--- a/tests/tests/files/webidl/external-interface.webidl
+++ b/tests/tests/files/webidl/external-interface.webidl
@@ -1,0 +1,1 @@
+interface TestExternalInterface;

--- a/tests/tests/files/webidl/includes.webidl
+++ b/tests/tests/files/webidl/includes.webidl
@@ -1,0 +1,1 @@
+TestInterface includes TestInterfaceMixin;

--- a/tests/tests/files/webidl/interface-mixin.webidl
+++ b/tests/tests/files/webidl/interface-mixin.webidl
@@ -1,0 +1,3 @@
+interface mixin TestInterfaceMixin {
+  void MixinMethod();
+};

--- a/tests/tests/files/webidl/iterable.webidl
+++ b/tests/tests/files/webidl/iterable.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForIterable {
+  iterable<KeyType, ValueType>;
+};

--- a/tests/tests/files/webidl/maplike.webidl
+++ b/tests/tests/files/webidl/maplike.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForMaplike {
+  maplike<KeyType, ValueType>;
+};

--- a/tests/tests/files/webidl/method.webidl
+++ b/tests/tests/files/webidl/method.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForMethod {
+  RetType MethodName(ArgType1 arg1, ArgType2 arg2);
+};

--- a/tests/tests/files/webidl/namespace.webidl
+++ b/tests/tests/files/webidl/namespace.webidl
@@ -1,0 +1,3 @@
+namespace TestNamespace {
+  void Func1();
+};

--- a/tests/tests/files/webidl/overload.webidl
+++ b/tests/tests/files/webidl/overload.webidl
@@ -1,0 +1,5 @@
+interface TestInterfaceForOverload {
+  RetType1 OverloadFunc(ArgType1 arg1);
+  RetType2 OverloadFunc(ArgType2_1 arg1, ArgType2_2 arg2);
+  RetType3 OverloadFunc(ArgType3_1 arg1, ArgType3_2 arg2, ArgType3_3 arg3);
+};

--- a/tests/tests/files/webidl/partial-dictionary.webidl
+++ b/tests/tests/files/webidl/partial-dictionary.webidl
@@ -1,0 +1,3 @@
+partial dictionary TestDictionary {
+  unsigned long Member2;
+};

--- a/tests/tests/files/webidl/partial-interface.webidl
+++ b/tests/tests/files/webidl/partial-interface.webidl
@@ -1,0 +1,3 @@
+partial interface TestInterface {
+  void PartialMethod();
+};

--- a/tests/tests/files/webidl/partial-namespace.webidl
+++ b/tests/tests/files/webidl/partial-namespace.webidl
@@ -1,0 +1,3 @@
+partial namespace TestNamespace {
+  void PartialFunc();
+};

--- a/tests/tests/files/webidl/setlike.webidl
+++ b/tests/tests/files/webidl/setlike.webidl
@@ -1,0 +1,3 @@
+interface TestInterfaceForSetlike {
+  setlike<ValueType>;
+};

--- a/tests/tests/files/webidl/super-dictionary.webidl
+++ b/tests/tests/files/webidl/super-dictionary.webidl
@@ -1,0 +1,2 @@
+dictionary TestSubDictionary : TestSuperDictionary {
+};

--- a/tests/tests/files/webidl/super-interface.webidl
+++ b/tests/tests/files/webidl/super-interface.webidl
@@ -1,0 +1,2 @@
+interface TestSubInterface : TestSuperInterface {
+};

--- a/tests/tests/files/webidl/type.webidl
+++ b/tests/tests/files/webidl/type.webidl
@@ -1,0 +1,9 @@
+interface TestInterfaceForType {
+  void Func1(NullableType? arg1,
+             sequence<ItemType1> arg2,
+             record<DOMString, ValueType> arg3,
+             ObservableArray<ItemType2> arg4,
+             Promise<PromiseValueType> arg5,
+             (UnionItemType1 or UnionItemType2 or UnionItemType3) arg5,
+             unsigned long arg6);
+};

--- a/tests/tests/files/webidl/typedef.webidl
+++ b/tests/tests/files/webidl/typedef.webidl
@@ -1,0 +1,1 @@
+typedef FromType ToType;

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -357,6 +357,15 @@ pub enum BindingOwnerLang {
     Jvm,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BindingImplKind {
+    // The auto-generated binding.
+    Binding,
+    // The actual implementation called by the binding.
+    Impl,
+}
+
 /// The binding slot mechanism is used to describe the exclusive relationship
 /// between IDL symbols and their bindings as well as the non-exclusive
 /// support relationships like enabling functions.
@@ -378,6 +387,8 @@ pub struct BindingSlotProps {
     pub slot_kind: BindingSlotKind,
     #[serde(rename = "slotLang")]
     pub slot_lang: BindingSlotLang,
+    #[serde(rename = "implKind", default)]
+    pub impl_kind: Option<BindingImplKind>,
     #[serde(rename = "ownerLang")]
     pub owner_lang: BindingOwnerLang,
 }

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -305,8 +305,8 @@ where
 pub enum BindingSlotKind {
     /// A class that directly implements or will be subclassed.
     Class,
-    /// For situations like XPConnect interfaces reflected into JS (and maybe
-    /// WebIDL?) where we are describing the symbol that exposes the IDL
+    /// For situations like XPConnect interfaces reflected into JS and
+    /// WebIDL where we are describing the symbol that exposes the IDL
     /// interface into the language, but where that symbol is not directly part
     /// of a class hierarchy.  I'm really not sure about the WebIDL case here,
     /// and it probably will want to depend on how we end up implementing the
@@ -316,7 +316,7 @@ pub enum BindingSlotKind {
     InterfaceName,
     /// Callable.
     Method,
-    /// A field/attribute/property that has JS XPIDL semantics where we only
+    /// A field/attribute/property that has JS XPIDL or WebIDL semantics where we only
     /// have a single symbol name but it could correspond to a property or any
     /// combination of a getter/setter.
     Attribute,

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -356,9 +356,11 @@ static RESERVED_WORDS_WEBIDL: &'static [&'static str] = &[
     "ArrayBuffer",
     "SharedArrayBuffer",
     "or",
-    "maplike",
-    "setlike",
-    "iterable",
+    // While maplike/setlike/iterable are reserved words, they're used as
+    // symbols for corresponding C++ namespace.
+    // "maplike",
+    // "setlike",
+    // "iterable",
     "Exposed",
     "ChromeOnly",
     "ChromeConstructor",


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1416899
depends on https://github.com/mozsearch/mozsearch-mozilla/pull/245
also depends on https://bugzilla.mozilla.org/show_bug.cgi?id=1901445

This does the following:
  * Collect WebIDL files, based on the filter from the config
  * Let `idl-analyze.sh` copy/download `WebIDL.py` in addition to `xpidl.py`
  * Generate analysis files for each WebIDL file, in the same way as XPIDL
  * Add slots to associate with C++ code
    * IDL interface => C++ namespace
      * e.g. `Performance` => `mozilla::dom::Performance_Binding`
    * IDL namespace => C++ namespace
      * e.g. `ChromeUtils` => `mozilla::dom::ChromeUtils_Binding`
    * IDL methods => C++ function
      * e.g. `ChromeUtils.getObjectNodeId` => `mozilla::dom::ChromeUtils_Binding::getObjectNodeId`
    * IDL attributes => C++ getter/setter functions
      * e.g. `Performance.timing` => `mozilla::dom::Performance_Binding::get_timing`
    * IDL const => C++ constant
      * e.g. `PerformanceNavigation.TYPE_NAVIGATE` => `mozilla::dom::PerformanceNavigation_Binding::TYPE_NAVIGATE`
    * IDL maplike/setlike/iterable/async iterable => C++ namespace for helpers
      * e.g. `HighlightRegistry.maplike` => `mozilla::dom::HighlightRegistry_Binding::MaplikeHelpers`
      * e.g. `ReadableStream::asynciterable` => `mozilla::dom::ReadableStreamAsyncIterator_Binding`
    * IDL dictionary => C++ class
      * e.g. `ImportESModuleOptionsDictionary` => `mozilla::dom::ImportESModuleOptionsDictionary`
    * IDL dictionary field => C++ class member
      * e.g. `ImportESModuleOptionsDictionary.global` => `mozilla::dom::ImportESModuleOptionsDictionary::mGlobal`
    * IDL enum => C++ enum class
      * e.g. `WebIDLProcType` => `mozilla::dom::WebIDLProcType`
  * Add slots to associate with JS symbols

TODO:
  * ~~remove the workaround once https://bugzilla.mozilla.org/show_bug.cgi?id=1901445 fix lands~~
  * ~~add testcases~~
  * ~~test on dev channel~~

Now available on dev channel, with importing `WebIDL.py` fix: https://dev.searchfox.org/mozilla-central/search?q=&path=.webidl&case=false&regexp=false