### PR TITLE
Bug 1904890 - Make build-codesearch.py resilient to previous failures.

### DIFF
--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os
 import sys
 import json
+import shutil
 
 from lib import run
 
@@ -26,6 +27,9 @@ def copy_objdir_files(dest_dir, config):
         f.write(data)
         f.close()
 
+# Make sure a failure during a prior invocation of this command does not break
+# our operation.  This step is not designed to run concurrently, so this is ok.
+shutil.rmtree('/tmp/dummy')
 os.mkdir('/tmp/dummy')
 
 config_fname = sys.argv[1]


### PR DESCRIPTION
If /tmp/dummy already exists, the script fails otherwise.  For hygiene / simplicity reasons I add a call to `shutil.rmtree` to clear out the dir before recreating it anew.  While we do include the tree name in all the paths we generate (except /tmp/livegrep.json), the invocations of `ln -s` will error if the link file already exist, so it is necessary to remove those.

Idiomatically, we use the `run` command to remove the tree at the end of the file, so that also could have made sense, but since we were using `os.mkdir` in the same location to make the directory, I went with using the relevant python command.