### PR TITLE
Bug 1905328 - Robustify against symbol parsing errors

### DIFF
--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -1120,7 +1120,13 @@ fn analyze_using_scip(
                     // For occurences that don't match any symbol, we create a new structured fake,
                     // save it, and return it.
 
-                    let symbol = scip::symbol::parse_symbol(&occurrence.symbol).unwrap();
+                    let symbol = match scip::symbol::parse_symbol(&occurrence.symbol) {
+                        Ok(s) => s,
+                        Err(e) => {
+                            error!("{:?}", e);
+                            continue;
+                        }
+                    };
 
                     let symbol_info = analyse_symbol(&symbol, &lang, lang_name, subtree_name, &doc.relative_path, None, None);
 


### PR DESCRIPTION
I got an error like:

```
thread 'main' panicked at src/bin/scip-indexer.rs:1123:81:
called `Result::unwrap()` on an `Err` value: InvalidLocalSymbol("local izedMessage.")
```

I need to investigate the root cause (seems like bad scip data) but in the meantime it would be great if this didn't completely abort the indexer.