### PR TITLE
Test result changes experienced on full reprovision.

### DIFF
--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_getter__json.snap
@@ -55,6 +55,7 @@ expression: "&to_value(scil).unwrap()"
           "slotOwner": {
             "slotKind": "getter",
             "slotLang": "cpp",
+            "implKind": null,
             "ownerLang": "idl",
             "sym": "XPIDL_nsIXPCTestObjectReadWrite_booleanProperty"
           },

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_attributes.idl/check_glob@booleanProperty_setter__json.snap
@@ -55,6 +55,7 @@ expression: "&to_value(scil).unwrap()"
           "slotOwner": {
             "slotKind": "setter",
             "slotLang": "cpp",
+            "implKind": null,
             "ownerLang": "idl",
             "sym": "XPIDL_nsIXPCTestObjectReadWrite_booleanProperty"
           },

--- a/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/xpctest_params.idl/check_glob@testOctet__json.snap
@@ -39,12 +39,14 @@ expression: "&to_value(scil).unwrap()"
             {
               "slotKind": "method",
               "slotLang": "js",
+              "implKind": null,
               "ownerLang": "idl",
               "sym": "#testOctet"
             },
             {
               "slotKind": "method",
               "slotLang": "cpp",
+              "implKind": null,
               "ownerLang": "idl",
               "sym": "_ZN16nsIXPCTestParams9TestOctetEhPhS0_"
             }
@@ -118,6 +120,7 @@ expression: "&to_value(scil).unwrap()"
           "slotOwner": {
             "slotKind": "method",
             "slotLang": "cpp",
+            "implKind": null,
             "ownerLang": "idl",
             "sym": "XPIDL_nsIXPCTestParams_testOctet"
           },

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@links_to_java_library_constructor__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@links_to_java_library_constructor__json.snap
@@ -63,7 +63,7 @@ expression: "&to_value(scil).unwrap()"
           "structured": 1,
           "pretty": "sample::JavaLibrary::<init>",
           "sym": "S_jvm_sample/JavaLibrary#<init>().",
-          "type_pretty": null,
+          "type_pretty": "public JavaLibrary()",
           "kind": "method",
           "subsystem": null,
           "parentsym": "S_jvm_sample/JavaLibrary#",

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@multiple_implements__json.snap
@@ -29,7 +29,7 @@ expression: "&to_value(scil).unwrap()"
           "structured": 1,
           "pretty": "sample::JavaLibrary::C",
           "sym": "S_jvm_sample/JavaLibrary#C#",
-          "type_pretty": null,
+          "type_pretty": "final class C",
           "kind": "class",
           "subsystem": null,
           "parentsym": "S_jvm_sample/JavaLibrary#",

--- a/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/JavaLibrary.java/check_glob@no_inverse_relationships__json.snap
@@ -47,7 +47,7 @@ expression: "&to_value(scil).unwrap()"
           "structured": 1,
           "pretty": "sample::JavaLibrary::A",
           "sym": "S_jvm_sample/JavaLibrary#A#",
-          "type_pretty": null,
+          "type_pretty": "interface A",
           "kind": "class",
           "subsystem": null,
           "parentsym": "S_jvm_sample/JavaLibrary#",


### PR DESCRIPTION
I just did a full local reprovision which included purging all docker containers and images as part of trying to make sure our Cargo.lock is up-to-date, and I ended up with these test changes which I'm going to merge.

I'm not quite sure how the xpctest attributes weren't up-to-date, but I think the changes make sense and could involve the difficulty of dealing with/juggling large patch-stacks with our snapshot mechanism and our current lack of CI.  When I was landing my hobby stack, I ended up basically doing an `edit` during a rebase for every single patch and re-running all tests to make sure the snapshots were updated at the right point.  I think this would be more painful now that we have Java build-steps that are (almost?) always re-run.

I believe the change in java is because a new release of scip-java has been made (https://bugzilla.mozilla.org/show_bug.cgi?id=1904166 is where :ryanvm will land it in m-c) and our [install steps don't mention a version](https://github.com/mozsearch/mozsearch/blob/c1afad3fac45665f803dc0c4fa551c635da96f6c/infrastructure/indexer-provision.sh#L56-L57) so the docker build process won't re-run that step unless we touch the file.  Ideally we would encode the version into the provisioning file to address that, although I also think we probably don't all regularly re-provision our docker images unless we need to (which I think is generally fine).

I will kick off a re-provisioning of the AWS images after this so they also end up on the same version of scip-java as us since https://phabricator.services.mozilla.com/D214660 is now approved and likely to land soon.