### PR TITLE
Bug 1904890 - Whoops, shutil.rmtree complains, just use rm -rf.

### DIFF
--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os
 import sys
 import json
-import shutil
 
 from lib import run
 
@@ -29,7 +28,7 @@ def copy_objdir_files(dest_dir, config):
 
 # Make sure a failure during a prior invocation of this command does not break
 # our operation.  This step is not designed to run concurrently, so this is ok.
-shutil.rmtree('/tmp/dummy')
+run(['rm', '-rf', '/tmp/dummy'])
 os.mkdir('/tmp/dummy')
 
 config_fname = sys.argv[1]


### PR DESCRIPTION
So I should have passed `ignore_errors=True` in the prior patch but I think, on balance, just doing the shell thing that most contributors will have awareness of is probably best after all.