### PR TITLE
Bug 1902875 - Show the field definition's lines in the field layout

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -328,9 +328,9 @@ private:
     }
   }
 
-  // Convert SourceRange to "line-line".
+  // Convert SourceRange to "line-line" or "line".
   // In the resulting string rep, line is 1-based.
-  std::string lineRangeToString(SourceRange Range) {
+  std::string lineRangeToString(SourceRange Range, bool omitEnd = false) {
     std::pair<FileID, unsigned> Begin = SM.getDecomposedLoc(Range.getBegin());
     std::pair<FileID, unsigned> End = SM.getDecomposedLoc(Range.getEnd());
 
@@ -344,7 +344,37 @@ private:
       return "";
     }
 
+    if (omitEnd && Line1 == Line2) {
+      return stringFormat("%d", Line1);
+    }
+
     return stringFormat("%d-%d", Line1, Line2);
+  }
+
+  // Convert SourceRange to "PATH#line-line" or "PATH#line".
+  // If Range's file is same as fromFileID, PATH is omitted.
+  std::string pathAndLineRangeToString(FileID fromFileID, SourceRange Range) {
+    FileInfo* toFile = getFileInfo(Range.getBegin());
+    FileInfo* fromFile = FileMap.find(fromFileID)->second.get();
+
+    auto lineRange = lineRangeToString(Range, true);
+
+    if (lineRange.empty()) {
+      return "";
+    }
+
+    if (toFile == fromFile) {
+      return "#" + lineRange;
+    }
+
+    if (toFile->Realname.empty()) {
+      return "#" + lineRange;
+    }
+
+    std::string result = toFile->Realname;
+    result += "#";
+    result += lineRange;
+    return result;
   }
 
   // Convert SourceRange to "line:column-line:column".
@@ -1189,6 +1219,8 @@ public:
       J.attributeEnd();
     }
 
+    FileID structFileID = SM.getFileID(Loc);
+
     J.attributeBegin("fields");
     J.arrayBegin();
     uint64_t iField = 0;
@@ -1199,6 +1231,7 @@ public:
       CharUnits localOffsetBytes = C.toCharUnitsFromBits(localOffsetBits);
 
       J.objectBegin();
+      J.attribute("lineRange", pathAndLineRangeToString(structFileID, Field.getSourceRange()));
       J.attribute("pretty", getQualifiedName(&Field));
       J.attribute("sym", getMangledName(CurMangleContext, &Field));
 

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1311,6 +1311,22 @@ g.true-diag g.node polygon {
 
 /* Field Layout */
 
+#symbol-tree-table-list .type-cell {
+  display: none;
+}
+
+#symbol-tree-table-list.hide-name .name-cell {
+  display: none;
+}
+
+#symbol-tree-table-list.show-type .type-cell {
+  display: table-cell;
+}
+
+#symbol-tree-table-list.hide-line .line-cell {
+  display: none;
+}
+
 .symbol-tree-table {
   border-collapse: separate;
 }
@@ -1348,21 +1364,25 @@ g.true-diag g.node polygon {
 .symbol-tree-table th,
 .symbol-tree-table td {
   border-block-end-width: 1px;
-  border-inline-end-width: 1px;
-}
-
-.symbol-tree-table th:first-child,
-.symbol-tree-table td:first-child {
   border-inline-start-width: 1px;
 }
 
-.symbol-tree-table tr:first-child th:first-child {
+.symbol-tree-table th:last-child,
+.symbol-tree-table td:last-child {
+  border-inline-end-width: 1px;
+}
+
+.symbol-tree-table tr:first-child th:first-child,
+#symbol-tree-table-list.hide-name.show-type tr:first-child th.type-cell,
+#symbol-tree-table-list.hide-name:not(.show-type) tr:first-child th.line-cell {
   border-start-start-radius: 4px;
 }
 .symbol-tree-table tr:first-child th:last-child {
   border-start-end-radius: 4px;
 }
-.symbol-tree-table tr:last-child td:first-child {
+.symbol-tree-table tr:last-child td:first-child,
+#symbol-tree-table-list.hide-name.show-type tr:last-child td.type-cell,
+#symbol-tree-table-list.hide-name:not(.show-type) tr:last-child td.line-cell {
   border-end-start-radius: 4px;
 }
 .symbol-tree-table tr:last-child td:last-child {

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1315,6 +1315,13 @@ g.true-diag g.node polygon {
   border-collapse: separate;
 }
 
+.symbol-tree-table .field-offset,
+.symbol-tree-table .field-size,
+.symbol-tree-table .field-hole,
+.symbol-tree-table .field-padding {
+  white-space: pre;
+}
+
 .symbol-tree-table + .symbol-tree-table {
   margin-top: 2em;
 }

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1393,3 +1393,15 @@ g.true-diag g.node polygon {
   color: var(--table-header-color);
   background-color: var(--table-header-background);
 }
+
+#symbol-tree-table-col-selector {
+  text-align: end;
+}
+
+#symbol-tree-table-col-selector label {
+  display: inline-block;
+}
+
+#symbol-tree-table-col-selector label + label {
+  margin: 0 0 0 8px;
+}

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1315,6 +1315,11 @@ g.true-diag g.node polygon {
   border-collapse: separate;
 }
 
+.symbol-tree-table .field-type {
+  display: inline-block;
+  max-width: 40vw;
+}
+
 .symbol-tree-table .field-offset,
 .symbol-tree-table .field-size,
 .symbol-tree-table .field-hole,

--- a/tests/tests/checks/inputs/fancy/format-symbol/field-layout/field-type.cpp/field_show_hide__name__json
+++ b/tests/tests/checks/inputs/fancy/format-symbol/field-layout/field-type.cpp/field_show_hide__name__json
@@ -1,0 +1,1 @@
+search-identifiers field_layout::field_type::S | crossref-lookup | format-symbols --mode="field-layout" --hide-cols=name,line

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_outercat__json.snap
@@ -125,6 +125,7 @@ expression: "&json_results"
     ],
     "fields": [
       {
+        "lineRange": "#241",
         "pretty": "outerNS::OuterCat::mIsFriendly",
         "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
         "type": "_Bool",
@@ -132,6 +133,7 @@ expression: "&json_results"
         "sizeBytes": 1
       },
       {
+        "lineRange": "#242",
         "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
         "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
         "type": "_Bool",
@@ -139,6 +141,7 @@ expression: "&json_results"
         "sizeBytes": 1
       },
       {
+        "lineRange": "#244",
         "pretty": "outerNS::OuterCat::mOwner",
         "sym": "F_<T_outerNS::OuterCat>_mOwner",
         "type": "class std::shared_ptr<class outerNS::Human>",
@@ -147,6 +150,7 @@ expression: "&json_results"
         "sizeBytes": 16
       },
       {
+        "lineRange": "#245",
         "pretty": "outerNS::OuterCat::mFavoriteCouch",
         "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
         "type": "class outerNS::Couch *",

--- a/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_thing__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/big_cpp.cpp/check_glob@structured_thing__json.snap
@@ -83,6 +83,7 @@ expression: "&json_results"
     ],
     "fields": [
       {
+        "lineRange": "#147",
         "pretty": "outerNS::Thing::mHP",
         "sym": "F_<T_outerNS::Thing>_mHP",
         "type": "int",
@@ -90,6 +91,7 @@ expression: "&json_results"
         "sizeBytes": 4
       },
       {
+        "lineRange": "#151",
         "pretty": "outerNS::Thing::mDefunct",
         "sym": "F_<T_outerNS::Thing>_mDefunct",
         "type": "_Bool",

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
@@ -66,6 +66,7 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [
             {
+              "lineRange": "#460",
               "pretty": "outerNS::StackArtHolder::mHeldArt",
               "sym": "F_<T_outerNS::StackArtHolder>_mHeldArt",
               "type": "class outerNS::PracticalArt &",

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
@@ -250,6 +250,7 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [
             {
+              "lineRange": "#147",
               "pretty": "outerNS::Thing::mHP",
               "sym": "F_<T_outerNS::Thing>_mHP",
               "type": "int",
@@ -259,6 +260,7 @@ expression: "&to_value(scil).unwrap()"
               "sizeBytes": 4
             },
             {
+              "lineRange": "#151",
               "pretty": "outerNS::Thing::mDefunct",
               "sym": "F_<T_outerNS::Thing>_mDefunct",
               "type": "_Bool",

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -232,6 +232,7 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [
             {
+              "lineRange": "#241",
               "pretty": "outerNS::OuterCat::mIsFriendly",
               "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
               "type": "_Bool",
@@ -241,6 +242,7 @@ expression: "&to_value(scil).unwrap()"
               "sizeBytes": 1
             },
             {
+              "lineRange": "#242",
               "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
               "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
               "type": "_Bool",
@@ -250,6 +252,7 @@ expression: "&to_value(scil).unwrap()"
               "sizeBytes": 1
             },
             {
+              "lineRange": "#244",
               "pretty": "outerNS::OuterCat::mOwner",
               "sym": "F_<T_outerNS::OuterCat>_mOwner",
               "type": "class std::shared_ptr<class outerNS::Human>",
@@ -268,6 +271,7 @@ expression: "&to_value(scil).unwrap()"
               ]
             },
             {
+              "lineRange": "#245",
               "pretty": "outerNS::OuterCat::mFavoriteCouch",
               "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
               "type": "class outerNS::Couch *",
@@ -544,6 +548,7 @@ expression: "&to_value(scil).unwrap()"
           ],
           "fields": [
             {
+              "lineRange": "#147",
               "pretty": "outerNS::Thing::mHP",
               "sym": "F_<T_outerNS::Thing>_mHP",
               "type": "int",
@@ -553,6 +558,7 @@ expression: "&to_value(scil).unwrap()"
               "sizeBytes": 4
             },
             {
+              "lineRange": "#151",
               "pretty": "outerNS::Thing::mDefunct",
               "sym": "F_<T_outerNS::Thing>_mDefunct",
               "type": "_Bool",

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -3694,6 +3694,7 @@ expression: "&json_results"
     ],
     "fields": [
       {
+        "lineRange": "#241",
         "pretty": "outerNS::OuterCat::mIsFriendly",
         "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
         "type": "_Bool",
@@ -3703,6 +3704,7 @@ expression: "&json_results"
         "sizeBytes": 1
       },
       {
+        "lineRange": "#242",
         "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
         "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
         "type": "_Bool",
@@ -3712,6 +3714,7 @@ expression: "&json_results"
         "sizeBytes": 1
       },
       {
+        "lineRange": "#244",
         "pretty": "outerNS::OuterCat::mOwner",
         "sym": "F_<T_outerNS::OuterCat>_mOwner",
         "type": "class std::shared_ptr<class outerNS::Human>",
@@ -3721,6 +3724,7 @@ expression: "&json_results"
         "sizeBytes": 16
       },
       {
+        "lineRange": "#245",
         "pretty": "outerNS::OuterCat::mFavoriteCouch",
         "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
         "type": "class outerNS::Couch *",
@@ -3900,6 +3904,7 @@ expression: "&json_results"
     ],
     "fields": [
       {
+        "lineRange": "#460",
         "pretty": "outerNS::StackArtHolder::mHeldArt",
         "sym": "F_<T_outerNS::StackArtHolder>_mHeldArt",
         "type": "class outerNS::PracticalArt &",
@@ -4099,6 +4104,7 @@ expression: "&json_results"
     ],
     "fields": [
       {
+        "lineRange": "#147",
         "pretty": "outerNS::Thing::mHP",
         "sym": "F_<T_outerNS::Thing>_mHP",
         "type": "int",
@@ -4108,6 +4114,7 @@ expression: "&json_results"
         "sizeBytes": 4
       },
       {
+        "lineRange": "#151",
         "pretty": "outerNS::Thing::mDefunct",
         "sym": "F_<T_outerNS::Thing>_mDefunct",
         "type": "_Bool",

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@callees__outercat_meet__json.snap
@@ -368,6 +368,7 @@ expression: sgc.to_json()
         ],
         "fields": [
           {
+            "lineRange": "#147",
             "pretty": "outerNS::Thing::mHP",
             "sym": "F_<T_outerNS::Thing>_mHP",
             "type": "int",
@@ -377,6 +378,7 @@ expression: sgc.to_json()
             "sizeBytes": 4
           },
           {
+            "lineRange": "#151",
             "pretty": "outerNS::Thing::mDefunct",
             "sym": "F_<T_outerNS::Thing>_mDefunct",
             "type": "_Bool",

--- a/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
+++ b/tests/tests/checks/snapshots/fancy/diagram/traverse/big_cpp.cpp/check_glob@uses__thing_takeDamage__hier__json.snap
@@ -154,6 +154,7 @@ expression: sgc.to_json()
         ],
         "fields": [
           {
+            "lineRange": "#241",
             "pretty": "outerNS::OuterCat::mIsFriendly",
             "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
             "type": "_Bool",
@@ -163,6 +164,7 @@ expression: sgc.to_json()
             "sizeBytes": 1
           },
           {
+            "lineRange": "#242",
             "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
             "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
             "type": "_Bool",
@@ -172,6 +174,7 @@ expression: sgc.to_json()
             "sizeBytes": 1
           },
           {
+            "lineRange": "#244",
             "pretty": "outerNS::OuterCat::mOwner",
             "sym": "F_<T_outerNS::OuterCat>_mOwner",
             "type": "class std::shared_ptr<class outerNS::Human>",
@@ -190,6 +193,7 @@ expression: sgc.to_json()
             ]
           },
           {
+            "lineRange": "#245",
             "pretty": "outerNS::OuterCat::mFavoriteCouch",
             "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
             "type": "class outerNS::Couch *",
@@ -314,6 +318,7 @@ expression: sgc.to_json()
         ],
         "fields": [
           {
+            "lineRange": "#147",
             "pretty": "outerNS::Thing::mHP",
             "sym": "F_<T_outerNS::Thing>_mHP",
             "type": "int",
@@ -323,6 +328,7 @@ expression: sgc.to_json()
             "sizeBytes": 4
           },
           {
+            "lineRange": "#151",
             "pretty": "outerNS::Thing::mDefunct",
             "sym": "F_<T_outerNS::Thing>_mDefunct",
             "type": "_Bool",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -472,6 +472,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#241",
                 "pretty": "outerNS::OuterCat::mIsFriendly",
                 "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
                 "type": "_Bool",
@@ -481,6 +482,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#242",
                 "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
                 "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
                 "type": "_Bool",
@@ -490,6 +492,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#244",
                 "pretty": "outerNS::OuterCat::mOwner",
                 "sym": "F_<T_outerNS::OuterCat>_mOwner",
                 "type": "class std::shared_ptr<class outerNS::Human>",
@@ -508,6 +511,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#245",
                 "pretty": "outerNS::OuterCat::mFavoriteCouch",
                 "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
                 "type": "class outerNS::Couch *",
@@ -632,6 +636,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#147",
                 "pretty": "outerNS::Thing::mHP",
                 "sym": "F_<T_outerNS::Thing>_mHP",
                 "type": "int",
@@ -641,6 +646,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#151",
                 "pretty": "outerNS::Thing::mDefunct",
                 "sym": "F_<T_outerNS::Thing>_mDefunct",
                 "type": "_Bool",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -843,5 +843,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/big_cpp.cpp/check_glob@field_layout__outercat__json.snap
@@ -693,6 +693,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mIsFriendly\">mIsFriendly</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0xd",
@@ -710,6 +713,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "_Bool",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly\">mIsSecretlyUnfriendly</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -734,6 +740,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_std::shared_ptr,T_outerNS::Human"
                   }
                 ],
+                "lines": [
+                  "  std::<span class=\"syn_type\" data-symbols=\"T_std::shared_ptr\">shared_ptr</span>&lt;<span class=\"syn_type\" data-symbols=\"T_outerNS::Human\">Human</span>> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mOwner\">mOwner</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x10",
@@ -751,6 +760,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "class outerNS::Couch *",
                     "symbols": "T_outerNS::Couch"
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_outerNS::Couch\">Couch</span> *<span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mFavoriteCouch\">mFavoriteCouch</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -776,6 +788,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -794,6 +807,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >int</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::Thing>_mHP\">mHP</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x8",
@@ -811,6 +827,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "_Bool",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::Thing>_mDefunct\">mDefunct</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -322,6 +322,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b1\">b1</span>: 1;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0 + 0 bit",
@@ -339,6 +342,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b2\">b2</span>: 3;"
                 ],
                 "offsetAndSize": [
                   {
@@ -358,6 +364,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b3\">b3</span>: 7;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0 + 4 bits",
@@ -375,6 +384,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b4\">b4</span>: 4;"
                 ],
                 "offsetAndSize": [
                   {
@@ -394,6 +406,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span>  <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b5\">b5</span>: 3;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x2 + 0 bit",
@@ -411,6 +426,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned short",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint16_t\">uint16_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::bitfields::S>_b6\">b6</span>: 2;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -217,6 +217,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#8",
                 "pretty": "field_layout::bitfields::S::b1",
                 "sym": "F_<T_field_layout::bitfields::S>_b1",
                 "type": "unsigned int",
@@ -229,6 +230,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": null
               },
               {
+                "lineRange": "#9",
                 "pretty": "field_layout::bitfields::S::b2",
                 "sym": "F_<T_field_layout::bitfields::S>_b2",
                 "type": "unsigned int",
@@ -241,6 +243,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": null
               },
               {
+                "lineRange": "#10",
                 "pretty": "field_layout::bitfields::S::b3",
                 "sym": "F_<T_field_layout::bitfields::S>_b3",
                 "type": "unsigned int",
@@ -253,6 +256,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": null
               },
               {
+                "lineRange": "#11",
                 "pretty": "field_layout::bitfields::S::b4",
                 "sym": "F_<T_field_layout::bitfields::S>_b4",
                 "type": "unsigned int",
@@ -265,6 +269,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": null
               },
               {
+                "lineRange": "#12",
                 "pretty": "field_layout::bitfields::S::b5",
                 "sym": "F_<T_field_layout::bitfields::S>_b5",
                 "type": "unsigned char",
@@ -277,6 +282,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": null
               },
               {
+                "lineRange": "#13",
                 "pretty": "field_layout::bitfields::S::b6",
                 "sym": "F_<T_field_layout::bitfields::S>_b6",
                 "type": "unsigned short",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/bitfields.cpp/check_glob@field_layout__bitfields__json.snap
@@ -447,5 +447,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/empty.cpp/check_glob@field_layout__empty__json.snap
@@ -75,5 +75,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -289,6 +289,7 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [
               {
+                "lineRange": "#33",
                 "pretty": "JS::Value::asBits_",
                 "sym": "F_<T_JS::Value>_asBits_",
                 "type": "unsigned long",
@@ -423,6 +424,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#78",
                 "pretty": "field_layout::field_type::S::value_field",
                 "sym": "F_<T_field_layout::field_type::S>_value_field",
                 "type": "struct field_layout::field_type::Type1",
@@ -438,6 +440,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#79",
                 "pretty": "field_layout::field_type::S::pointer_field",
                 "sym": "F_<T_field_layout::field_type::S>_pointer_field",
                 "type": "const struct field_layout::field_type::Type1 *",
@@ -453,6 +456,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#80",
                 "pretty": "field_layout::field_type::S::template_field_1",
                 "sym": "F_<T_field_layout::field_type::S>_template_field_1",
                 "type": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
@@ -468,6 +472,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#81",
                 "pretty": "field_layout::field_type::S::template_field_2",
                 "sym": "F_<T_field_layout::field_type::S>_template_field_2",
                 "type": "struct field_layout::field_type::Container2<struct field_layout::field_type::Type1, field_layout::field_type::Enum1::No>",
@@ -483,6 +488,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#82",
                 "pretty": "field_layout::field_type::S::vector_field",
                 "sym": "F_<T_field_layout::field_type::S>_vector_field",
                 "type": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
@@ -498,6 +504,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#83",
                 "pretty": "field_layout::field_type::S::rooted_field",
                 "sym": "F_<T_field_layout::field_type::S>_rooted_field",
                 "type": "class JS::Rooted<class JS::Value>",
@@ -513,6 +520,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#84",
                 "pretty": "field_layout::field_type::S::rooted_vec_field",
                 "sym": "F_<T_field_layout::field_type::S>_rooted_vec_field",
                 "type": "class JS::RootedVector<class JS::Value>",
@@ -528,6 +536,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#85",
                 "pretty": "field_layout::field_type::S::hash_map_field",
                 "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
                 "type": "class JS::GCHashMap<class JS::Value, class JSObject *>",
@@ -547,6 +556,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#86",
                 "pretty": "field_layout::field_type::S::protected_field",
                 "sym": "F_<T_field_layout::field_type::S>_protected_field",
                 "type": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, class JS::Value>",
@@ -652,6 +662,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#59",
                 "pretty": "field_layout::field_type::Type1::a",
                 "sym": "F_<T_field_layout::field_type::Type1>_a",
                 "type": "unsigned char",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -736,6 +736,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_field_layout::field_type::Type1"
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_value_field\">value_field</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -759,6 +762,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_field_layout::field_type::Type1"
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >const</span> <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>* <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_pointer_field\">pointer_field</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x8",
@@ -777,6 +783,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_field_layout::field_type::Container1"
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Container1\">Container1</span>&lt;<span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_template_field_1\">template_field_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x10",
@@ -794,6 +803,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "struct field_layout::field_type::Container2<struct field_layout::field_type::Type1, field_layout::field_type::Enum1::No>",
                     "symbols": "T_field_layout::field_type::Container2"
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Container2\">Container2</span>&lt;<span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>, <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Enum1\">Enum1</span>::<span data-symbols=\"E_<T_field_layout::field_type::Enum1>_No\">No</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_template_field_2\">template_field_2</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -818,6 +830,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_std::vector,T_field_layout::field_type::Type1"
                   }
                 ],
+                "lines": [
+                  "  std::<span class=\"syn_type\" data-symbols=\"T_std::vector\">vector</span>&lt;<span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_vector_field\">vector_field</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x18",
@@ -835,6 +850,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "class JS::Rooted<class JS::Value>",
                     "symbols": "T_JS::Rooted,T_JS::Value"
                   }
+                ],
+                "lines": [
+                  "  JS::<span class=\"syn_type\" data-symbols=\"T_JS::Rooted\">Rooted</span>&lt;JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_rooted_field\">rooted_field</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -854,6 +872,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_JS::RootedVector,T_JS::Value"
                   }
                 ],
+                "lines": [
+                  "  JS::<span class=\"syn_type\" data-symbols=\"T_JS::RootedVector\">RootedVector</span>&lt;JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_rooted_vec_field\">rooted_vec_field</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x31",
@@ -872,6 +893,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_JS::GCHashMap,T_JS::Value,T_JSObject"
                   }
                 ],
+                "lines": [
+                  "  JS::<span class=\"syn_type\" data-symbols=\"T_JS::GCHashMap\">GCHashMap</span>&lt;JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>, <span class=\"syn_type\" data-symbols=\"T_JSObject\">JSObject</span>*> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_hash_map_field\">hash_map_field</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x32",
@@ -889,6 +913,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, class JS::Value>",
                     "symbols": "T_js::ProtectedDataNoCheckArgs,T_js::TestCheck,T_JS::Value"
                   }
+                ],
+                "lines": [
+                  "  js::<span class=\"syn_type\" data-symbols=\"T_js::ProtectedDataNoCheckArgs\">ProtectedDataNoCheckArgs</span>&lt;js::<span class=\"syn_type\" data-symbols=\"T_js::TestCheck\">TestCheck</span>,  JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_protected_field\">protected_field</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -30,7 +30,196 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#85"
+            "def": "field-layout/field-type.cpp#44"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_macro_fields_1": {
+          "sym": "F_<T_field_layout::field_type::S>_macro_fields_1",
+          "pretty": "field_layout::field_type::S::macro_fields_1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::macro_fields_1",
+            "sym": "F_<T_field_layout::field_type::S>_macro_fields_1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#46"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_macro_fields_2": {
+          "sym": "F_<T_field_layout::field_type::S>_macro_fields_2",
+          "pretty": "field_layout::field_type::S::macro_fields_2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::macro_fields_2",
+            "sym": "F_<T_field_layout::field_type::S>_macro_fields_2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#46"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_macro_fields_3": {
+          "sym": "F_<T_field_layout::field_type::S>_macro_fields_3",
+          "pretty": "field_layout::field_type::S::macro_fields_3",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::macro_fields_3",
+            "sym": "F_<T_field_layout::field_type::S>_macro_fields_3",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#46"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_multiline_field": {
+          "sym": "F_<T_field_layout::field_type::S>_multiline_field",
+          "pretty": "field_layout::field_type::S::multiline_field",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::multiline_field",
+            "sym": "F_<T_field_layout::field_type::S>_multiline_field",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type.cpp#50"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_other_file_field1": {
+          "sym": "F_<T_field_layout::field_type::S>_other_file_field1",
+          "pretty": "field_layout::field_type::S::other_file_field1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::other_file_field1",
+            "sym": "F_<T_field_layout::field_type::S>_other_file_field1",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type-include.h#1"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_other_file_field2": {
+          "sym": "F_<T_field_layout::field_type::S>_other_file_field2",
+          "pretty": "field_layout::field_type::S::other_file_field2",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::other_file_field2",
+            "sym": "F_<T_field_layout::field_type::S>_other_file_field2",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type-include.h#4"
+          }
+        },
+        "F_<T_field_layout::field_type::S>_other_file_field3": {
+          "sym": "F_<T_field_layout::field_type::S>_other_file_field3",
+          "pretty": "field_layout::field_type::S::other_file_field3",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::S::other_file_field3",
+            "sym": "F_<T_field_layout::field_type::S>_other_file_field3",
+            "type_pretty": null,
+            "kind": "field",
+            "subsystem": null,
+            "parentsym": "T_field_layout::field_type::S",
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
+          "jumps": {
+            "def": "field-layout/field-type-include.h#9"
           }
         },
         "F_<T_field_layout::field_type::S>_pointer_field": {
@@ -57,7 +246,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#79"
+            "def": "field-layout/field-type.cpp#38"
           }
         },
         "F_<T_field_layout::field_type::S>_protected_field": {
@@ -84,7 +273,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#86"
+            "def": "field-layout/field-type.cpp#45"
           }
         },
         "F_<T_field_layout::field_type::S>_rooted_field": {
@@ -111,7 +300,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#83"
+            "def": "field-layout/field-type.cpp#42"
           }
         },
         "F_<T_field_layout::field_type::S>_rooted_vec_field": {
@@ -138,7 +327,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#84"
+            "def": "field-layout/field-type.cpp#43"
           }
         },
         "F_<T_field_layout::field_type::S>_template_field_1": {
@@ -165,7 +354,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#80"
+            "def": "field-layout/field-type.cpp#39"
           }
         },
         "F_<T_field_layout::field_type::S>_template_field_2": {
@@ -192,7 +381,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#81"
+            "def": "field-layout/field-type.cpp#40"
           }
         },
         "F_<T_field_layout::field_type::S>_value_field": {
@@ -219,7 +408,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#78"
+            "def": "field-layout/field-type.cpp#37"
           }
         },
         "F_<T_field_layout::field_type::S>_vector_field": {
@@ -246,28 +435,28 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#82"
+            "def": "field-layout/field-type.cpp#41"
           }
         },
         "T_JS::GCHashMap": {
           "sym": "T_JS::GCHashMap",
           "pretty": "T_JS::GCHashMap",
           "jumps": {
-            "def": "field-layout/field-type.cpp#38"
+            "def": "field-layout/field-type.h#34"
           }
         },
         "T_JS::Rooted": {
           "sym": "T_JS::Rooted",
           "pretty": "T_JS::Rooted",
           "jumps": {
-            "def": "field-layout/field-type.cpp#15"
+            "def": "field-layout/field-type.h#11"
           }
         },
         "T_JS::RootedVector": {
           "sym": "T_JS::RootedVector",
           "pretty": "T_JS::RootedVector",
           "jumps": {
-            "def": "field-layout/field-type.cpp#28"
+            "def": "field-layout/field-type.h#24"
           }
         },
         "T_JS::Value": {
@@ -289,7 +478,7 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [
               {
-                "lineRange": "#33",
+                "lineRange": "#29",
                 "pretty": "JS::Value::asBits_",
                 "sym": "F_<T_JS::Value>_asBits_",
                 "type": "unsigned long",
@@ -304,7 +493,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#31"
+            "def": "field-layout/field-type.h#27"
           }
         },
         "T_JSObject": {
@@ -333,21 +522,28 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#5"
+            "def": "field-layout/field-type.h#1"
           }
         },
         "T_field_layout::field_type::Container1": {
           "sym": "T_field_layout::field_type::Container1",
           "pretty": "T_field_layout::field_type::Container1",
           "jumps": {
-            "def": "field-layout/field-type.cpp#63"
+            "def": "field-layout/field-type.cpp#15"
           }
         },
         "T_field_layout::field_type::Container2": {
           "sym": "T_field_layout::field_type::Container2",
           "pretty": "T_field_layout::field_type::Container2",
           "jumps": {
-            "def": "field-layout/field-type.cpp#73"
+            "def": "field-layout/field-type.cpp#25"
+          }
+        },
+        "T_field_layout::field_type::Enum1": {
+          "sym": "T_field_layout::field_type::Enum1",
+          "pretty": "T_field_layout::field_type::Enum1",
+          "jumps": {
+            "def": "field-layout/field-type.cpp#19"
           }
         },
         "T_field_layout::field_type::S": {
@@ -361,7 +557,7 @@ expression: "&to_value(sttl).unwrap()"
             "kind": "struct",
             "subsystem": null,
             "implKind": "",
-            "sizeBytes": 56,
+            "sizeBytes": 88,
             "ownVFPtrBytes": null,
             "bindingSlots": [],
             "ontologySlots": [],
@@ -424,7 +620,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
-                "lineRange": "#78",
+                "lineRange": "#37",
                 "pretty": "field_layout::field_type::S::value_field",
                 "sym": "F_<T_field_layout::field_type::S>_value_field",
                 "type": "struct field_layout::field_type::Type1",
@@ -440,7 +636,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#79",
+                "lineRange": "#38",
                 "pretty": "field_layout::field_type::S::pointer_field",
                 "sym": "F_<T_field_layout::field_type::S>_pointer_field",
                 "type": "const struct field_layout::field_type::Type1 *",
@@ -456,7 +652,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#80",
+                "lineRange": "#39",
                 "pretty": "field_layout::field_type::S::template_field_1",
                 "sym": "F_<T_field_layout::field_type::S>_template_field_1",
                 "type": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
@@ -472,7 +668,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#81",
+                "lineRange": "#40",
                 "pretty": "field_layout::field_type::S::template_field_2",
                 "sym": "F_<T_field_layout::field_type::S>_template_field_2",
                 "type": "struct field_layout::field_type::Container2<struct field_layout::field_type::Type1, field_layout::field_type::Enum1::No>",
@@ -488,7 +684,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#82",
+                "lineRange": "#41",
                 "pretty": "field_layout::field_type::S::vector_field",
                 "sym": "F_<T_field_layout::field_type::S>_vector_field",
                 "type": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
@@ -504,7 +700,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#83",
+                "lineRange": "#42",
                 "pretty": "field_layout::field_type::S::rooted_field",
                 "sym": "F_<T_field_layout::field_type::S>_rooted_field",
                 "type": "class JS::Rooted<class JS::Value>",
@@ -520,7 +716,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#84",
+                "lineRange": "#43",
                 "pretty": "field_layout::field_type::S::rooted_vec_field",
                 "sym": "F_<T_field_layout::field_type::S>_rooted_vec_field",
                 "type": "class JS::RootedVector<class JS::Value>",
@@ -536,7 +732,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#85",
+                "lineRange": "#44",
                 "pretty": "field_layout::field_type::S::hash_map_field",
                 "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
                 "type": "class JS::GCHashMap<class JS::Value, class JSObject *>",
@@ -556,7 +752,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
-                "lineRange": "#86",
+                "lineRange": "#45",
                 "pretty": "field_layout::field_type::S::protected_field",
                 "sym": "F_<T_field_layout::field_type::S>_protected_field",
                 "type": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, class JS::Value>",
@@ -574,6 +770,116 @@ expression: "&to_value(sttl).unwrap()"
                     "sym": "T_JS::Value"
                   }
                 ]
+              },
+              {
+                "lineRange": "",
+                "pretty": "field_layout::field_type::S::macro_fields_1",
+                "sym": "F_<T_field_layout::field_type::S>_macro_fields_1",
+                "type": "struct field_layout::field_type::Type1",
+                "typesym": "T_field_layout::field_type::Type1",
+                "offsetBytes": 52,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              },
+              {
+                "lineRange": "",
+                "pretty": "field_layout::field_type::S::macro_fields_2",
+                "sym": "F_<T_field_layout::field_type::S>_macro_fields_2",
+                "type": "enum field_layout::field_type::Enum1",
+                "typesym": "T_field_layout::field_type::Enum1",
+                "offsetBytes": 53,
+                "bitPositions": null,
+                "sizeBytes": 1
+              },
+              {
+                "lineRange": "",
+                "pretty": "field_layout::field_type::S::macro_fields_3",
+                "sym": "F_<T_field_layout::field_type::S>_macro_fields_3",
+                "type": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                "typesym": "T_field_layout::field_type::Container1",
+                "offsetBytes": 54,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Container1"
+                  }
+                ]
+              },
+              {
+                "lineRange": "#47-50",
+                "pretty": "field_layout::field_type::S::multiline_field",
+                "sym": "F_<T_field_layout::field_type::S>_multiline_field",
+                "type": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, struct field_layout::field_type::Type1>",
+                "typesym": "T_js::ProtectedDataNoCheckArgs",
+                "offsetBytes": 55,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_js::TestCheck"
+                  },
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              },
+              {
+                "lineRange": "field-layout/field-type-include.h#1",
+                "pretty": "field_layout::field_type::S::other_file_field1",
+                "sym": "F_<T_field_layout::field_type::S>_other_file_field1",
+                "type": "struct field_layout::field_type::Type1",
+                "typesym": "T_field_layout::field_type::Type1",
+                "offsetBytes": 56,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
+              },
+              {
+                "lineRange": "field-layout/field-type-include.h#3-4",
+                "pretty": "field_layout::field_type::S::other_file_field2",
+                "sym": "F_<T_field_layout::field_type::S>_other_file_field2",
+                "type": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                "typesym": "T_field_layout::field_type::Container1",
+                "offsetBytes": 57,
+                "bitPositions": null,
+                "sizeBytes": 1,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Container1"
+                  }
+                ]
+              },
+              {
+                "lineRange": "field-layout/field-type-include.h#6-9",
+                "pretty": "field_layout::field_type::S::other_file_field3",
+                "sym": "F_<T_field_layout::field_type::S>_other_file_field3",
+                "type": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
+                "typesym": "T_std::vector",
+                "offsetBytes": 64,
+                "bitPositions": null,
+                "sizeBytes": 24,
+                "pointerInfo": [
+                  {
+                    "kind": "contains",
+                    "sym": "T_field_layout::field_type::Type1"
+                  }
+                ]
               }
             ],
             "overrides": [],
@@ -581,7 +887,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#77"
+            "def": "field-layout/field-type.cpp#36"
           }
         },
         "T_field_layout::field_type::Type1": {
@@ -662,7 +968,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
-                "lineRange": "#59",
+                "lineRange": "#11",
                 "pretty": "field_layout::field_type::Type1::a",
                 "sym": "F_<T_field_layout::field_type::Type1>_a",
                 "type": "unsigned char",
@@ -677,14 +983,14 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#58"
+            "def": "field-layout/field-type.cpp#10"
           }
         },
         "T_js::ProtectedDataNoCheckArgs": {
           "sym": "T_js::ProtectedDataNoCheckArgs",
           "pretty": "T_js::ProtectedDataNoCheckArgs",
           "jumps": {
-            "def": "field-layout/field-type.cpp#49"
+            "def": "field-layout/field-type.h#45"
           }
         },
         "T_js::TestCheck": {
@@ -710,7 +1016,7 @@ expression: "&to_value(sttl).unwrap()"
             "variants": []
           },
           "jumps": {
-            "def": "field-layout/field-type.cpp#45"
+            "def": "field-layout/field-type.h#41"
           }
         },
         "T_std::vector": {
@@ -915,7 +1221,7 @@ expression: "&to_value(sttl).unwrap()"
                   }
                 ],
                 "lines": [
-                  "  js::<span class=\"syn_type\" data-symbols=\"T_js::ProtectedDataNoCheckArgs\">ProtectedDataNoCheckArgs</span>&lt;js::<span class=\"syn_type\" data-symbols=\"T_js::TestCheck\">TestCheck</span>,  JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_protected_field\">protected_field</span>;"
+                  "  js::<span class=\"syn_type\" data-symbols=\"TA_js::TestLockData\">TestLockData</span>&lt;JS::<span class=\"syn_type\" data-symbols=\"T_JS::Value\">Value</span>> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_protected_field\">protected_field</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -926,9 +1232,163 @@ expression: "&to_value(sttl).unwrap()"
               }
             },
             {
-              "EndPadding": [
-                "4 bytes padding"
+              "Field": {
+                "name": "macro_fields_1",
+                "symbols": "F_<T_field_layout::field_type::S>_macro_fields_1",
+                "types": [
+                  {
+                    "name": "struct field_layout::field_type::Type1",
+                    "symbols": "T_field_layout::field_type::Type1"
+                  }
+                ],
+                "lines": [
+                  "  <span class=\"syn_def syn_def syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_macro_fields_1,F_<T_field_layout::field_type::S>_macro_fields_2,F_<T_field_layout::field_type::S>_macro_fields_3,M_4176c48bcfb9a1bd\">DEFINE_FIELDS</span>"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x34",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Field": {
+                "name": "macro_fields_2",
+                "symbols": "F_<T_field_layout::field_type::S>_macro_fields_2",
+                "types": [
+                  {
+                    "name": "enum field_layout::field_type::Enum1",
+                    "symbols": "T_field_layout::field_type::Enum1"
+                  }
+                ],
+                "lines": [
+                  "  <span class=\"syn_def syn_def syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_macro_fields_1,F_<T_field_layout::field_type::S>_macro_fields_2,F_<T_field_layout::field_type::S>_macro_fields_3,M_4176c48bcfb9a1bd\">DEFINE_FIELDS</span>"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x35",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Field": {
+                "name": "macro_fields_3",
+                "symbols": "F_<T_field_layout::field_type::S>_macro_fields_3",
+                "types": [
+                  {
+                    "name": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                    "symbols": "T_field_layout::field_type::Container1"
+                  }
+                ],
+                "lines": [
+                  "  <span class=\"syn_def syn_def syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_macro_fields_1,F_<T_field_layout::field_type::S>_macro_fields_2,F_<T_field_layout::field_type::S>_macro_fields_3,M_4176c48bcfb9a1bd\">DEFINE_FIELDS</span>"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x36",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Field": {
+                "name": "multiline_field",
+                "symbols": "F_<T_field_layout::field_type::S>_multiline_field",
+                "types": [
+                  {
+                    "name": "class js::ProtectedDataNoCheckArgs<class js::TestCheck, struct field_layout::field_type::Type1>",
+                    "symbols": "T_js::ProtectedDataNoCheckArgs,T_js::TestCheck,T_field_layout::field_type::Type1"
+                  }
+                ],
+                "lines": [
+                  "  js::<span class=\"syn_type\" data-symbols=\"TA_js::TestLockData\">TestLockData</span>&lt;",
+                  "    <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>",
+                  "  >",
+                  "  <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_multiline_field\">multiline_field</span>"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x37",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Field": {
+                "name": "other_file_field1",
+                "symbols": "F_<T_field_layout::field_type::S>_other_file_field1",
+                "types": [
+                  {
+                    "name": "struct field_layout::field_type::Type1",
+                    "symbols": "T_field_layout::field_type::Type1"
+                  }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_other_file_field1\">other_file_field1</span>;"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x38",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Field": {
+                "name": "other_file_field2",
+                "symbols": "F_<T_field_layout::field_type::S>_other_file_field2",
+                "types": [
+                  {
+                    "name": "struct field_layout::field_type::Container1<struct field_layout::field_type::Type1>",
+                    "symbols": "T_field_layout::field_type::Container1"
+                  }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Container1\">Container1</span>&lt;<span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>>",
+                  "    <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_other_file_field2\">other_file_field2</span>;"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x39",
+                    "size": "1"
+                  }
+                ]
+              }
+            },
+            {
+              "Hole": [
+                "6 bytes hole"
               ]
+            },
+            {
+              "Field": {
+                "name": "other_file_field3",
+                "symbols": "F_<T_field_layout::field_type::S>_other_file_field3",
+                "types": [
+                  {
+                    "name": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
+                    "symbols": "T_std::vector,T_field_layout::field_type::Type1"
+                  }
+                ],
+                "lines": [
+                  "  std::<span class=\"syn_type\" data-symbols=\"T_std::vector\">vector</span>&lt;",
+                  "    <span class=\"syn_type\" data-symbols=\"T_field_layout::field_type::Type1\">Type1</span>",
+                  "  >",
+                  "    <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::field_type::S>_other_file_field3\">other_file_field3</span>;"
+                ],
+                "offsetAndSize": [
+                  {
+                    "offset": "@ 0x40",
+                    "size": "24"
+                  }
+                ]
+              }
             }
           ]
         }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -485,7 +485,7 @@ expression: "&to_value(sttl).unwrap()"
               {
                 "pretty": "field_layout::field_type::S::vector_field",
                 "sym": "F_<T_field_layout::field_type::S>_vector_field",
-                "type": "class std::vector<struct field_layout::field_type::Type1>",
+                "type": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
                 "typesym": "T_std::vector",
                 "offsetBytes": 24,
                 "bitPositions": null,
@@ -803,7 +803,7 @@ expression: "&to_value(sttl).unwrap()"
                 "symbols": "F_<T_field_layout::field_type::S>_vector_field",
                 "types": [
                   {
-                    "name": "class std::vector<struct field_layout::field_type::Type1>",
+                    "name": "class std::vector<struct field_layout::field_type::Type1, class std::allocator<struct field_layout::field_type::Type1> >",
                     "symbols": "T_std::vector,T_field_layout::field_type::Type1"
                   }
                 ],

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_show_hide__name__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_show_hide__name__json.snap
@@ -1395,5 +1395,5 @@ expression: "&to_value(sttl).unwrap()"
       ]
     }
   ],
-  "className": null
+  "className": "hide-name hide-line"
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -379,6 +379,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Sub>_x\">x</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0xc",
@@ -401,6 +404,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Sub>_y\">y</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -426,6 +432,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Base>_a\">a</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -449,6 +458,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint16_t\">uint16_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Base>_b\">b</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x2",
@@ -467,6 +479,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Base>_c\">c</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x4",
@@ -484,6 +499,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >char</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::holes::Base>_d\">d</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -520,5 +520,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/holes.cpp/check_glob@field_layout__holes__json.snap
@@ -226,6 +226,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#8",
                 "pretty": "field_layout::holes::Base::a",
                 "sym": "F_<T_field_layout::holes::Base>_a",
                 "type": "unsigned char",
@@ -235,6 +236,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#9",
                 "pretty": "field_layout::holes::Base::b",
                 "sym": "F_<T_field_layout::holes::Base>_b",
                 "type": "unsigned short",
@@ -244,6 +246,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 2
               },
               {
+                "lineRange": "#10",
                 "pretty": "field_layout::holes::Base::c",
                 "sym": "F_<T_field_layout::holes::Base>_c",
                 "type": "unsigned int",
@@ -253,6 +256,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#11",
                 "pretty": "field_layout::holes::Base::d",
                 "sym": "F_<T_field_layout::holes::Base>_d",
                 "type": "char",
@@ -328,6 +332,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#15",
                 "pretty": "field_layout::holes::Sub::x",
                 "sym": "F_<T_field_layout::holes::Sub>_x",
                 "type": "unsigned char",
@@ -337,6 +342,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#16",
                 "pretty": "field_layout::holes::Sub::y",
                 "sym": "F_<T_field_layout::holes::Sub>_y",
                 "type": "unsigned int",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -1484,6 +1484,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1\">sub_sub_sub_a_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x40",
@@ -1517,6 +1520,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1\">sub_sub_c_1</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -1552,6 +1558,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1\">sub_sub_b_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x3c",
@@ -1580,6 +1589,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1\">sub_a_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -1601,6 +1613,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "short",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int16_t\">int16_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2\">sub_a_2</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -1636,6 +1651,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1\">sub_b_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x8",
@@ -1657,6 +1675,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "signed char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int8_t\">int8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2\">sub_b_2</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -1692,6 +1713,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int64_t\">int64_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3\">sub_b_3</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x10",
@@ -1717,6 +1741,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1\">sub_d_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x20",
@@ -1738,6 +1765,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "signed char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int8_t\">int8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2\">sub_d_2</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -1779,6 +1809,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int64_t\">int64_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1\">sub_e_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x30",
@@ -1800,6 +1833,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2\">sub_e_2</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -1839,6 +1875,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int8_t\">int8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1\">sub_c_1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x18",
@@ -1866,6 +1905,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "int",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int32_t\">int32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2\">sub_c_2</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -1935,5 +1935,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/multiple_inheritance.cpp/check_glob@field_layout__multiple_inheritance__json.snap
@@ -520,6 +520,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#11",
                 "pretty": "field_layout::multiple_inheritance::SubA::sub_a_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_1",
                 "type": "int",
@@ -529,6 +530,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#12",
                 "pretty": "field_layout::multiple_inheritance::SubA::sub_a_2",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubA>_sub_a_2",
                 "type": "short",
@@ -613,6 +615,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#16",
                 "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
                 "type": "int",
@@ -622,6 +625,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#17",
                 "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
                 "type": "signed char",
@@ -631,6 +635,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#19",
                 "pretty": "field_layout::multiple_inheritance::SubB::sub_b_3",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_3",
                 "type": "long",
@@ -707,6 +712,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#16",
                     "pretty": "field_layout::multiple_inheritance::SubB::sub_b_1",
                     "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_1",
                     "type": "int",
@@ -716,6 +722,7 @@ expression: "&to_value(sttl).unwrap()"
                     "sizeBytes": 4
                   },
                   {
+                    "lineRange": "#17",
                     "pretty": "field_layout::multiple_inheritance::SubB::sub_b_2",
                     "sym": "F_<T_field_layout::multiple_inheritance::SubB>_sub_b_2",
                     "type": "signed char",
@@ -806,6 +813,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#24",
                 "pretty": "field_layout::multiple_inheritance::SubC::sub_c_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_1",
                 "type": "signed char",
@@ -815,6 +823,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#25",
                 "pretty": "field_layout::multiple_inheritance::SubC::sub_c_2",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubC>_sub_c_2",
                 "type": "int",
@@ -899,6 +908,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#29",
                 "pretty": "field_layout::multiple_inheritance::SubD::sub_d_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_1",
                 "type": "int",
@@ -908,6 +918,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#30",
                 "pretty": "field_layout::multiple_inheritance::SubD::sub_d_2",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubD>_sub_d_2",
                 "type": "signed char",
@@ -992,6 +1003,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#34",
                 "pretty": "field_layout::multiple_inheritance::SubE::sub_e_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_1",
                 "type": "long",
@@ -1001,6 +1013,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 8
               },
               {
+                "lineRange": "#35",
                 "pretty": "field_layout::multiple_inheritance::SubE::sub_e_2",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubE>_sub_e_2",
                 "type": "int",
@@ -1095,6 +1108,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#42",
                 "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
                 "type": "int",
@@ -1181,6 +1195,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#42",
                     "pretty": "field_layout::multiple_inheritance::SubSubA::sub_sub_c_1",
                     "sym": "F_<T_field_layout::multiple_inheritance::SubSubA>_sub_sub_c_1",
                     "type": "int",
@@ -1271,6 +1286,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#46",
                 "pretty": "field_layout::multiple_inheritance::SubSubB::sub_sub_b_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubSubB>_sub_sub_b_1",
                 "type": "int",
@@ -1351,6 +1367,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#51",
                 "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
                 "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
                 "type": "int",
@@ -1420,6 +1437,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#51",
                     "pretty": "field_layout::multiple_inheritance::SubSubSubA::sub_sub_sub_a_1",
                     "sym": "F_<T_field_layout::multiple_inheritance::SubSubSubA>_sub_sub_sub_a_1",
                     "type": "int",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -52,6 +52,7 @@ expression: "&to_value(sttl).unwrap()"
             "methods": [],
             "fields": [
               {
+                "lineRange": "#11",
                 "pretty": "field_layout::non_struct::Proxy::x",
                 "sym": "F_<T_field_layout::non_struct::Proxy>_x",
                 "type": "signed char",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -139,5 +139,6 @@ expression: "&to_value(sttl).unwrap()"
       ],
       "rows": []
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/non-struct.cpp/check_glob@field_layout__non_struct__json.snap
@@ -89,6 +89,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_int8_t\">int8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::non_struct::Proxy>_x\">x</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -869,5 +869,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -690,6 +690,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S3>_f6\">f6</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0xc",
@@ -729,6 +732,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S2>_f4\">f4</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x8",
@@ -754,6 +760,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S2>_f5\">f5</span>;"
                 ],
                 "offsetAndSize": [
                   null,
@@ -781,6 +790,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S1>_f1\">f1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -807,6 +819,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S1>_f2\">f2</span>;"
+                ],
                 "offsetAndSize": [
                   null,
                   {
@@ -829,6 +844,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::S1>_f3\">f3</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_1__json.snap
@@ -226,6 +226,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#8",
                 "pretty": "field_layout::platform_specific_field::S1::f1",
                 "sym": "F_<T_field_layout::platform_specific_field::S1>_f1",
                 "type": "unsigned int",
@@ -235,6 +236,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#15",
                 "pretty": "field_layout::platform_specific_field::S1::f3",
                 "sym": "F_<T_field_layout::platform_specific_field::S1>_f3",
                 "type": "unsigned char",
@@ -305,6 +307,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#8",
                     "pretty": "field_layout::platform_specific_field::S1::f1",
                     "sym": "F_<T_field_layout::platform_specific_field::S1>_f1",
                     "type": "unsigned int",
@@ -314,6 +317,7 @@ expression: "&to_value(sttl).unwrap()"
                     "sizeBytes": 4
                   },
                   {
+                    "lineRange": "#11",
                     "pretty": "field_layout::platform_specific_field::S1::f2",
                     "sym": "F_<T_field_layout::platform_specific_field::S1>_f2",
                     "type": "unsigned int",
@@ -404,6 +408,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#20",
                 "pretty": "field_layout::platform_specific_field::S2::f4",
                 "sym": "F_<T_field_layout::platform_specific_field::S2>_f4",
                 "type": "unsigned int",
@@ -480,6 +485,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#20",
                     "pretty": "field_layout::platform_specific_field::S2::f4",
                     "sym": "F_<T_field_layout::platform_specific_field::S2>_f4",
                     "type": "unsigned int",
@@ -489,6 +495,7 @@ expression: "&to_value(sttl).unwrap()"
                     "sizeBytes": 4
                   },
                   {
+                    "lineRange": "#23",
                     "pretty": "field_layout::platform_specific_field::S2::f5",
                     "sym": "F_<T_field_layout::platform_specific_field::S2>_f5",
                     "type": "unsigned char",
@@ -570,6 +577,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#28",
                 "pretty": "field_layout::platform_specific_field::S3::f6",
                 "sym": "F_<T_field_layout::platform_specific_field::S3>_f6",
                 "type": "unsigned char",
@@ -634,6 +642,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#28",
                     "pretty": "field_layout::platform_specific_field::S3::f6",
                     "sym": "F_<T_field_layout::platform_specific_field::S3>_f6",
                     "type": "unsigned char",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -869,5 +869,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -253,6 +253,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#32",
                 "pretty": "field_layout::platform_specific_field::T1::f1",
                 "sym": "F_<T_field_layout::platform_specific_field::T1>_f1",
                 "type": "unsigned char",
@@ -337,6 +338,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#36",
                 "pretty": "field_layout::platform_specific_field::T2::f2",
                 "sym": "F_<T_field_layout::platform_specific_field::T2>_f2",
                 "type": "unsigned int",
@@ -346,6 +348,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#41",
                 "pretty": "field_layout::platform_specific_field::T2::f3b",
                 "sym": "F_<T_field_layout::platform_specific_field::T2>_f3b",
                 "type": "unsigned char",
@@ -422,6 +425,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#36",
                     "pretty": "field_layout::platform_specific_field::T2::f2",
                     "sym": "F_<T_field_layout::platform_specific_field::T2>_f2",
                     "type": "unsigned int",
@@ -431,6 +435,7 @@ expression: "&to_value(sttl).unwrap()"
                     "sizeBytes": 4
                   },
                   {
+                    "lineRange": "#39",
                     "pretty": "field_layout::platform_specific_field::T2::f3",
                     "sym": "F_<T_field_layout::platform_specific_field::T2>_f3",
                     "type": "unsigned char",
@@ -512,6 +517,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#46",
                 "pretty": "field_layout::platform_specific_field::T3::f4",
                 "sym": "F_<T_field_layout::platform_specific_field::T3>_f4",
                 "type": "unsigned int",
@@ -521,6 +527,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#53",
                 "pretty": "field_layout::platform_specific_field::T3::f6",
                 "sym": "F_<T_field_layout::platform_specific_field::T3>_f6",
                 "type": "unsigned char",
@@ -585,6 +592,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#46",
                     "pretty": "field_layout::platform_specific_field::T3::f4",
                     "sym": "F_<T_field_layout::platform_specific_field::T3>_f4",
                     "type": "unsigned int",
@@ -594,6 +602,7 @@ expression: "&to_value(sttl).unwrap()"
                     "sizeBytes": 4
                   },
                   {
+                    "lineRange": "#49",
                     "pretty": "field_layout::platform_specific_field::T3::f5",
                     "sym": "F_<T_field_layout::platform_specific_field::T3>_f5",
                     "type": "unsigned int",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_field.cpp/check_glob@field_layout__platform_specific_field_2__json.snap
@@ -650,6 +650,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T3>_f4\">f4</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0xc",
@@ -676,6 +679,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T3>_f5\">f5</span>;"
+                ],
                 "offsetAndSize": [
                   null,
                   {
@@ -698,6 +704,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T3>_f6\">f6</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -739,6 +748,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint32_t\">uint32_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T2>_f2\">f2</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x4",
@@ -764,6 +776,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T2>_f3\">f3</span>;"
                 ],
                 "offsetAndSize": [
                   null,
@@ -791,6 +806,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T2>_f3b\">f3b</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -827,6 +845,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_field::T1>_f1\">f1</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -211,5 +211,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -82,6 +82,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#20",
                 "pretty": "field_layout::platform_specific_size::S::f1",
                 "sym": "F_<T_field_layout::platform_specific_size::S>_f1",
                 "type": "unsigned long",
@@ -140,6 +141,7 @@ expression: "&to_value(sttl).unwrap()"
                 ],
                 "fields": [
                   {
+                    "lineRange": "#20",
                     "pretty": "field_layout::platform_specific_size::S::f1",
                     "sym": "F_<T_field_layout::platform_specific_size::S>_f1",
                     "type": "unsigned int",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/platform_specific_size.cpp/check_glob@field_layout__platform_specific_size__json.snap
@@ -192,6 +192,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_field_layout::platform_specific_size::T1\">T1</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::platform_specific_size::S>_f1\">f1</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
@@ -1067,5 +1067,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
@@ -433,6 +433,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#24",
                 "pretty": "field_layout::vtable::Sub1a::x",
                 "sym": "F_<T_field_layout::vtable::Sub1a>_x",
                 "type": "unsigned char",
@@ -517,6 +518,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#30",
                 "pretty": "field_layout::vtable::Sub1b::y",
                 "sym": "F_<T_field_layout::vtable::Sub1b>_y",
                 "type": "unsigned char",
@@ -601,6 +603,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#36",
                 "pretty": "field_layout::vtable::Sub2::w",
                 "sym": "F_<T_field_layout::vtable::Sub2>_w",
                 "type": "unsigned char",
@@ -685,6 +688,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#42",
                 "pretty": "field_layout::vtable::Sub3::v",
                 "sym": "F_<T_field_layout::vtable::Sub3>_v",
                 "type": "unsigned char",
@@ -784,6 +788,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#48",
                 "pretty": "field_layout::vtable::SubSub::z",
                 "sym": "F_<T_field_layout::vtable::SubSub>_z",
                 "type": "unsigned char",

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/vtable.cpp/check_glob@field_layout__vtable__json.snap
@@ -825,6 +825,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::vtable::SubSub>_z\">z</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x39",
@@ -853,6 +856,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::vtable::Sub1a>_x\">x</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -883,6 +889,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::vtable::Sub1b>_y\">y</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x18",
@@ -911,6 +920,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::vtable::Sub2>_w\">w</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -941,6 +953,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x30",
@@ -958,6 +971,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "unsigned char",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"TA_uint8_t\">uint8_t</span> <span class=\"syn_def\" data-symbols=\"F_<T_field_layout::vtable::Sub3>_v\">v</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -983,6 +999,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -1007,6 +1024,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x10",
@@ -1031,6 +1049,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x20",

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -472,6 +472,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#241",
                 "pretty": "outerNS::OuterCat::mIsFriendly",
                 "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
                 "type": "_Bool",
@@ -481,6 +482,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#242",
                 "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
                 "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
                 "type": "_Bool",
@@ -490,6 +492,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 1
               },
               {
+                "lineRange": "#244",
                 "pretty": "outerNS::OuterCat::mOwner",
                 "sym": "F_<T_outerNS::OuterCat>_mOwner",
                 "type": "class std::shared_ptr<class outerNS::Human>",
@@ -508,6 +511,7 @@ expression: "&to_value(sttl).unwrap()"
                 ]
               },
               {
+                "lineRange": "#245",
                 "pretty": "outerNS::OuterCat::mFavoriteCouch",
                 "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
                 "type": "class outerNS::Couch *",
@@ -632,6 +636,7 @@ expression: "&to_value(sttl).unwrap()"
             ],
             "fields": [
               {
+                "lineRange": "#147",
                 "pretty": "outerNS::Thing::mHP",
                 "sym": "F_<T_outerNS::Thing>_mHP",
                 "type": "int",
@@ -641,6 +646,7 @@ expression: "&to_value(sttl).unwrap()"
                 "sizeBytes": 4
               },
               {
+                "lineRange": "#151",
                 "pretty": "outerNS::Thing::mDefunct",
                 "sym": "F_<T_outerNS::Thing>_mDefunct",
                 "type": "_Bool",

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -843,5 +843,6 @@ expression: "&to_value(sttl).unwrap()"
         }
       ]
     }
-  ]
+  ],
+  "className": null
 }

--- a/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/field-layout/check_glob@query__field_layout__outercat__json.snap
@@ -693,6 +693,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mIsFriendly\">mIsFriendly</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0xd",
@@ -710,6 +713,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "_Bool",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly\">mIsSecretlyUnfriendly</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -734,6 +740,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": "T_std::shared_ptr,T_outerNS::Human"
                   }
                 ],
+                "lines": [
+                  "  std::<span class=\"syn_type\" data-symbols=\"T_std::shared_ptr\">shared_ptr</span>&lt;<span class=\"syn_type\" data-symbols=\"T_outerNS::Human\">Human</span>> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mOwner\">mOwner</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x10",
@@ -751,6 +760,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "class outerNS::Couch *",
                     "symbols": "T_outerNS::Couch"
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_type\" data-symbols=\"T_outerNS::Couch\">Couch</span> *<span class=\"syn_def\" data-symbols=\"F_<T_outerNS::OuterCat>_mFavoriteCouch\">mFavoriteCouch</span>;"
                 ],
                 "offsetAndSize": [
                   {
@@ -776,6 +788,7 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x0",
@@ -794,6 +807,9 @@ expression: "&to_value(sttl).unwrap()"
                     "symbols": ""
                   }
                 ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >int</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::Thing>_mHP\">mHP</span>;"
+                ],
                 "offsetAndSize": [
                   {
                     "offset": "@ 0x8",
@@ -811,6 +827,9 @@ expression: "&to_value(sttl).unwrap()"
                     "name": "_Bool",
                     "symbols": ""
                   }
+                ],
+                "lines": [
+                  "  <span class=\"syn_reserved\" >bool</span> <span class=\"syn_def\" data-symbols=\"F_<T_outerNS::Thing>_mDefunct\">mDefunct</span>;"
                 ],
                 "offsetAndSize": [
                   {

--- a/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
@@ -254,6 +254,7 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [
           {
+            "lineRange": "#241",
             "pretty": "outerNS::OuterCat::mIsFriendly",
             "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
             "type": "_Bool",
@@ -263,6 +264,7 @@ expression: "&to_value(grb).unwrap()"
             "sizeBytes": 1
           },
           {
+            "lineRange": "#242",
             "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
             "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
             "type": "_Bool",
@@ -272,6 +274,7 @@ expression: "&to_value(grb).unwrap()"
             "sizeBytes": 1
           },
           {
+            "lineRange": "#244",
             "pretty": "outerNS::OuterCat::mOwner",
             "sym": "F_<T_outerNS::OuterCat>_mOwner",
             "type": "class std::shared_ptr<class outerNS::Human>",
@@ -290,6 +293,7 @@ expression: "&to_value(grb).unwrap()"
             ]
           },
           {
+            "lineRange": "#245",
             "pretty": "outerNS::OuterCat::mFavoriteCouch",
             "sym": "F_<T_outerNS::OuterCat>_mFavoriteCouch",
             "type": "class outerNS::Couch *",
@@ -414,6 +418,7 @@ expression: "&to_value(grb).unwrap()"
         ],
         "fields": [
           {
+            "lineRange": "#147",
             "pretty": "outerNS::Thing::mHP",
             "sym": "F_<T_outerNS::Thing>_mHP",
             "type": "int",
@@ -423,6 +428,7 @@ expression: "&to_value(grb).unwrap()"
             "sizeBytes": 4
           },
           {
+            "lineRange": "#151",
             "pretty": "outerNS::Thing::mDefunct",
             "sym": "F_<T_outerNS::Thing>_mDefunct",
             "type": "_Bool",

--- a/tests/tests/files/field-layout/field-type-include.h
+++ b/tests/tests/files/field-layout/field-type-include.h
@@ -1,0 +1,9 @@
+  Type1 other_file_field1;
+
+  Container1<Type1>
+    other_file_field2;
+
+  std::vector<
+    Type1
+  >
+    other_file_field3;

--- a/tests/tests/files/field-layout/field-type.cpp
+++ b/tests/tests/files/field-layout/field-type.cpp
@@ -1,55 +1,7 @@
 #include <vector>
 #include <stddef.h>
 #include <stdint.h>
-
-class JSObject {
-};
-
-namespace JS {
-
-class TestAllocPolicy {
-};
-
-
-template <typename T>
-class Rooted {
-};
-
-template <typename T, size_t MinInlineCapacity = 0,
-          typename AllocPolicy = TestAllocPolicy>
-class GCVector {
-};
-
-template <typename T, typename AllocPolicy = TestAllocPolicy>
-class StackGCVector : public GCVector<T, 8, AllocPolicy> {
-};
-
-template <typename T>
-class RootedVector : public Rooted<StackGCVector<T>> {
-};
-
-class alignas(8) Value {
- private:
-  uint64_t asBits_;
-};
-
-
-template <typename Key, typename Value>
-class GCHashMap {
-};
-
-}
-
-namespace js {
-
-class TestCheck {
-};
-
-template <typename Check, typename T>
-class ProtectedDataNoCheckArgs {
-};
-
-}
+#include "field-type.h"
 
 namespace field_layout {
 
@@ -74,6 +26,13 @@ struct Container2 {
   T a;
 };
 
+#define DEFINE_FIELDS \
+  Type1 macro_fields_1; \
+  Enum1 macro_fields_2; \
+  Container1<Type1> macro_fields_3;
+
+#define SOME_ANNOTATION __attribute__((annotate("some_annotation")))
+
 struct S {
   Type1 value_field;
   const Type1* pointer_field;
@@ -83,7 +42,14 @@ struct S {
   JS::Rooted<JS::Value> rooted_field;
   JS::RootedVector<JS::Value> rooted_vec_field;
   JS::GCHashMap<JS::Value, JSObject*> hash_map_field;
-  js::ProtectedDataNoCheckArgs<js::TestCheck,  JS::Value> protected_field;
+  js::TestLockData<JS::Value> protected_field;
+  DEFINE_FIELDS
+  js::TestLockData<
+    Type1
+  >
+  multiline_field
+  SOME_ANNOTATION;
+#include "field-type-include.h"
 };
 
 S f() {

--- a/tests/tests/files/field-layout/field-type.h
+++ b/tests/tests/files/field-layout/field-type.h
@@ -1,0 +1,51 @@
+class JSObject {
+};
+
+namespace JS {
+
+class TestAllocPolicy {
+};
+
+
+template <typename T>
+class Rooted {
+};
+
+template <typename T, size_t MinInlineCapacity = 0,
+          typename AllocPolicy = TestAllocPolicy>
+class GCVector {
+};
+
+template <typename T, typename AllocPolicy = TestAllocPolicy>
+class StackGCVector : public GCVector<T, 8, AllocPolicy> {
+};
+
+template <typename T>
+class RootedVector : public Rooted<StackGCVector<T>> {
+};
+
+class alignas(8) Value {
+ private:
+  uint64_t asBits_;
+};
+
+
+template <typename Key, typename Value>
+class GCHashMap {
+};
+
+}
+
+namespace js {
+
+class TestCheck {
+};
+
+template <typename Check, typename T>
+class ProtectedDataNoCheckArgs {
+};
+
+template <typename T>
+using TestLockData = ProtectedDataNoCheckArgs<TestCheck, T>;
+
+}

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -128,6 +128,23 @@ pub struct LocalIndex {
     file_lookup_map: FileLookupMap,
 }
 
+impl LocalIndex {
+    fn normalize_and_validate_path<'a>(&self, sf_path: &'a str) -> Result<&'a str> {
+        // We normalize off any leading "/" mainly to support our test cases
+        // being able to use "/" to indicate they're interested in a root dir.
+        let norm_path = if sf_path.starts_with('/') {
+            &sf_path[1..]
+        } else {
+            sf_path
+        };
+        // We don't want anyone trying to construct a path that escapes the
+        // sub-tree.
+        validate_absoluteish_path(norm_path)?;
+
+        Ok(norm_path)
+    }
+}
+
 #[async_trait]
 impl AbstractServer for LocalIndex {
     fn clonify(&self) -> Box<dyn AbstractServer + Send + Sync> {
@@ -163,32 +180,15 @@ impl AbstractServer for LocalIndex {
     }
 
     async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
-        // We normalize off any leading "/" mainly to support our test cases
-        // being able to use "/" to indicate they're interested in a root dir.
-        let norm_path = if sf_path.starts_with('/') {
-            &sf_path[1..]
-        } else {
-            sf_path
-        };
-        // We don't want anyone trying to construct a path that escapes the
-        // sub-tree.
-        validate_absoluteish_path(norm_path)?;
-        let full_path = format!("{}/analysis/{}.gz", self.config_paths.index_path, norm_path);
+        let norm_path = self.normalize_and_validate_path(sf_path)?;
+        let full_path = self.translate_path(
+            SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;
         let values = read_gzipped_ndjson_from_file(&full_path).await?;
         Ok(Box::pin(tokio_stream::iter(values)))
     }
 
     async fn fetch_raw_source(&self, sf_path: &str) -> Result<String> {
-        // We normalize off any leading "/" mainly to support our test cases
-        // being able to use "/" to indicate they're interested in a root dir.
-        let norm_path = if sf_path.starts_with('/') {
-            &sf_path[1..]
-        } else {
-            sf_path
-        };
-        // We don't want anyone trying to construct a path that escapes the
-        // sub-tree.
-        validate_absoluteish_path(norm_path)?;
+        let norm_path = self.normalize_and_validate_path(sf_path)?;
         let full_path = format!("{}/{}", self.config_paths.files_path, norm_path);
 
         let mut f = File::open(full_path).await?;
@@ -198,16 +198,7 @@ impl AbstractServer for LocalIndex {
     }
 
     async fn fetch_html(&self, root: HtmlFileRoot, sf_path: &str) -> Result<String> {
-        // We normalize off any leading "/" mainly to support our test cases
-        // being able to use "/" to indicate they're interested in a root dir.
-        let norm_path = if sf_path.starts_with('/') {
-            &sf_path[1..]
-        } else {
-            sf_path
-        };
-        // We don't want anyone trying to construct a path that escapes the
-        // sub-tree.
-        validate_absoluteish_path(norm_path)?;
+        let norm_path = self.normalize_and_validate_path(sf_path)?;
         let (full_path, is_gzipped) = match root {
             HtmlFileRoot::FormattedFile => (
                 format!("{}/file/{}.gz", self.config_paths.index_path, norm_path),

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -117,6 +117,10 @@ impl AbstractServer for RemoteServer {
         Ok(Box::pin(tokio_stream::iter(values?)))
     }
 
+    async fn fetch_formatted_lines(&self, _sf_path: &str) -> Result<(Vec<String>, String)> {
+        Err(ServerError::Unsupported)
+    }
+
     async fn fetch_raw_source(&self, _sf_path: &str) -> Result<String> {
         // I'm not sure we actually expose the underlying raw file?
         Err(ServerError::Unsupported)

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -303,6 +303,12 @@ pub trait AbstractServer {
     /// we can actually check the source file out if needed.
     async fn fetch_raw_source(&self, sf_path: &str) -> Result<String>;
 
+    /// Fetch the lines in the rendered HTML file.
+    ///
+    /// Returns a tuple of a list of lines, 0-th item for line 1,
+    /// and a JSON string for the SYM_INFO object.
+    async fn fetch_formatted_lines(&self, sf_path: &str) -> Result<(Vec<String>, String)>;
+
     /// Fetch the contents of a rendered HTML file, decompressing if it's
     /// compressed.  If `is_file` is true, this will be from the INDEX/file
     /// sub-tree.  If `is_file` is false, we're treating it as a directory

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -948,6 +948,7 @@ fn analyze_using_scip(
                                     }
                                     Some("field") => {
                                         pstruct.fields.push(StructuredFieldInfo {
+                                            line_range: ustr(""),
                                             pretty: symbol_info.pretty,
                                             sym: symbol_info.norm_sym,
                                             type_pretty: type_pretty.unwrap_or_else(|| ustr("")),

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -51,6 +51,12 @@ pub enum SymbolFormatMode {
 pub struct FormatSymbols {
     #[clap(long, value_parser, value_enum, default_value = "field-layout")]
     pub mode: SymbolFormatMode,
+
+    #[clap(long, value_parser)]
+    pub show_cols: Option<String>,
+
+    #[clap(long, value_parser)]
+    pub hide_cols: Option<String>,
 }
 
 #[derive(Debug)]
@@ -1217,8 +1223,31 @@ impl PipelineCommand for FormatSymbolsCommand {
                     map.generate_tables(&mut tables);
                 }
 
+                let mut class_names = vec![];
+                if let Some(cols) = &self.args.show_cols {
+                    for col in cols.split(",") {
+                        if col == "type" {
+                            class_names.push(format!("show-{}", col));
+                        }
+                    }
+                }
+                if let Some(cols) = &self.args.hide_cols {
+                    for col in cols.split(",") {
+                        if col == "line" || col == "name" {
+                            class_names.push(format!("hide-{}", col));
+                        }
+                    }
+                }
+
+                let class_name = if class_names.is_empty() {
+                    None
+                } else {
+                    Some(class_names.join(" "))
+                };
+
                 Ok(PipelineValues::SymbolTreeTableList(SymbolTreeTableList {
                     tables,
+                    class_name: class_name,
                 }))
             }
         }

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -78,6 +78,8 @@ pub struct SymbolTreeTable {
 #[derive(Serialize)]
 pub struct SymbolTreeTableList {
     pub tables: Vec<SymbolTreeTable>,
+    #[serde(rename = "className")]
+    pub class_name: Option<String>,
 }
 
 impl SymbolTreeTableList {

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -70,6 +70,9 @@ pub struct SymbolTreeTable {
     pub node_set: SymbolGraphNodeSet,
     pub platforms: Vec<String>,
     pub rows: Vec<SymbolTreeTableNode>,
+
+    /// Symbols to put into SYM_INFO, in addition to node_set.
+    pub extra_syms: HashMap<String, Value>,
 }
 
 #[derive(Serialize)]
@@ -86,6 +89,12 @@ impl SymbolTreeTableList {
                 jumprefs.insert(
                     sym_info.symbol.clone(),
                     convert_crossref_value_to_sym_info_rep(info, &sym_info.symbol, None),
+                );
+            }
+            for (sym, info) in &table.extra_syms {
+                jumprefs.insert(
+                    ustr(sym.as_str()),
+                    info.clone(),
                 );
             }
         }
@@ -180,6 +189,7 @@ pub struct SymbolTreeTableField {
     pub name: String,
     pub symbols: String,
     pub types: Vec<SymbolTreeTableFieldType>,
+    pub lines: Vec<String>,
     #[serde(rename = "offsetAndSize")]
     pub offset_and_size: Vec<Option<SymbolTreeTableFieldOffsetAndSize>>
 }
@@ -190,6 +200,7 @@ impl SymbolTreeTableField {
             name: name,
             symbols: symbols,
             types: vec![],
+            lines: vec![],
             offset_and_size: vec![],
         }
     }
@@ -231,6 +242,7 @@ impl SymbolTreeTable {
             node_set: SymbolGraphNodeSet::new(),
             platforms: vec![],
             rows: vec![],
+            extra_syms: HashMap::new(),
         }
     }
 }

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -270,6 +270,18 @@ pub struct StructuredFieldInfo<StrT = Ustr>
 where
     StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
 {
+    /// The field definition's location in "PATH#line-line" or "PATH#line" format.
+    ///
+    /// If this field is defined in single line, "PATH#line" format is used,
+    /// otherwise "PATH#line-line" format is used with first line and last line.
+    ///
+    /// If this field is defined in the same file as struct itself,
+    /// PATH part is omitted.
+    /// Otherwise PATH is the full path inside the repository.
+    ///
+    /// TODO: Use relative path from struct's file to reduce the size.
+    #[serde(rename = "lineRange", default)]
+    pub line_range: StrT,
     #[serde(default)]
     pub pretty: StrT,
     #[serde(default)]

--- a/tools/src/query/query_core.toml
+++ b/tools/src/query/query_core.toml
@@ -258,6 +258,16 @@ transforms = ["path_glob"]
 command = "search-text"
 args.re = "$0"
 
+[term.show-cols]
+[[term.show-cols.group.semantic-format]]
+command = "format-symbols"
+args.show-cols = "$0"
+
+[term.hide-cols]
+[[term.hide-cols.group.semantic-format]]
+command = "format-symbols"
+args.hide-cols = "$0"
+
 [term.sym]
 alias = "symbol"
 

--- a/tools/templates/query_results/symbol_tree_table.liquid
+++ b/tools/templates/query_results/symbol_tree_table.liquid
@@ -1,17 +1,17 @@
 <table class="symbol-tree-table">
   <thead>
     <tr>
-      <th>Name</th>
-      <th>Type</th>
-      <th>Line</th>
+      <th class="name-cell">Name</th>
+      <th class="type-cell">Type</th>
+      <th class="line-cell">Line</th>
       {%- for platform in table.platforms -%}
         <th colspan="2">{{- platform | escape -}}</th>
       {%- endfor -%}
     </tr>
     <tr>
-      <th></th>
-      <th></th>
-      <th></th>
+      <th class="name-cell"></th>
+      <th class="type-cell"></th>
+      <th class="line-cell"></th>
       {%- for platform in table.platforms -%}
         <th>Offset</th>
         <th>Size</th>

--- a/tools/templates/query_results/symbol_tree_table.liquid
+++ b/tools/templates/query_results/symbol_tree_table.liquid
@@ -3,11 +3,13 @@
     <tr>
       <th>Name</th>
       <th>Type</th>
+      <th>Line</th>
       {%- for platform in table.platforms -%}
         <th colspan="2">{{- platform | escape -}}</th>
       {%- endfor -%}
     </tr>
     <tr>
+      <th></th>
       <th></th>
       <th></th>
       {%- for platform in table.platforms -%}

--- a/tools/templates/query_results/symbol_tree_table_list_root.liquid
+++ b/tools/templates/query_results/symbol_tree_table_list_root.liquid
@@ -1,3 +1,6 @@
+<div id="symbol-tree-table-list"
+{%- if results.SymbolTreeTableList.className %} class="{{ results.SymbolTreeTableList.className }}"{% endif -%}>
 {% for table in results.SymbolTreeTableList.tables %}
     {% include 'query_results/symbol_tree_table.liquid' table: table, forloop: forloop %}
 {% endfor %}
+</div>

--- a/tools/templates/query_results/symbol_tree_table_list_root.liquid
+++ b/tools/templates/query_results/symbol_tree_table_list_root.liquid
@@ -1,3 +1,9 @@
+<div id="symbol-tree-table-col-selector">
+  Columns:
+  <label for="col-show-name"><input type="checkbox" id="col-show-name">Name</label>
+  <label for="col-show-type"><input type="checkbox" id="col-show-type">Type</label>
+  <label for="col-show-line"><input type="checkbox" id="col-show-line">Line</label>
+</div>
 <div id="symbol-tree-table-list"
 {%- if results.SymbolTreeTableList.className %} class="{{ results.SymbolTreeTableList.className }}"{% endif -%}>
 {% for table in results.SymbolTreeTableList.tables %}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -1,9 +1,11 @@
 <tr>
   <td colspan="{{ platforms.size | times: 2 | plus: 3 }}">
     <h3>
-      <span data-symbols="{{ node.symbols }}">
-        {{- node.name | escape -}}
-      </span>
+      <code>
+        <span data-symbols="{{ node.symbols }}">
+          {{- node.name | escape -}}
+        </span>
+      </code>
     </h3>
   </td>
 </tr>
@@ -11,21 +13,25 @@
   {%- if item contains "Field" -%}
     <tr>
       <td>
-        <span data-symbols="{{ item.Field.symbols }}">
-          {{- item.Field.name | escape -}}
-        </span>
+        <code>
+          <span data-symbols="{{ item.Field.symbols }}">
+            {{- item.Field.name | escape -}}
+          </span>
+        </code>
       </td>
       <td>
-        {%- assign first = true -%}
-        {%- for type in item.Field.types -%}
-          {%- if first == false -%}
-            |<br>
-          {%- endif -%}
-          <span data-symbols="{{ type.symbols }}">
-            {{ type.name | escape }}
-          </span>
-          {%- assign first = false -%}
-        {%- endfor -%}
+        <code>
+          {%- assign first = true -%}
+          {%- for type in item.Field.types -%}
+            {%- if first == false -%}
+              |<br>
+            {%- endif -%}
+            <span data-symbols="{{ type.symbols }}">
+              {{ type.name | escape }}
+            </span>
+            {%- assign first = false -%}
+          {%- endfor -%}
+        </code>
       </td>
       <td>
         {%- assign first = true -%}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -20,7 +20,7 @@
         </code>
       </td>
       <td>
-        <code>
+        <code class="field-type">
           {%- assign first = true -%}
           {%- for type in item.Field.types -%}
             {%- if first == false -%}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -12,14 +12,14 @@
 {%- for item in node.items -%}
   {%- if item contains "Field" -%}
     <tr>
-      <td>
+      <td class="name-cell">
         <code>
           <span data-symbols="{{ item.Field.symbols }}">
             {{- item.Field.name | escape -}}
           </span>
         </code>
       </td>
-      <td>
+      <td class="type-cell">
         <code class="field-type">
           {%- assign first = true -%}
           {%- for type in item.Field.types -%}
@@ -33,7 +33,7 @@
           {%- endfor -%}
         </code>
       </td>
-      <td>
+      <td class="line-cell">
         {%- assign first = true -%}
         {%- for line in item.Field.lines -%}
           {%- if first == false -%}
@@ -63,7 +63,9 @@
     </tr>
   {%- elsif item contains "Hole" -%}
     <tr>
-      <td colspan="3">
+      <td class="name-cell"></td>
+      <td class="type-cell"></td>
+      <td class="line-cell"></td>
       </td>
       {%- for hole in item.Hole -%}
         {%- if hole -%}
@@ -80,7 +82,9 @@
     </tr>
   {%- elsif item contains "EndPadding" -%}
     <tr>
-      <td colspan="3">
+      <td class="name-cell"></td>
+      <td class="type-cell"></td>
+      <td class="line-cell"></td>
       </td>
       {%- for padding in item.EndPadding -%}
         {%- if padding -%}

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -1,5 +1,5 @@
 <tr>
-  <td colspan="{{ platforms.size | times: 2 | plus: 2 }}">
+  <td colspan="{{ platforms.size | times: 2 | plus: 3 }}">
     <h3>
       <span data-symbols="{{ node.symbols }}">
         {{- node.name | escape -}}
@@ -27,6 +27,16 @@
           {%- assign first = false -%}
         {%- endfor -%}
       </td>
+      <td>
+        {%- assign first = true -%}
+        {%- for line in item.Field.lines -%}
+          {%- if first == false -%}
+            <br>
+          {%- endif -%}
+          <code>{{- line -}}</code>
+          {%- assign first = false -%}
+        {%- endfor -%}
+      </td>
       {%- for offsetAndSize in item.Field.offsetAndSize -%}
         {%- if offsetAndSize -%}
           <td>
@@ -43,7 +53,7 @@
     </tr>
   {%- elsif item contains "Hole" -%}
     <tr>
-      <td colspan="2">
+      <td colspan="3">
       </td>
       {%- for hole in item.Hole -%}
         {%- if hole -%}
@@ -58,7 +68,7 @@
     </tr>
   {%- elsif item contains "EndPadding" -%}
     <tr>
-      <td colspan="2">
+      <td colspan="3">
       </td>
       {%- for padding in item.EndPadding -%}
         {%- if padding -%}
@@ -73,7 +83,7 @@
     </tr>
   {%- elsif item contains "Warning" -%}
     <tr>
-      <th colspan="{{ platforms.size | times: 2 | plus: 2 }}">
+      <th colspan="{{ platforms.size | times: 2 | plus: 3 }}">
         <em class="warning">
           {{- item.Warning | escape -}}
         </em>

--- a/tools/templates/query_results/symbol_tree_table_node.liquid
+++ b/tools/templates/query_results/symbol_tree_table_node.liquid
@@ -40,10 +40,14 @@
       {%- for offsetAndSize in item.Field.offsetAndSize -%}
         {%- if offsetAndSize -%}
           <td>
-            {{- offsetAndSize.offset | escape -}}
+            <span class="field-offset">
+              {{- offsetAndSize.offset | escape -}}
+            </span>
           </td>
           <td>
-            {{- offsetAndSize.size | escape -}}
+            <span class="field-size">
+              {{- offsetAndSize.size | escape -}}
+            </span>
           </td>
         {%- else -%}
           <td colspan="2">
@@ -58,7 +62,9 @@
       {%- for hole in item.Hole -%}
         {%- if hole -%}
           <td colspan="2">
-            {{- hole | escape -}}
+            <span class="field-hole">
+              {{- hole | escape -}}
+            </span>
           </td>
         {%- else -%}
           <td colspan="2">
@@ -73,7 +79,9 @@
       {%- for padding in item.EndPadding -%}
         {%- if padding -%}
           <td colspan="2">
-            {{- padding | escape -}}
+            <span class="field-padding">
+              {{- padding | escape -}}
+            </span>
           </td>
         {%- else -%}
           <td colspan="2">


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1902875

This does the following:
  * Add server method to fetch list of HTML-formatted lines separately
  * Add field's range as `lineRange` property to `StructuredFieldInfo`
    * this uses `PATH#line` or `PATH#line-line` format
    * `PATH` part is omitted if the field and struct exist in the same file
    * `PATH` is the full path in the repository
      * this could be relative path from the struct's file, but given it doesn't often happen in the current implementation (where the situation can happen only when the field is defined by `#include`), I'll leave it to other bug
      * once we support macro expansion, the situation will happen more, and we'll need to support relative path, in order to shorten the value
  * Rewrite the field sorting algorithm to use the `lineRange`, including:
    * use the start line for sorting
    * do not use line number when fields come from different file
  * Show the field definition lines in the table
    * This is same thing as source listing
  * Hide the field type column by default
  * Add column selector
    * controllable by both the query parameter and the checkbox
    * uses `show-cols` and `hide-cols` query parameter, with comma-separated values, instead of multiple `show-col`/`hide-col` parameters, given the named parameter doesn't support multiple occurrences in the query parser
    * show/hide is controlled by CSS classes, applied to the `#symbol-tree-table-list` div
  * Tweak the table styling:
    * use monospace font for field name and type
    * avoid line-wrapping for offset/size
    * make the border rendering compatible with showing/hiding columns

currently available on dev channel
https://dev.searchfox.org/mozilla-central/query/default?q=field-layout%3A%27mozilla%3A%3Adom%3A%3ABrowsingContext%27
