### PR TITLE
Bug 1904474 - Explicitly specify platform when running image

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -92,6 +92,7 @@ else
     # - `-p`: specifies the port mapping to expose the nginx web-server (when
     #   running; it doesn't automatically run!) on localhost port 16995.
     docker run \
+        --platform linux/amd64 \
         -it \
         --name $CONTAINER_NAME \
         --mount type=bind,source=${THIS_DIR},target=${INSIDE_CONTAINER_DIR} \


### PR DESCRIPTION
Now that the image is built as linux/amd64 running it without a platform argument emits a warning on aarch64 hosts. This silences the warning