### PR TITLE
WIP: Bug 1297090 - Support contextual keyword.

### DIFF
--- a/tests/tests/checks/inputs/web/files/contextual_keyword/contextual_keyword_cpp__html
+++ b/tests/tests/checks/inputs/web/files/contextual_keyword/contextual_keyword_cpp__html
@@ -1,0 +1,1 @@
+cat-html cpp/contextual_keyword.cpp --select ".syn_reserved"

--- a/tests/tests/checks/inputs/web/files/contextual_keyword/contextual_keyword_js__html
+++ b/tests/tests/checks/inputs/web/files/contextual_keyword/contextual_keyword_js__html
@@ -1,0 +1,1 @@
+cat-html js/contextual_keyword.js --select ".syn_reserved"

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -245,6 +245,12 @@ expression: "&fb.contents"
         </tr>
 
         <tr>
+          <td><a href="/tests/source/cpp" class="mimetype-fixed-container mimetype-icon-folder">cpp</a></td>
+          <td class="description"><a href="/tests/source/cpp" title=""></td>
+          <td><a href="/tests/source/cpp"></a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/critters-postcard.jpg" class="mimetype-fixed-container mimetype-icon-jpg">critters-postcard.jpg</a></td>
           <td class="description"><a href="/tests/source/critters-postcard.jpg" title=""></td>
           <td><a href="/tests/source/critters-postcard.jpg">108154</a></td>

--- a/tests/tests/checks/snapshots/web/files/contextual_keyword/check_glob@contextual_keyword_cpp__html.snap
+++ b/tests/tests/checks/snapshots/web/files/contextual_keyword/check_glob@contextual_keyword_cpp__html.snap
@@ -1,0 +1,20 @@
+---
+source: tests/test_check_insta.rs
+expression: "&fb.contents"
+---
+<span class="syn_reserved" >class</span>
+<span class="syn_reserved" >public</span>
+<span class="syn_reserved" >virtual</span>
+<span class="syn_reserved" >void</span>
+<span class="syn_reserved" >class</span>
+<span class="syn_reserved" >final</span>
+<span class="syn_reserved" >public</span>
+<span class="syn_reserved" >public</span>
+<span class="syn_reserved" >void</span>
+<span class="syn_reserved" >override</span>
+<span class="syn_reserved" >int</span>
+<span class="syn_reserved" >int</span>
+<span class="syn_reserved" >int</span>
+<span class="syn_reserved" >int</span>
+<span class="syn_reserved" >int</span>
+<span class="syn_reserved" >return</span>

--- a/tests/tests/checks/snapshots/web/files/contextual_keyword/check_glob@contextual_keyword_js__html.snap
+++ b/tests/tests/checks/snapshots/web/files/contextual_keyword/check_glob@contextual_keyword_js__html.snap
@@ -1,0 +1,36 @@
+---
+source: tests/test_check_insta.rs
+expression: "&fb.contents"
+---
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >async</span>
+<span class="syn_reserved" >function</span>
+<span class="syn_reserved" >await</span>
+<span class="syn_reserved" >yield</span>
+<span class="syn_reserved" >let</span>
+<span class="syn_reserved" >for</span>
+<span class="syn_reserved" >var</span>
+<span class="syn_reserved" >of</span>
+<span class="syn_reserved" >class</span>
+<span class="syn_reserved" >new</span>
+<span class="syn_reserved" >target</span>
+<span class="syn_reserved" >static</span>
+<span class="syn_reserved" >get</span>
+<span class="syn_reserved" >set</span>

--- a/tests/tests/files/cpp/contextual_keyword.cpp
+++ b/tests/tests/files/cpp/contextual_keyword.cpp
@@ -1,0 +1,18 @@
+class Base {
+public:
+  virtual void Foo();
+};
+
+class Sub final : public Base {
+public:
+  void Foo() override;
+};
+
+int f() {
+  int final = 10;
+  int import = 20;
+  int module = 30;
+  int override = 40;
+
+  return final + import + module + override;
+}

--- a/tests/tests/files/js/contextual_keyword.js
+++ b/tests/tests/files/js/contextual_keyword.js
@@ -1,0 +1,37 @@
+var await = 0;
+var yield = 0;
+var let = 0;
+var static = 0;
+var implements = 0;
+var interface = 0;
+var package = 0;
+var private = 0;
+var protected = 0;
+var public = 0;
+var as = 0;
+var async = 0;
+var from = 0;
+var get = 0;
+var meta = 0;
+var of = 0;
+var set = 0;
+var target = 0;
+
+async function* f() {
+  await 10;
+  yield 10;
+  let x = 10;
+}
+
+for (var x of []) {
+}
+
+class C {
+  constructor() {
+    new.target;
+  }
+
+  static foo() {}
+  get prop() {}
+  set prop(v) {}
+}

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -18,12 +18,26 @@ pub struct LanguageSpec {
     pub markdown_slug: &'static str,
 }
 
-pub const SYN_RESERVED_CLASS: &'static str = "class=\"syn_reserved\" ";
+pub const SYN_RESERVED_CLASS: &'static str = "syn_reserved";
+pub const SYN_CONTEXTUAL_KEYWORD_CLASS: &'static str = "syn_contextual";
 
 fn make_reserved(v: &[&str]) -> HashMap<String, String> {
     let mut reserved_words = HashMap::new();
     for word in v {
         reserved_words.insert(word.to_string(), SYN_RESERVED_CLASS.into());
+    }
+    reserved_words
+}
+
+fn make_reserved_with_contextual(
+    reserved: &[&str], contextual: &[&str]) -> HashMap<String, String>
+{
+    let mut reserved_words = HashMap::new();
+    for word in reserved {
+        reserved_words.insert(word.to_string(), SYN_RESERVED_CLASS.into());
+    }
+    for word in contextual {
+        reserved_words.insert(word.to_string(), SYN_CONTEXTUAL_KEYWORD_CLASS.into());
     }
     reserved_words
 }
@@ -39,11 +53,9 @@ static RESERVED_WORDS_JS: &'static [&'static str] = &[
     "switch",
     "break",
     "export",
-    "interface",
     "synchronized",
     "byte",
     "extends",
-    "let",
     "this",
     "case",
     "false",
@@ -63,22 +75,17 @@ static RESERVED_WORDS_JS: &'static [&'static str] = &[
     "true",
     "const",
     "for",
-    "package",
     "try",
     "continue",
     "function",
-    "private",
     "typeof",
     "debugger",
     "goto",
-    "protected",
     "var",
     "default",
     "if",
-    "public",
     "void",
     "delete",
-    "implements",
     "return",
     "volatile",
     "do",
@@ -87,10 +94,35 @@ static RESERVED_WORDS_JS: &'static [&'static str] = &[
     "while",
     "double",
     "in",
-    "static",
     "with",
+];
+
+static CONTEXTUAL_KEYWORDS_JS: &'static [&'static str] = &[
+    // Keyword in async context.
+    "await",
+
+    // Keywrod in generator.
+    "yield",
+
+    // Keyword in strict.
+    "let",
+    "static",
+    "implements",
+    "interface",
+    "package",
+    "private",
+    "protected",
+    "public",
+
+    // Certain Syntactic production.
+    "as",
+    "async",
+    "from",
     "get",
+    "meta",
+    "of",
     "set",
+    "target",
 ];
 
 static RESERVED_WORDS_CPP: &'static [&'static str] = &[
@@ -140,7 +172,6 @@ static RESERVED_WORDS_CPP: &'static [&'static str] = &[
     "int",
     "import",
     "long",
-    "module",
     "mutable",
     "namespace",
     "new",
@@ -199,6 +230,13 @@ static RESERVED_WORDS_CPP: &'static [&'static str] = &[
     "#include",
     "#error",
     "defined",
+];
+
+static CONTEXTUAL_KEYWORDS_CPP: &'static [&'static str] = &[
+    "final",
+    "import",
+    "module",
+    "override",
 ];
 
 static RESERVED_WORDS_AIDL: &'static [&'static str] = &[
@@ -567,7 +605,8 @@ static RESERVED_WORDS_KOTLIN: &'static [&'static str] = &[
 
 lazy_static! {
     static ref JS_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_JS),
+        reserved_words: make_reserved_with_contextual(&*RESERVED_WORDS_JS,
+                                                      &*CONTEXTUAL_KEYWORDS_JS),
         hash_identifier: true,
         c_style_comments: true,
         backtick_strings: true,
@@ -582,7 +621,8 @@ lazy_static! {
     };
 
     static ref CPP_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_CPP),
+        reserved_words: make_reserved_with_contextual(&*RESERVED_WORDS_CPP,
+                                                      &*CONTEXTUAL_KEYWORDS_CPP),
         c_style_comments: true,
         c_preprocessor: true,
         cxx14_digit_separators: true,

--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -1598,7 +1598,7 @@ mod tests {
                 (":", TokenKind::Punctuation),
                 (
                     "while",
-                    TokenKind::Identifier(Some(String::from("class=\"syn_reserved\" "))),
+                    TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
                 ),
             ],
             &rust_spec,
@@ -1609,7 +1609,7 @@ mod tests {
                 ("'\\n'", TokenKind::StringLiteral),
                 (
                     "while",
-                    TokenKind::Identifier(Some(String::from("class=\"syn_reserved\" "))),
+                    TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
                 ),
             ],
             &rust_spec,
@@ -1620,7 +1620,7 @@ mod tests {
                 ("'b'", TokenKind::StringLiteral),
                 (
                     "while",
-                    TokenKind::Identifier(Some(String::from("class=\"syn_reserved\" "))),
+                    TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
                 ),
             ],
             &rust_spec,
@@ -1699,7 +1699,7 @@ mod tests {
             "#define",
             &vec![(
                 "#define",
-                TokenKind::Identifier(Some("class=\"syn_reserved\" ".to_string())),
+                TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
             )],
             &cpp_spec,
         );
@@ -1708,7 +1708,7 @@ mod tests {
             "#  \t  \t  define",
             &vec![(
                 "#  \t  \t  define",
-                TokenKind::Identifier(Some("class=\"syn_reserved\" ".to_string())),
+                TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
             )],
             &cpp_spec,
         );
@@ -1726,7 +1726,7 @@ mod tests {
                 (" ", TokenKind::PlainText),
                 (
                     "bar",
-                    TokenKind::Identifier(Some(crate::languages::SYN_RESERVED_CLASS.into())),
+                    TokenKind::Identifier(Some(SYN_RESERVED_CLASS.into())),
                 ),
                 (":", TokenKind::Punctuation),
                 (" ", TokenKind::PlainText),


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1297090

This does:
  * Modify the class name handling to be based on the class name itself, instead of `class="..."` attribute
  * Add `syn_contextual` which is temporary class for internal use
  * If a token with `syn_contextual` has corresponding analysis record, convert it into symbol for the record
  * If a token with `syn_contextual` has no corresponding analysis record, convert it into `syn_reserved`

This patch is should be rebased onto [bug 1781179](https://bugzilla.mozilla.org/show_bug.cgi?id=1781179), and also needs to be split into smaller patch after that.