### PR TITLE
Add symbol info to field types in field layout table

### DIFF
--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -562,10 +562,44 @@ kind = "weak"
 [types."nsRefPtrHashKey".pointer]
 kind = "strong"
 
+# ### JS Wrapper Types ###
+
+[types."JS::Result".value]
+
+# ### JS Container Types ###
+
+[types."js::HashMap".container]
+
+[types."js::HashSet".container]
+
+[types."js::ProtectedData".container]
+
+[types."js::ProtectedDataNoCheckArgs".container]
+
+[types."js::ProtectedDataWriteOnce".container]
+
+[types."js::Vector".container]
+
+# ### JS Pointer Types ###
+
+[types."js::AtomicRefCounted".pointer]
+kind = "strong"
+
+[types."js::RefCounted".pointer]
+kind = "strong"
+
+# ### JS GC Wrapper Types ###
+
+[types."js::GCPtr".pointer]
+kind = "gcref"
+
 [types."JS::Handle".pointer]
 kind = "gcref"
 
 [types."JS::Heap".pointer]
+kind = "gcref"
+
+[types."js::HeapPtr".pointer]
 kind = "gcref"
 
 [types."JS::TenuredHeap".pointer]
@@ -574,8 +608,25 @@ kind = "gcref"
 [types."JS::MutableHandle".pointer]
 kind = "gcref"
 
+[types."JS::PersistentRooted".pointer]
+kind = "gcref"
+
 [types."JS::Rooted".pointer]
 kind = "gcref"
+
+# ### JS GC Collection Types ###
+
+[types."JS::GCHashMap".container]
+
+[types."js::GCRekeyableHashMap".container]
+
+[types."JS::GCVector".container]
+
+[types."JS::PersistentRootedVector".container]
+
+[types."JS::RootedVector".container]
+
+[types."JS::StackGCVector".container]
 
 # #### Webkit
 #

--- a/tests/tests/checks/inputs/fancy/format-symbol/field-layout/field-type.cpp/field_layout__field_type__json
+++ b/tests/tests/checks/inputs/fancy/format-symbol/field-layout/field-type.cpp/field_layout__field_type__json
@@ -1,0 +1,1 @@
+search-identifiers field_layout::field_type::S | crossref-lookup | format-symbols --mode="field-layout"

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -168,6 +168,167 @@ expression: "&to_value(sttl).unwrap()"
             "def": "big_cpp.cpp#147"
           }
         },
+        "T_outerNS::Couch": {
+          "sym": "T_outerNS::Couch",
+          "pretty": "outerNS::Couch",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Couch",
+            "sym": "T_outerNS::Couch",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::Couch::Couch",
+                "sym": "_ZN7outerNS5CouchC1Ei",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::operator=",
+                "sym": "_ZN7outerNS5CouchaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::operator=",
+                "sym": "_ZN7outerNS5CouchaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::~Couch",
+                "sym": "_ZN7outerNS5CouchD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#211"
+          }
+        },
+        "T_outerNS::Human": {
+          "sym": "T_outerNS::Human",
+          "pretty": "outerNS::Human",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Human",
+            "sym": "T_outerNS::Human",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1Ev",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::operator=",
+                "sym": "_ZN7outerNS5HumanaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::operator=",
+                "sym": "_ZN7outerNS5HumanaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::~Human",
+                "sym": "_ZN7outerNS5HumanD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_outerNS::Superhero"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#185"
+          }
+        },
         "T_outerNS::OuterCat": {
           "sym": "T_outerNS::OuterCat",
           "pretty": "outerNS::OuterCat",
@@ -502,6 +663,10 @@ expression: "&to_value(sttl).unwrap()"
           "jumps": {
             "def": "big_cpp.cpp#141"
           }
+        },
+        "T_std::shared_ptr": {
+          "sym": "T_std::shared_ptr",
+          "pretty": "T_std::shared_ptr"
         }
       },
       "columns": [
@@ -591,7 +756,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "_Bool"
+                      "SymbolText": {
+                        "text": "_Bool",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -635,7 +803,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "_Bool"
+                      "SymbolText": {
+                        "text": "_Bool",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -698,7 +869,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "class std::shared_ptr<class outerNS::Human>"
+                      "SymbolText": {
+                        "text": "class std::shared_ptr<class outerNS::Human>",
+                        "symbols": "T_std::shared_ptr,T_outerNS::Human"
+                      }
                     }
                   ],
                   "colspan": 1
@@ -742,7 +916,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "class outerNS::Couch *"
+                      "SymbolText": {
+                        "text": "class outerNS::Couch *",
+                        "symbols": "T_outerNS::Couch"
+                      }
                     }
                   ],
                   "colspan": 1
@@ -843,7 +1020,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -887,7 +1067,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "_Bool"
+                          "SymbolText": {
+                            "text": "_Bool",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -558,22 +558,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "outerNS::OuterCat"
-            }
-          ],
-          "sym": "T_outerNS::OuterCat",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "mIsFriendly"
+                  "SymbolHeading": {
+                    "text": "outerNS::OuterCat",
+                    "symbols": "T_outerNS::OuterCat"
+                  }
                 }
               ],
-              "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mIsFriendly",
+                        "symbols": "F_<T_outerNS::OuterCat>_mIsFriendly"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -602,17 +615,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mIsSecretlyUnfriendly"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mIsSecretlyUnfriendly",
+                        "symbols": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -641,17 +659,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -663,17 +678,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mOwner"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mOwner",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mOwner",
+                        "symbols": "F_<T_outerNS::OuterCat>_mOwner"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -702,17 +722,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mFavoriteCouch"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mFavoriteCouch",
+                        "symbols": "F_<T_outerNS::OuterCat>_mFavoriteCouch"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -741,26 +766,35 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "outerNS::Thing (base class)"
-                }
-              ],
-              "sym": "T_outerNS::Thing",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "outerNS::Thing (base class)",
+                        "symbols": "T_outerNS::Thing"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -789,17 +823,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "mHP"
-                    }
-                  ],
-                  "sym": "F_<T_outerNS::Thing>_mHP",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "mHP",
+                            "symbols": "F_<T_outerNS::Thing>_mHP"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -828,17 +867,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "mDefunct"
-                    }
-                  ],
-                  "sym": "F_<T_outerNS::Thing>_mDefunct",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "mDefunct",
+                            "symbols": "F_<T_outerNS::Thing>_mDefunct"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -867,14 +911,11 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -352,22 +352,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::bitfields::S"
-            }
-          ],
-          "sym": "T_field_layout::bitfields::S",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "b1"
+                  "SymbolHeading": {
+                    "text": "field_layout::bitfields::S",
+                    "symbols": "T_field_layout::bitfields::S"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::bitfields::S>_b1",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b1",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -396,17 +409,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "b2"
-                }
-              ],
-              "sym": "F_<T_field_layout::bitfields::S>_b2",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b2",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b2"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -435,17 +453,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "b3"
-                }
-              ],
-              "sym": "F_<T_field_layout::bitfields::S>_b3",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b3",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b3"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -474,17 +497,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "b4"
-                }
-              ],
-              "sym": "F_<T_field_layout::bitfields::S>_b4",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b4",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b4"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -513,17 +541,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "b5"
-                }
-              ],
-              "sym": "F_<T_field_layout::bitfields::S>_b5",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b5",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b5"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -552,17 +585,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "b6"
-                }
-              ],
-              "sym": "F_<T_field_layout::bitfields::S>_b6",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "b6",
+                        "symbols": "F_<T_field_layout::bitfields::S>_b6"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -591,17 +629,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -613,11 +648,9 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -385,7 +385,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -429,7 +432,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -473,7 +479,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -517,7 +526,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -561,7 +573,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned char"
+                      "SymbolText": {
+                        "text": "unsigned char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -605,7 +620,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned short"
+                      "SymbolText": {
+                        "text": "unsigned short",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
@@ -118,15 +118,21 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::empty::S"
+              "header": false,
+              "contents": [
+                {
+                  "SymbolHeading": {
+                    "text": "field_layout::empty::S",
+                    "symbols": "T_field_layout::empty::S"
+                  }
+                }
+              ],
+              "colspan": 5
             }
           ],
-          "sym": "T_field_layout::empty::S",
-          "colVals": [],
-          "children": [],
-          "colspan": 4
+          "children": []
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -1,0 +1,762 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(sttl).unwrap()"
+---
+{
+  "tables": [
+    {
+      "jumprefs": {
+        "F_<T_field_layout::field_type::S>_pointer_field": {
+          "sym": "F_<T_field_layout::field_type::S>_pointer_field",
+          "pretty": "field_layout::field_type::S::pointer_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::pointer_field",
+            "sym": "F_<T_field_layout::field_type::S>_pointer_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#29"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_template_field_1": {
+          "sym": "F_<T_field_layout::field_type::S>_template_field_1",
+          "pretty": "field_layout::field_type::S::template_field_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::template_field_1",
+            "sym": "F_<T_field_layout::field_type::S>_template_field_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#30"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_template_field_2": {
+          "sym": "F_<T_field_layout::field_type::S>_template_field_2",
+          "pretty": "field_layout::field_type::S::template_field_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::template_field_2",
+            "sym": "F_<T_field_layout::field_type::S>_template_field_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#31"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_value_field": {
+          "sym": "F_<T_field_layout::field_type::S>_value_field",
+          "pretty": "field_layout::field_type::S::value_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::value_field",
+            "sym": "F_<T_field_layout::field_type::S>_value_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#28"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_vector_field": {
+          "sym": "F_<T_field_layout::field_type::S>_vector_field",
+          "pretty": "field_layout::field_type::S::vector_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::vector_field",
+            "sym": "F_<T_field_layout::field_type::S>_vector_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#32"
+          }
+        },
+        "T_field_layout::field_type::Container1": {
+          "sym": "T_field_layout::field_type::Container1",
+          "pretty": "T_field_layout::field_type::Container1",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#13"
+          }
+        },
+        "T_field_layout::field_type::Container2": {
+          "sym": "T_field_layout::field_type::Container2",
+          "pretty": "T_field_layout::field_type::Container2",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#23"
+          }
+        },
+        "T_field_layout::field_type::S": {
+          "sym": "T_field_layout::field_type::S",
+          "pretty": "field_layout::field_type::S",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S",
+            "sym": "T_field_layout::field_type::S",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 48,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [
+              {
+                "pretty": "field_layout::field_type::S::S",
+                "sym": "_ZN12field_layout10field_type1SC1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::S::S",
+                "sym": "_ZN12field_layout10field_type1SC1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::S::operator=",
+                "sym": "_ZN12field_layout10field_type1SaSERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::S::operator=",
+                "sym": "_ZN12field_layout10field_type1SaSEOS1_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::S::~S",
+                "sym": "_ZN12field_layout10field_type1SD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::S::S",
+                "sym": "_ZN12field_layout10field_type1SC1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::field_type::S::value_field",
+                "sym": "F_<T_field_layout::field_type::S>_value_field",
+                "type": "struct field_layout::field_type::Type1",
+                "typesym": "T_field_layout::field_type::Type1",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::pointer_field",
+                "sym": "F_<T_field_layout::field_type::S>_pointer_field",
+                "type": "const struct field_layout::field_type::Type1 *",
+                "typesym": "T_field_layout::field_type::Type1",
+                "offsetBytes": 8,
+                "bitPositions": null,
+                "sizeBytes": 8,
+                "pointerInfo": [
+                  {
+                    "kind": "raw",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::template_field_1",
+                "sym": "F_<T_field_layout::field_type::S>_template_field_1",
+                "type": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                "typesym": "T_field_layout::field_type::Container1",
+                "offsetBytes": 16,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Container1"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::template_field_2",
+                "sym": "F_<T_field_layout::field_type::S>_template_field_2",
+                "type": "struct field_layout::field_type::Container2<struct field_layout::field_type::Type1, field_layout::field_type::Enum1::No>",
+                "typesym": "T_field_layout::field_type::Container2",
+                "offsetBytes": 17,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Container2"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::vector_field",
+                "sym": "F_<T_field_layout::field_type::S>_vector_field",
+                "type": "class std::vector<struct field_layout::field_type::Type1>",
+                "typesym": "T_std::vector",
+                "offsetBytes": 24,
+                "bitPositions": null,
+                "sizeBytes": 24,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#27"
+          }
+        },
+        "T_field_layout::field_type::Type1": {
+          "sym": "T_field_layout::field_type::Type1",
+          "pretty": "field_layout::field_type::Type1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::Type1",
+            "sym": "T_field_layout::field_type::Type1",
+            "type_pretty": null,
+            "kind": "struct",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 1,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [
+              {
+                "pretty": "field_layout::field_type::Type1::Type1",
+                "sym": "_ZN12field_layout10field_type5Type1C1ERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::Type1::Type1",
+                "sym": "_ZN12field_layout10field_type5Type1C1EOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::Type1::~Type1",
+                "sym": "_ZN12field_layout10field_type5Type1D1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::Type1::operator=",
+                "sym": "_ZN12field_layout10field_type5Type1aSERKS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::Type1::operator=",
+                "sym": "_ZN12field_layout10field_type5Type1aSEOS1_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "field_layout::field_type::Type1::Type1",
+                "sym": "_ZN12field_layout10field_type5Type1C1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [
+              {
+                "pretty": "field_layout::field_type::Type1::a",
+                "sym": "F_<T_field_layout::field_type::Type1>_a",
+                "type": "unsigned char",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 1
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#8"
+          }
+        },
+        "T_std::vector": {
+          "sym": "T_std::vector",
+          "pretty": "T_std::vector"
+        }
+      },
+      "columns": [
+        {
+          "label": [
+            {
+              "Heading": "Name"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "Type"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Heading": "All platforms"
+            }
+          ],
+          "colspan": 2
+        }
+      ],
+      "sub_columns": [
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Offset"
+            }
+          ],
+          "colspan": 1
+        },
+        {
+          "label": [
+            {
+              "Text": "Size"
+            }
+          ],
+          "colspan": 1
+        }
+      ],
+      "rows": [
+        {
+          "colVals": [
+            {
+              "header": false,
+              "contents": [
+                {
+                  "SymbolHeading": {
+                    "text": "field_layout::field_type::S",
+                    "symbols": "T_field_layout::field_type::S"
+                  }
+                }
+              ],
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "value_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_value_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "struct field_layout::field_type::Type1",
+                        "symbols": "T_field_layout::field_type::Type1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x0"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [],
+                  "colspan": 2
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "ItalicText": "7 bytes hole"
+                    }
+                  ],
+                  "colspan": 2
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "pointer_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_pointer_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "const struct field_layout::field_type::Type1 *",
+                        "symbols": "T_field_layout::field_type::Type1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x8"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "8"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "template_field_1",
+                        "symbols": "F_<T_field_layout::field_type::S>_template_field_1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                        "symbols": "T_field_layout::field_type::Container1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x10"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "template_field_2",
+                        "symbols": "F_<T_field_layout::field_type::S>_template_field_2"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "struct field_layout::field_type::Container2<struct field_layout::field_type::Type1, field_layout::field_type::Enum1::No>",
+                        "symbols": "T_field_layout::field_type::Container2"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x11"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [],
+                  "colspan": 2
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "ItalicText": "6 bytes hole"
+                    }
+                  ],
+                  "colspan": 2
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "vector_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_vector_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "class std::vector<struct field_layout::field_type::Type1>",
+                        "symbols": "T_std::vector,T_field_layout::field_type::Type1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x18"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "24"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -6,6 +6,33 @@ expression: "&to_value(sttl).unwrap()"
   "tables": [
     {
       "jumprefs": {
+        "F_<T_field_layout::field_type::S>_hash_map_field": {
+          "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
+          "pretty": "field_layout::field_type::S::hash_map_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::hash_map_field",
+            "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#85"
+          }
+        },
         "F_<T_field_layout::field_type::S>_pointer_field": {
           "sym": "F_<T_field_layout::field_type::S>_pointer_field",
           "pretty": "field_layout::field_type::S::pointer_field",
@@ -30,7 +57,88 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#29"
+            "def": "field-layout/field-type.cpp#79"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_protected_field": {
+          "sym": "F_<T_field_layout::field_type::S>_protected_field",
+          "pretty": "field_layout::field_type::S::protected_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::protected_field",
+            "sym": "F_<T_field_layout::field_type::S>_protected_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#86"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_rooted_field": {
+          "sym": "F_<T_field_layout::field_type::S>_rooted_field",
+          "pretty": "field_layout::field_type::S::rooted_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::rooted_field",
+            "sym": "F_<T_field_layout::field_type::S>_rooted_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#83"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_rooted_vec_field": {
+          "sym": "F_<T_field_layout::field_type::S>_rooted_vec_field",
+          "pretty": "field_layout::field_type::S::rooted_vec_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::rooted_vec_field",
+            "sym": "F_<T_field_layout::field_type::S>_rooted_vec_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#84"
           }
         },
         "F_<T_field_layout::field_type::S>_template_field_1": {
@@ -57,7 +165,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#30"
+            "def": "field-layout/field-type.cpp#80"
           }
         },
         "F_<T_field_layout::field_type::S>_template_field_2": {
@@ -84,7 +192,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#31"
+            "def": "field-layout/field-type.cpp#81"
           }
         },
         "F_<T_field_layout::field_type::S>_value_field": {
@@ -111,7 +219,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#28"
+            "def": "field-layout/field-type.cpp#78"
           }
         },
         "F_<T_field_layout::field_type::S>_vector_field": {
@@ -138,21 +246,107 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#32"
+            "def": "field-layout/field-type.cpp#82"
+          }
+        },
+        "T_JS::GCHashMap": {
+          "sym": "T_JS::GCHashMap",
+          "pretty": "T_JS::GCHashMap",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#38"
+          }
+        },
+        "T_JS::Rooted": {
+          "sym": "T_JS::Rooted",
+          "pretty": "T_JS::Rooted",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#15"
+          }
+        },
+        "T_JS::RootedVector": {
+          "sym": "T_JS::RootedVector",
+          "pretty": "T_JS::RootedVector",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#28"
+          }
+        },
+        "T_JS::Value": {
+          "sym": "T_JS::Value",
+          "pretty": "JS::Value",
+          "meta": {
+            "structured": 1,
+            "pretty": "JS::Value",
+            "sym": "T_JS::Value",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 8,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [
+              {
+                "pretty": "JS::Value::asBits_",
+                "sym": "F_<T_JS::Value>_asBits_",
+                "type": "unsigned long",
+                "typesym": "",
+                "offsetBytes": 0,
+                "bitPositions": null,
+                "sizeBytes": 8
+              }
+            ],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#31"
+          }
+        },
+        "T_JSObject": {
+          "sym": "T_JSObject",
+          "pretty": "JSObject",
+          "meta": {
+            "structured": 1,
+            "pretty": "JSObject",
+            "sym": "T_JSObject",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 1,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "labels": [
+              "class-diagram:stop"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#5"
           }
         },
         "T_field_layout::field_type::Container1": {
           "sym": "T_field_layout::field_type::Container1",
           "pretty": "T_field_layout::field_type::Container1",
           "jumps": {
-            "def": "field-layout/field-type.cpp#13"
+            "def": "field-layout/field-type.cpp#63"
           }
         },
         "T_field_layout::field_type::Container2": {
           "sym": "T_field_layout::field_type::Container2",
           "pretty": "T_field_layout::field_type::Container2",
           "jumps": {
-            "def": "field-layout/field-type.cpp#23"
+            "def": "field-layout/field-type.cpp#73"
           }
         },
         "T_field_layout::field_type::S": {
@@ -166,7 +360,7 @@ expression: "&to_value(sttl).unwrap()"
             "kind": "struct",
             "subsystem": null,
             "implKind": "",
-            "sizeBytes": 48,
+            "sizeBytes": 56,
             "ownVFPtrBytes": null,
             "bindingSlots": [],
             "ontologySlots": [],
@@ -302,6 +496,74 @@ expression: "&to_value(sttl).unwrap()"
                     "sym": "T_field_layout::field_type::Type1"
                   }
                 ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::rooted_field",
+                "sym": "F_<T_field_layout::field_type::S>_rooted_field",
+                "type": "class JS::Rooted<class JS::Value>",
+                "typesym": "T_JS::Rooted",
+                "offsetBytes": 48,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "gcref",
+                    "sym": "T_JS::Value"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::rooted_vec_field",
+                "sym": "F_<T_field_layout::field_type::S>_rooted_vec_field",
+                "type": "class JS::RootedVector<class JS::Value>",
+                "typesym": "T_JS::RootedVector",
+                "offsetBytes": 49,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_JS::Value"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::hash_map_field",
+                "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
+                "type": "class JS::GCHashMap<class JS::Value, class JSObject *>",
+                "typesym": "T_JS::GCHashMap",
+                "offsetBytes": 50,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_JS::Value"
+                  },
+                  {
+                    "kind": "raw",
+                    "sym": "T_JSObject"
+                  }
+                ]
+              },
+              {
+                "pretty": "field_layout::field_type::S::protected_field",
+                "sym": "F_<T_field_layout::field_type::S>_protected_field",
+                "type": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, class JS::Value>",
+                "typesym": "T_js::ProtectedDataNoCheckArgs",
+                "offsetBytes": 51,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_js::TestCheck"
+                  },
+                  {
+                    "kind": "contains",
+                    "sym": "T_JS::Value"
+                  }
+                ]
               }
             ],
             "overrides": [],
@@ -309,7 +571,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#27"
+            "def": "field-layout/field-type.cpp#77"
           }
         },
         "T_field_layout::field_type::Type1": {
@@ -404,7 +666,40 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#8"
+            "def": "field-layout/field-type.cpp#58"
+          }
+        },
+        "T_js::ProtectedDataNoCheckArgs": {
+          "sym": "T_js::ProtectedDataNoCheckArgs",
+          "pretty": "T_js::ProtectedDataNoCheckArgs",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#49"
+          }
+        },
+        "T_js::TestCheck": {
+          "sym": "T_js::TestCheck",
+          "pretty": "js::TestCheck",
+          "meta": {
+            "structured": 1,
+            "pretty": "js::TestCheck",
+            "sym": "T_js::TestCheck",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": 1,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#45"
           }
         },
         "T_std::vector": {
@@ -750,6 +1045,213 @@ expression: "&to_value(sttl).unwrap()"
                     }
                   ],
                   "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "rooted_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_rooted_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "class JS::Rooted<class JS::Value>",
+                        "symbols": "T_JS::Rooted,T_JS::Value"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x30"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "rooted_vec_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_rooted_vec_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "class JS::RootedVector<class JS::Value>",
+                        "symbols": "T_JS::RootedVector,T_JS::Value"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x31"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "hash_map_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_hash_map_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "class JS::GCHashMap<class JS::Value, class JSObject *>",
+                        "symbols": "T_JS::GCHashMap,T_JS::Value,T_JSObject"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x32"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "protected_field",
+                        "symbols": "F_<T_field_layout::field_type::S>_protected_field"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, class JS::Value>",
+                        "symbols": "T_js::ProtectedDataNoCheckArgs,T_js::TestCheck,T_JS::Value"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "@ 0x33"
+                    }
+                  ],
+                  "colspan": 1
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "Text": "1"
+                    }
+                  ],
+                  "colspan": 1
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [],
+                  "colspan": 2
+                },
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "ItalicText": "4 bytes padding"
+                    }
+                  ],
+                  "colspan": 2
                 }
               ],
               "children": []

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -409,22 +409,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::holes::Sub"
-            }
-          ],
-          "sym": "T_field_layout::holes::Sub",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "x"
+                  "SymbolHeading": {
+                    "text": "field_layout::holes::Sub",
+                    "symbols": "T_field_layout::holes::Sub"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::holes::Sub>_x",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "x",
+                        "symbols": "F_<T_field_layout::holes::Sub>_x"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -453,17 +466,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -475,17 +485,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "y"
-                }
-              ],
-              "sym": "F_<T_field_layout::holes::Sub>_y",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "y",
+                        "symbols": "F_<T_field_layout::holes::Sub>_y"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -514,26 +529,38 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::holes::Base (base class)"
-                }
-              ],
-              "sym": "T_field_layout::holes::Base",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "a"
+                      "SymbolHeading": {
+                        "text": "field_layout::holes::Base (base class)",
+                        "symbols": "T_field_layout::holes::Base"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::holes::Base>_a",
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "a",
+                            "symbols": "F_<T_field_layout::holes::Base>_a"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -562,17 +589,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -584,17 +608,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "b"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::holes::Base>_b",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "b",
+                            "symbols": "F_<T_field_layout::holes::Base>_b"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -623,17 +652,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "c"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::holes::Base>_c",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "c",
+                            "symbols": "F_<T_field_layout::holes::Base>_c"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -662,17 +696,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "d"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::holes::Base>_d",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "d",
+                            "symbols": "F_<T_field_layout::holes::Base>_d"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -701,17 +740,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -723,14 +759,11 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -442,7 +442,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned char"
+                      "SymbolText": {
+                        "text": "unsigned char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -505,7 +508,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -565,7 +571,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -628,7 +637,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned short"
+                          "SymbolText": {
+                            "text": "unsigned short",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -672,7 +684,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned int"
+                          "SymbolText": {
+                            "text": "unsigned int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -716,7 +731,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "char"
+                          "SymbolText": {
+                            "text": "char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -1558,7 +1558,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "int"
+                      "SymbolText": {
+                        "text": "int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -1664,7 +1667,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1768,7 +1774,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1848,7 +1857,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1910,7 +1922,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "short"
+                          "SymbolText": {
+                            "text": "short",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2018,7 +2033,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2080,7 +2098,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "signed char"
+                          "SymbolText": {
+                            "text": "signed char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2190,7 +2211,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "long"
+                          "SymbolText": {
+                            "text": "long",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2262,7 +2286,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2324,7 +2351,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "signed char"
+                          "SymbolText": {
+                            "text": "signed char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2456,7 +2486,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "long"
+                          "SymbolText": {
+                            "text": "long",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2518,7 +2551,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2632,7 +2668,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "signed char"
+                          "SymbolText": {
+                            "text": "signed char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -2722,7 +2761,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -1525,22 +1525,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::multiple_inheritance::SubSubSubA"
-            }
-          ],
-          "sym": "T_field_layout::multiple_inheritance::SubSubSubA",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "sub_sub_sub_a_1"
+                  "SymbolHeading": {
+                    "text": "field_layout::multiple_inheritance::SubSubSubA",
+                    "symbols": "T_field_layout::multiple_inheritance::SubSubSubA"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
+              "colspan": 7
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "sub_sub_sub_a_1",
+                        "symbols": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -1587,17 +1600,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -1618,26 +1628,38 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubSubA (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubSubA",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_sub_c_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubSubA (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubSubA"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_sub_c_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1684,17 +1706,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1711,29 +1730,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubSubB (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubSubB",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_sub_b_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubSubB (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubSubB"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_sub_b_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1780,29 +1810,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubA (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubA",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_a_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubA (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubA"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_a_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1849,17 +1890,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_a_2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_a_2",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1906,17 +1952,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1937,29 +1980,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubB (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubB",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_b_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubB (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubB"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_b_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2006,17 +2060,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_b_2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_b_2",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2063,17 +2122,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -2090,17 +2146,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -2117,17 +2170,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_b_3"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_b_3",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2166,29 +2224,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubD (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubD",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_d_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubD (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubD"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_d_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2235,17 +2304,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_d_2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_d_2",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2292,17 +2366,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -2323,29 +2394,32 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::SubE (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubE (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubE"
+                      }
+                    }
+                  ],
+                  "colspan": 7
                 }
               ],
-              "sym": "T_field_layout::multiple_inheritance::SubE",
-              "colVals": [],
               "children": [
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -2362,17 +2436,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_e_1"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_e_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2419,17 +2498,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_e_2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_e_2",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2476,51 +2560,74 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
-              "colVals": [],
-              "children": [],
-              "colspan": 6
-            },
-            {
-              "label": [
-                {
-                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
-              "colVals": [],
-              "children": [],
-              "colspan": 6
-            },
-            {
-              "label": [
-                {
-                  "Heading": "field_layout::multiple_inheritance::SubC (base class)"
-                }
-              ],
-              "sym": "T_field_layout::multiple_inheritance::SubC",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "sub_c_1"
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::BaseEmpty (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::BaseEmpty"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
+                  "colspan": 7
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::BaseEmpty (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::BaseEmpty"
+                      }
+                    }
+                  ],
+                  "colspan": 7
+                }
+              ],
+              "children": []
+            },
+            {
+              "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::SubC (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::SubC"
+                      }
+                    }
+                  ],
+                  "colspan": 7
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_c_1",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2567,17 +2674,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -2598,17 +2702,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "sub_c_2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "sub_c_2",
+                            "symbols": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -2655,36 +2764,45 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 6
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::BaseEmpty (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::BaseEmpty"
+                      }
+                    }
+                  ],
+                  "colspan": 7
                 }
               ],
-              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
-              "colVals": [],
-              "children": [],
-              "colspan": 6
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::multiple_inheritance::BaseEmpty (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::multiple_inheritance::BaseEmpty (base class)",
+                        "symbols": "T_field_layout::multiple_inheritance::BaseEmpty"
+                      }
+                    }
+                  ],
+                  "colspan": 7
                 }
               ],
-              "sym": "T_field_layout::multiple_inheritance::BaseEmpty",
-              "colVals": [],
-              "children": [],
-              "colspan": 6
+              "children": []
             }
-          ],
-          "colspan": 6
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -124,22 +124,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::non_struct::Proxy"
-            }
-          ],
-          "sym": "T_field_layout::non_struct::Proxy",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "x"
+                  "SymbolHeading": {
+                    "text": "field_layout::non_struct::Proxy",
+                    "symbols": "T_field_layout::non_struct::Proxy"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::non_struct::Proxy>_x",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "x",
+                        "symbols": "F_<T_field_layout::non_struct::Proxy>_x"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -168,11 +181,9 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -157,7 +157,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "signed char"
+                      "SymbolText": {
+                        "text": "signed char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -763,22 +763,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::platform_specific_field::S3"
-            }
-          ],
-          "sym": "T_field_layout::platform_specific_field::S3",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "f6"
+                  "SymbolHeading": {
+                    "text": "field_layout::platform_specific_field::S3",
+                    "symbols": "T_field_layout::platform_specific_field::S3"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::platform_specific_field::S3>_f6",
+              "colspan": 9
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "f6",
+                        "symbols": "F_<T_field_layout::platform_specific_field::S3>_f6"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -843,17 +856,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -883,26 +893,38 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::platform_specific_field::S2 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::platform_specific_field::S2",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "f4"
+                      "SymbolHeading": {
+                        "text": "field_layout::platform_specific_field::S2 (base class)",
+                        "symbols": "T_field_layout::platform_specific_field::S2"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::platform_specific_field::S2>_f4",
+                  "colspan": 9
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f4",
+                            "symbols": "F_<T_field_layout::platform_specific_field::S2>_f4"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -967,17 +989,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f5"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::S2>_f5",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f5",
+                            "symbols": "F_<T_field_layout::platform_specific_field::S2>_f5"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1026,29 +1053,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 8
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::platform_specific_field::S1 (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::platform_specific_field::S1 (base class)",
+                        "symbols": "T_field_layout::platform_specific_field::S1"
+                      }
+                    }
+                  ],
+                  "colspan": 9
                 }
               ],
-              "sym": "T_field_layout::platform_specific_field::S1",
-              "colVals": [],
               "children": [
                 {
-                  "label": [
-                    {
-                      "Text": "f1"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::S1>_f1",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f1",
+                            "symbols": "F_<T_field_layout::platform_specific_field::S1>_f1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1113,17 +1151,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::S1>_f2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f2",
+                            "symbols": "F_<T_field_layout::platform_specific_field::S1>_f2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1180,17 +1223,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f3"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::S1>_f3",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f3",
+                            "symbols": "F_<T_field_layout::platform_specific_field::S1>_f3"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1239,17 +1287,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1271,14 +1316,11 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 8
+              ]
             }
-          ],
-          "colspan": 8
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -796,7 +796,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned char"
+                      "SymbolText": {
+                        "text": "unsigned char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -929,7 +932,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned int"
+                          "SymbolText": {
+                            "text": "unsigned int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1009,7 +1015,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1091,7 +1100,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned int"
+                          "SymbolText": {
+                            "text": "unsigned int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1171,7 +1183,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned int"
+                          "SymbolText": {
+                            "text": "unsigned int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1243,7 +1258,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -723,22 +723,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::platform_specific_field::T3"
+              "header": false,
+              "contents": [
+                {
+                  "SymbolHeading": {
+                    "text": "field_layout::platform_specific_field::T3",
+                    "symbols": "T_field_layout::platform_specific_field::T3"
+                  }
+                }
+              ],
+              "colspan": 9
             }
           ],
-          "sym": "T_field_layout::platform_specific_field::T3",
-          "colVals": [],
           "children": [
             {
-              "label": [
-                {
-                  "Text": "f4"
-                }
-              ],
-              "sym": "F_<T_field_layout::platform_specific_field::T3>_f4",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "f4",
+                        "symbols": "F_<T_field_layout::platform_specific_field::T3>_f4"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -803,17 +816,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "f5"
-                }
-              ],
-              "sym": "F_<T_field_layout::platform_specific_field::T3>_f5",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "f5",
+                        "symbols": "F_<T_field_layout::platform_specific_field::T3>_f5"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -870,17 +888,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "f6"
-                }
-              ],
-              "sym": "F_<T_field_layout::platform_specific_field::T3>_f6",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "f6",
+                        "symbols": "F_<T_field_layout::platform_specific_field::T3>_f6"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -929,17 +952,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -961,26 +981,30 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::platform_specific_field::T2 (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::platform_specific_field::T2 (base class)",
+                        "symbols": "T_field_layout::platform_specific_field::T2"
+                      }
+                    }
+                  ],
+                  "colspan": 9
                 }
               ],
-              "sym": "T_field_layout::platform_specific_field::T2",
-              "colVals": [],
               "children": [
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1010,17 +1034,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f2"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::T2>_f2",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f2",
+                            "symbols": "F_<T_field_layout::platform_specific_field::T2>_f2"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1085,17 +1114,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f3"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::T2>_f3",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f3",
+                            "symbols": "F_<T_field_layout::platform_specific_field::T2>_f3"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1144,17 +1178,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1176,17 +1207,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "f3b"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::platform_specific_field::T2>_f3b",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f3b",
+                            "symbols": "F_<T_field_layout::platform_specific_field::T2>_f3b"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1243,17 +1279,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1279,29 +1312,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 8
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::platform_specific_field::T1 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::platform_specific_field::T1",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "f1"
+                      "SymbolHeading": {
+                        "text": "field_layout::platform_specific_field::T1 (base class)",
+                        "symbols": "T_field_layout::platform_specific_field::T1"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::platform_specific_field::T1>_f1",
+                  "colspan": 9
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "f1",
+                            "symbols": "F_<T_field_layout::platform_specific_field::T1>_f1"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1366,14 +1410,11 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 8
+              ]
             }
-          ],
-          "colspan": 8
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -756,7 +756,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -836,7 +839,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -908,7 +914,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned char"
+                      "SymbolText": {
+                        "text": "unsigned char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -1054,7 +1063,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned int"
+                          "SymbolText": {
+                            "text": "unsigned int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1134,7 +1146,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1227,7 +1242,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1350,7 +1368,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -245,22 +245,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::platform_specific_size::S"
-            }
-          ],
-          "sym": "T_field_layout::platform_specific_size::S",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "f1"
+                  "SymbolHeading": {
+                    "text": "field_layout::platform_specific_size::S",
+                    "symbols": "T_field_layout::platform_specific_size::S"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::platform_specific_size::S>_f1",
+              "colspan": 7
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "f1",
+                        "symbols": "F_<T_field_layout::platform_specific_size::S>_f1"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -314,11 +327,9 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             }
-          ],
-          "colspan": 6
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -278,14 +278,20 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned long"
+                      "SymbolText": {
+                        "text": "unsigned long",
+                        "symbols": ""
+                      }
                     },
                     {
                       "Text": " | "
                     },
                     "Newline",
                     {
-                      "Text": "unsigned int"
+                      "SymbolText": {
+                        "text": "unsigned int",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
@@ -889,7 +889,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "unsigned char"
+                      "SymbolText": {
+                        "text": "unsigned char",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -968,7 +971,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1049,7 +1055,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1130,7 +1139,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -1252,7 +1264,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "unsigned char"
+                          "SymbolText": {
+                            "text": "unsigned char",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
@@ -856,22 +856,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "field_layout::vtable::SubSub"
-            }
-          ],
-          "sym": "T_field_layout::vtable::SubSub",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "z"
+                  "SymbolHeading": {
+                    "text": "field_layout::vtable::SubSub",
+                    "symbols": "T_field_layout::vtable::SubSub"
+                  }
                 }
               ],
-              "sym": "F_<T_field_layout::vtable::SubSub>_z",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "z",
+                        "symbols": "F_<T_field_layout::vtable::SubSub>_z"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -900,17 +913,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -922,26 +932,38 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Sub1a (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Sub1a",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "x"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Sub1a (base class)",
+                        "symbols": "T_field_layout::vtable::Sub1a"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::vtable::Sub1a>_x",
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "x",
+                            "symbols": "F_<T_field_layout::vtable::Sub1a>_x"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -970,17 +992,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -992,29 +1011,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Sub1b (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Sub1b",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "y"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Sub1b (base class)",
+                        "symbols": "T_field_layout::vtable::Sub1b"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::vtable::Sub1b>_y",
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "y",
+                            "symbols": "F_<T_field_layout::vtable::Sub1b>_y"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1043,17 +1073,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1065,29 +1092,40 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Sub2 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Sub2",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "w"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Sub2 (base class)",
+                        "symbols": "T_field_layout::vtable::Sub2"
+                      }
                     }
                   ],
-                  "sym": "F_<T_field_layout::vtable::Sub2>_w",
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "w",
+                            "symbols": "F_<T_field_layout::vtable::Sub2>_w"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1116,17 +1154,14 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [],
-                  "sym": null,
                   "colVals": [
                     {
                       "header": false,
                       "contents": [],
-                      "colspan": 1
+                      "colspan": 2
                     },
                     {
                       "header": false,
@@ -1138,29 +1173,37 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 2
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Sub3 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Sub3",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Sub3 (base class)",
+                        "symbols": "T_field_layout::vtable::Sub3"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1189,17 +1232,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "v"
-                    }
-                  ],
-                  "sym": "F_<T_field_layout::vtable::Sub3>_v",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "v",
+                            "symbols": "F_<T_field_layout::vtable::Sub3>_v"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1228,29 +1276,37 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Base1 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Base1",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Base1 (base class)",
+                        "symbols": "T_field_layout::vtable::Base1"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1279,29 +1335,37 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Base1 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Base1",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Base1 (base class)",
+                        "symbols": "T_field_layout::vtable::Base1"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1330,29 +1394,37 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Base2 (base class)"
-                }
-              ],
-              "sym": "T_field_layout::vtable::Base2",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Base2 (base class)",
+                        "symbols": "T_field_layout::vtable::Base2"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -1381,25 +1453,28 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "field_layout::vtable::Base3 (base class)"
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolHeading": {
+                        "text": "field_layout::vtable::Base3 (base class)",
+                        "symbols": "T_field_layout::vtable::Base3"
+                      }
+                    }
+                  ],
+                  "colspan": 5
                 }
               ],
-              "sym": "T_field_layout::vtable::Base3",
-              "colVals": [],
-              "children": [],
-              "colspan": 4
+              "children": []
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -168,6 +168,167 @@ expression: "&to_value(sttl).unwrap()"
             "def": "big_cpp.cpp#147"
           }
         },
+        "T_outerNS::Couch": {
+          "sym": "T_outerNS::Couch",
+          "pretty": "outerNS::Couch",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Couch",
+            "sym": "T_outerNS::Couch",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::Couch::Couch",
+                "sym": "_ZN7outerNS5CouchC1Ei",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::operator=",
+                "sym": "_ZN7outerNS5CouchaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::operator=",
+                "sym": "_ZN7outerNS5CouchaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Couch::~Couch",
+                "sym": "_ZN7outerNS5CouchD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#211"
+          }
+        },
+        "T_outerNS::Human": {
+          "sym": "T_outerNS::Human",
+          "pretty": "outerNS::Human",
+          "meta": {
+            "structured": 1,
+            "pretty": "outerNS::Human",
+            "sym": "T_outerNS::Human",
+            "type_pretty": null,
+            "kind": "class",
+            "subsystem": "Core/Big",
+            "implKind": "",
+            "sizeBytes": 16,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [
+              {
+                "sym": "T_outerNS::Thing",
+                "offsetBytes": 0,
+                "props": []
+              }
+            ],
+            "methods": [
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1Ev",
+                "props": [
+                  "instance",
+                  "user"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::operator=",
+                "sym": "_ZN7outerNS5HumanaSERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::operator=",
+                "sym": "_ZN7outerNS5HumanaSEOS0_",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::~Human",
+                "sym": "_ZN7outerNS5HumanD1Ev",
+                "props": [
+                  "instance",
+                  "defaulted"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1ERKS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              },
+              {
+                "pretty": "outerNS::Human::Human",
+                "sym": "_ZN7outerNS5HumanC1EOS0_",
+                "props": [
+                  "instance",
+                  "defaulted",
+                  "constexpr"
+                ],
+                "args": []
+              }
+            ],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "subclasses": [
+              "T_outerNS::Superhero"
+            ],
+            "variants": []
+          },
+          "jumps": {
+            "def": "big_cpp.cpp#185"
+          }
+        },
         "T_outerNS::OuterCat": {
           "sym": "T_outerNS::OuterCat",
           "pretty": "outerNS::OuterCat",
@@ -502,6 +663,10 @@ expression: "&to_value(sttl).unwrap()"
           "jumps": {
             "def": "big_cpp.cpp#141"
           }
+        },
+        "T_std::shared_ptr": {
+          "sym": "T_std::shared_ptr",
+          "pretty": "T_std::shared_ptr"
         }
       },
       "columns": [
@@ -591,7 +756,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "_Bool"
+                      "SymbolText": {
+                        "text": "_Bool",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -635,7 +803,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "_Bool"
+                      "SymbolText": {
+                        "text": "_Bool",
+                        "symbols": ""
+                      }
                     }
                   ],
                   "colspan": 1
@@ -698,7 +869,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "class std::shared_ptr<class outerNS::Human>"
+                      "SymbolText": {
+                        "text": "class std::shared_ptr<class outerNS::Human>",
+                        "symbols": "T_std::shared_ptr,T_outerNS::Human"
+                      }
                     }
                   ],
                   "colspan": 1
@@ -742,7 +916,10 @@ expression: "&to_value(sttl).unwrap()"
                   "header": false,
                   "contents": [
                     {
-                      "Text": "class outerNS::Couch *"
+                      "SymbolText": {
+                        "text": "class outerNS::Couch *",
+                        "symbols": "T_outerNS::Couch"
+                      }
                     }
                   ],
                   "colspan": 1
@@ -843,7 +1020,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "int"
+                          "SymbolText": {
+                            "text": "int",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1
@@ -887,7 +1067,10 @@ expression: "&to_value(sttl).unwrap()"
                       "header": false,
                       "contents": [
                         {
-                          "Text": "_Bool"
+                          "SymbolText": {
+                            "text": "_Bool",
+                            "symbols": ""
+                          }
                         }
                       ],
                       "colspan": 1

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -558,22 +558,35 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": [
         {
-          "label": [
+          "colVals": [
             {
-              "Heading": "outerNS::OuterCat"
-            }
-          ],
-          "sym": "T_outerNS::OuterCat",
-          "colVals": [],
-          "children": [
-            {
-              "label": [
+              "header": false,
+              "contents": [
                 {
-                  "Text": "mIsFriendly"
+                  "SymbolHeading": {
+                    "text": "outerNS::OuterCat",
+                    "symbols": "T_outerNS::OuterCat"
+                  }
                 }
               ],
-              "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
+              "colspan": 5
+            }
+          ],
+          "children": [
+            {
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mIsFriendly",
+                        "symbols": "F_<T_outerNS::OuterCat>_mIsFriendly"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -602,17 +615,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mIsSecretlyUnfriendly"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mIsSecretlyUnfriendly",
+                        "symbols": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -641,17 +659,14 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [],
-              "sym": null,
               "colVals": [
                 {
                   "header": false,
                   "contents": [],
-                  "colspan": 1
+                  "colspan": 2
                 },
                 {
                   "header": false,
@@ -663,17 +678,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 2
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mOwner"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mOwner",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mOwner",
+                        "symbols": "F_<T_outerNS::OuterCat>_mOwner"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -702,17 +722,22 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
-                {
-                  "Text": "mFavoriteCouch"
-                }
-              ],
-              "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
               "colVals": [
+                {
+                  "header": false,
+                  "contents": [
+                    {
+                      "SymbolText": {
+                        "text": "mFavoriteCouch",
+                        "symbols": "F_<T_outerNS::OuterCat>_mFavoriteCouch"
+                      }
+                    }
+                  ],
+                  "colspan": 1
+                },
                 {
                   "header": false,
                   "contents": [
@@ -741,26 +766,35 @@ expression: "&to_value(sttl).unwrap()"
                   "colspan": 1
                 }
               ],
-              "children": [],
-              "colspan": 1
+              "children": []
             },
             {
-              "label": [
+              "colVals": [
                 {
-                  "Heading": "outerNS::Thing (base class)"
-                }
-              ],
-              "sym": "T_outerNS::Thing",
-              "colVals": [],
-              "children": [
-                {
-                  "label": [
+                  "header": false,
+                  "contents": [
                     {
-                      "Text": "(vtable)"
+                      "SymbolHeading": {
+                        "text": "outerNS::Thing (base class)",
+                        "symbols": "T_outerNS::Thing"
+                      }
                     }
                   ],
-                  "sym": null,
+                  "colspan": 5
+                }
+              ],
+              "children": [
+                {
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "Text": "(vtable)"
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -789,17 +823,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "mHP"
-                    }
-                  ],
-                  "sym": "F_<T_outerNS::Thing>_mHP",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "mHP",
+                            "symbols": "F_<T_outerNS::Thing>_mHP"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -828,17 +867,22 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 },
                 {
-                  "label": [
-                    {
-                      "Text": "mDefunct"
-                    }
-                  ],
-                  "sym": "F_<T_outerNS::Thing>_mDefunct",
                   "colVals": [
+                    {
+                      "header": false,
+                      "contents": [
+                        {
+                          "SymbolText": {
+                            "text": "mDefunct",
+                            "symbols": "F_<T_outerNS::Thing>_mDefunct"
+                          }
+                        }
+                      ],
+                      "colspan": 1
+                    },
                     {
                       "header": false,
                       "contents": [
@@ -867,14 +911,11 @@ expression: "&to_value(sttl).unwrap()"
                       "colspan": 1
                     }
                   ],
-                  "children": [],
-                  "colspan": 1
+                  "children": []
                 }
-              ],
-              "colspan": 4
+              ]
             }
-          ],
-          "colspan": 4
+          ]
         }
       ]
     }

--- a/tests/tests/files/field-layout/field-type.cpp
+++ b/tests/tests/files/field-layout/field-type.cpp
@@ -1,5 +1,55 @@
 #include <vector>
+#include <stddef.h>
 #include <stdint.h>
+
+class JSObject {
+};
+
+namespace JS {
+
+class TestAllocPolicy {
+};
+
+
+template <typename T>
+class Rooted {
+};
+
+template <typename T, size_t MinInlineCapacity = 0,
+          typename AllocPolicy = TestAllocPolicy>
+class GCVector {
+};
+
+template <typename T, typename AllocPolicy = TestAllocPolicy>
+class StackGCVector : public GCVector<T, 8, AllocPolicy> {
+};
+
+template <typename T>
+class RootedVector : public Rooted<StackGCVector<T>> {
+};
+
+class alignas(8) Value {
+ private:
+  uint64_t asBits_;
+};
+
+
+template <typename Key, typename Value>
+class GCHashMap {
+};
+
+}
+
+namespace js {
+
+class TestCheck {
+};
+
+template <typename Check, typename T>
+class ProtectedDataNoCheckArgs {
+};
+
+}
 
 namespace field_layout {
 
@@ -30,6 +80,10 @@ struct S {
   Container1<Type1> template_field_1;
   Container2<Type1, Enum1::No> template_field_2;
   std::vector<Type1> vector_field;
+  JS::Rooted<JS::Value> rooted_field;
+  JS::RootedVector<JS::Value> rooted_vec_field;
+  JS::GCHashMap<JS::Value, JSObject*> hash_map_field;
+  js::ProtectedDataNoCheckArgs<js::TestCheck,  JS::Value> protected_field;
 };
 
 S f() {

--- a/tests/tests/files/field-layout/field-type.cpp
+++ b/tests/tests/files/field-layout/field-type.cpp
@@ -1,0 +1,42 @@
+#include <vector>
+#include <stdint.h>
+
+namespace field_layout {
+
+namespace field_type {
+
+struct Type1 {
+  uint8_t a;
+};
+
+template<typename T>
+struct Container1 {
+  T a;
+};
+
+enum class Enum1 : uint8_t {
+  No,
+  Yes,
+};
+
+template<typename T, Enum1 e>
+struct Container2 {
+  T a;
+};
+
+struct S {
+  Type1 value_field;
+  const Type1* pointer_field;
+  Container1<Type1> template_field_1;
+  Container2<Type1, Enum1::No> template_field_2;
+  std::vector<Type1> vector_field;
+};
+
+S f() {
+  S s;
+  return s;
+}
+
+}
+
+}

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -102,6 +102,14 @@ pub struct SymbolTreeTableColumn {
 }
 
 #[derive(Serialize)]
+pub struct TextWithSymbol {
+    // Text to go within the `span` tag; this will be escaped.
+    pub text: String,
+    // The `data-symbols` attribute of the `span`.
+    pub symbols: String,
+}
+
+#[derive(Serialize)]
 pub struct BasicLink {
     // Text to go within the `a` tag; this will be escaped.
     pub text: String,
@@ -143,8 +151,10 @@ pub enum BasicMarkup {
     // the client side so that a user's preferred config can perform an
     // override.
     QueryLink(BasicLink),
-    // This is a
     SourceLink(BasicLink),
+    // These are a variant of Heading and Text where the text has data-symbols.
+    SymbolHeading(TextWithSymbol),
+    SymbolText(TextWithSymbol),
 }
 
 #[derive(Serialize)]

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -20,7 +20,7 @@ use crate::{
     file_format::crossref_converter::convert_crossref_value_to_sym_info_rep,
 };
 
-use super::symbol_graph::{SymbolGraphCollection, SymbolGraphNodeId, SymbolGraphNodeSet};
+use super::symbol_graph::{SymbolGraphCollection, SymbolGraphNodeSet};
 
 #[derive(Clone, Debug, PartialEq, ValueEnum)]
 pub enum RecordType {
@@ -211,11 +211,8 @@ impl SymbolTreeTableCell {
 }
 
 pub struct SymbolTreeTableNode {
-    pub label: Vec<BasicMarkup>,
-    pub sym_id: Option<SymbolGraphNodeId>,
     pub col_vals: Vec<SymbolTreeTableCell>,
     pub children: Vec<SymbolTreeTableNode>,
-    pub colspan: u32,
 }
 
 impl SymbolTreeTable {
@@ -278,19 +275,12 @@ impl<'a> Serialize for SerializingSymbolTreeTableNode<'a> {
         S: Serializer,
     {
         let mut stt = serializer.serialize_struct("SymbolTreeTableNode", 2)?;
-        stt.serialize_field("label", &self.node.label)?;
-        if let Some(sym_id) = &self.node.sym_id {
-            stt.serialize_field("sym", &self.node_set.get(sym_id).symbol)?;
-        } else {
-            stt.serialize_field("sym", &Value::Null)?;
-        }
         stt.serialize_field("colVals", &self.node.col_vals)?;
         let wrapped_rows = SerializingSymbolTreeTableRows {
             node_set: &self.node_set,
             rows: &self.node.children,
         };
         stt.serialize_field("children", &wrapped_rows)?;
-        stt.serialize_field("colspan", &self.node.colspan)?;
         stt.end()
     }
 }

--- a/tools/templates/query_results/basic_markup_array.liquid
+++ b/tools/templates/query_results/basic_markup_array.liquid
@@ -5,6 +5,16 @@
     <i>{{ piece.ItalicText | escape }}</i>
   {% elsif piece contains "Newline" %}
     <br>
+  {% elsif piece contains "SymbolHeading" %}
+    <h3>
+      <span data-symbols="{{ piece.SymbolHeading.symbols }}">
+        {{ piece.SymbolHeading.text | escape }}
+      </span>
+    </h3>
+  {% elsif piece contains "SymbolText" %}
+    <span data-symbols="{{ piece.SymbolText.symbols }}">
+      {{ piece.SymbolText.text | escape }}
+    </span>
   {% elsif piece contains "Text" %}
     {{ piece.Text | escape }}
   {% endif %}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -1,11 +1,4 @@
 <tr>
-  <td
-  {% if node.colspan != 1 %}
-    colspan="{{ node.colspan }}"
-  {% endif %}
-  >
-    <span data-symbols="{{ node.sym }}">{%- include 'query_results/basic_markup_array.liquid' markup: node.label -%}</span>
-  </td>
   {% for col in node.colVals %}
     {% if col.header %}
       <th


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1900830

This does the following:
  * Refactor the symbol tree table:
    * Add `BasicMarkup` variants for text/heading with `data-symbols`
    * Convert the field name cell into general `SymbolTreeTableCell`
  * Make each field type into span with `data-symbols`, for the field type and `pointerInfo` types
    * given we don't have tokenization for the pretty string, the entire pretty string is marked with `span` with `data-symbols`, for all types appears inside it
  * Add more JS types to ontology mapping, to make them available in field layout table

Single type:
<img width="537" alt="single-type" src="https://github.com/mozsearch/mozsearch/assets/6299746/a3021dcd-7301-47fd-93a3-91e290426d26">

Wrapped type:
<img width="632" alt="wrapped-type" src="https://github.com/mozsearch/mozsearch/assets/6299746/a0433331-1ddc-4734-b192-5ec841179ae3">
