### PR TITLE
Emit structured info for EnumDecl

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1271,6 +1271,10 @@ public:
     J.arrayEnd();
     J.attributeEnd();
   }
+
+  void emitStructuredEnumInfo(llvm::json::OStream &J, const EnumDecl *ED) {
+    J.attribute("kind", "enum");
+  }
   
   void emitStructuredFunctionInfo(llvm::json::OStream &J, const FunctionDecl *decl) {
     emitBindingAttributes(J, *decl);
@@ -1426,6 +1430,8 @@ public:
 
     if (const RecordDecl *RD = dyn_cast<RecordDecl>(decl)) {
       emitStructuredRecordInfo(J, Loc, RD);
+    } else if (const EnumDecl *ED = dyn_cast<EnumDecl>(decl)) {
+      emitStructuredEnumInfo(J, ED);
     } else if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(decl)) {
       emitStructuredFunctionInfo(J, FD);
     } else if (const FieldDecl *FD = dyn_cast<FieldDecl>(decl)) {
@@ -1916,6 +1922,12 @@ public:
           findBindingToJavaClass(*AstContext, *D3);
           findBoundAsJavaClasses(*AstContext, *D3);
         }
+        emitStructuredInfo(Loc, D2);
+      }
+    }
+    if (EnumDecl *D2 = dyn_cast<EnumDecl>(D)) {
+      if (D2->isThisDeclarationADefinition() && !D2->isDependentType() &&
+          !TemplateStack) {
         emitStructuredInfo(Loc, D2);
       }
     }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap
@@ -541,7 +541,26 @@ expression: "&to_value(sttl).unwrap()"
         },
         "T_field_layout::field_type::Enum1": {
           "sym": "T_field_layout::field_type::Enum1",
-          "pretty": "T_field_layout::field_type::Enum1",
+          "pretty": "field_layout::field_type::Enum1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::Enum1",
+            "sym": "T_field_layout::field_type::Enum1",
+            "type_pretty": null,
+            "kind": "enum",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
           "jumps": {
             "def": "field-layout/field-type.cpp#19"
           }

--- a/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_show_hide__name__json.snap
+++ b/tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_show_hide__name__json.snap
@@ -541,7 +541,26 @@ expression: "&to_value(sttl).unwrap()"
         },
         "T_field_layout::field_type::Enum1": {
           "sym": "T_field_layout::field_type::Enum1",
-          "pretty": "T_field_layout::field_type::Enum1",
+          "pretty": "field_layout::field_type::Enum1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::Enum1",
+            "sym": "T_field_layout::field_type::Enum1",
+            "type_pretty": null,
+            "kind": "enum",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
           "jumps": {
             "def": "field-layout/field-type.cpp#19"
           }


### PR DESCRIPTION
This is a first attempt at emitting structured information for a new type of C++ entity, enumerations.

It's currently causing the below difference in the output of an existing test (as well as a similar one in the same directory), which I haven't accepted yet because I'm not sure yet if everything in this change is ok.

The appearance of the new `"meta"` field is expected (that's the point of the patch), but the following are open questions in my mind:

 1. Why is the value of the `"pretty"` key next to `"meta"` changing from `"T_field_layout::field_type::Enum1"` to `"field_layout::field_type::Enum1"`?
 2. In terms of the contents of the structured record, the patch is currently only filling out the `"kind"`, because that's the only thing needed by the semantic highlighting code that I'm using this for. Is that all right for now, or will other things get confused by the other fields in the record being null or empty?

```diff
$ diff -u8 tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap.new
--- tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap 2024-06-28 02:10:30.059569389 -0400
+++ tests/tests/checks/snapshots/fancy/format-symbol/field-layout/field-type.cpp/check_glob@field_layout__field_type__json.snap.new     2024-06-28 19:52:25.530934810 -0400
@@ -1,10 +1,11 @@
 ---
 source: tests/test_check_insta.rs
+assertion_line: 143
 expression: "&to_value(sttl).unwrap()"
 ---
 {
   "tables": [
     {
       "jumprefs": {
         "F_<T_field_layout::field_type::S>_hash_map_field": {
           "sym": "F_<T_field_layout::field_type::S>_hash_map_field",
@@ -536,17 +537,36 @@
           "sym": "T_field_layout::field_type::Container2",
           "pretty": "T_field_layout::field_type::Container2",
           "jumps": {
             "def": "field-layout/field-type.cpp#25"
           }
         },
         "T_field_layout::field_type::Enum1": {
           "sym": "T_field_layout::field_type::Enum1",
-          "pretty": "T_field_layout::field_type::Enum1",
+          "pretty": "field_layout::field_type::Enum1",
+          "meta": {
+            "structured": 1,
+            "pretty": "field_layout::field_type::Enum1",
+            "sym": "T_field_layout::field_type::Enum1",
+            "type_pretty": null,
+            "kind": "enum",
+            "subsystem": null,
+            "implKind": "",
+            "sizeBytes": null,
+            "ownVFPtrBytes": null,
+            "bindingSlots": [],
+            "ontologySlots": [],
+            "supers": [],
+            "methods": [],
+            "fields": [],
+            "overrides": [],
+            "props": [],
+            "variants": []
+          },
           "jumps": {
             "def": "field-layout/field-type.cpp#19"
           }
         },
         "T_field_layout::field_type::S": {
           "sym": "T_field_layout::field_type::S",
           "pretty": "field_layout::field_type::S",
           "meta": {
```