### PR TITLE
Bug 1905491 - Add webtest for Symbol and Copy as Markdown in panel

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -167,7 +167,7 @@ for repo in config['trees']:
     if config.get("allow_webtest"):
         location(f'/tests/webtest', [
             f'root {mozsearch_path};',
-            'add_header Cache-Control "must-revalidate";',
+            'add_header Cache-Control "no-cache";',
         ])
 
     location(f'/{repo}/pages/', [f'alias {index_path}/pages/;'])

--- a/tests/tests/files/webtest/CopyAsMarkdown.cpp
+++ b/tests/tests/files/webtest/CopyAsMarkdown.cpp
@@ -1,0 +1,24 @@
+// WARNING: The testcase relies on the line number for each item.
+
+// Comment at the top level.
+
+bool globalVariable = true;
+
+namespace copy_as_markdown {
+
+// Comment inside namespace.
+
+class CopyAsMarkdown {
+
+  // Comment inside class.
+
+  void SomeMethod() {
+
+    // Comment inside method.
+
+    bool LocalVariable = true;
+  }
+
+};
+
+};

--- a/tests/webtest/head.js
+++ b/tests/webtest/head.js
@@ -29,7 +29,40 @@ class TestHarness {
    *        The message for the log.
    */
   static log(type, msg) {
-    console.log(`${type} - ${msg}`);
+    let color = "";
+    switch (type) {
+      case "INFO":
+        // blue
+        color = "light-dark(#0000FF, #6060FF)";
+        break;
+      case "DEBUG":
+        // gray
+        color = "light-dark(#A0A0A0, #A0A0A0)";
+        break;
+      case "PASS":
+        // green
+        color = "light-dark(#00A600, #40D940)";
+        break;
+      case "FAIL":
+      case "STACK":
+        // red
+        color = "light-dark(#D00000, #FF4040)";
+        break;
+      case "TEST_START":
+      case "TEST_END":
+        // yellow
+        color = "light-dark(#B0A000, #D0D040)";
+        break;
+      default:
+        // cyan
+        color = "light-dark(#00A6B2, #60E5E5)";
+        break;
+        // unused
+        // magenta
+        // color = "light-dark(#B200B2, #D040D0)";
+    }
+    console.log(`%c${type}%c - ${msg}`,
+                `color: ${color};`, "");
     this.pendingLogs.push([type, `${msg}`]);
   }
 

--- a/tests/webtest/head.js
+++ b/tests/webtest/head.js
@@ -309,11 +309,28 @@ class TestUtils {
    *
    * @param {Element} elem
    *        The element to be clicked.
+   * @param {Object?} options
+   *        The options for the mouse event.
    */
-  static click(elem) {
+  static click(elem, options = { bubbles: true }) {
     TestHarness.debug(`Clicking`);
 
-    const ev = new MouseEvent("click", { bubbles: true });
+    const ev = new MouseEvent("click", options);
+    elem.dispatchEvent(ev);
+  }
+
+  /**
+   * Emulate keypress event.
+   *
+   * @param {Element} elem
+   *        The element for the event..
+   * @param {Object} options
+   *        The options for the event.
+   */
+  static keypress(elem, options) {
+    TestHarness.debug(`dispatching keypress event`);
+
+    const ev = new KeyboardEvent("keypress", options);
     elem.dispatchEvent(ev);
   }
 

--- a/tests/webtest/head.js
+++ b/tests/webtest/head.js
@@ -48,6 +48,10 @@ class TestHarness {
     this.log("INFO", msg);
   }
 
+  static debug(msg) {
+    this.log("DEBUG", msg);
+  }
+
   /**
    * Add a test function which is an asynchronous function.
    *
@@ -199,7 +203,7 @@ class TestUtils {
   static async loadPath(path) {
     const loadPromise = this.waitForLoad();
 
-    this.info(`Loading ${path}`);
+    TestHarness.debug(`Loading ${path}`);
 
     const frame = document.querySelector("#frame");
     frame.src = path;
@@ -216,16 +220,16 @@ class TestUtils {
    *          Resolves when the subsequent page load finishes.
    */
   static async waitForLoad() {
-    this.info(`Waiting for load`);
+    TestHarness.debug(`Waiting for load`);
 
     const frame = document.querySelector("#frame");
     const loadEvent = Promise.withResolvers();
     const pageshowEvent = Promise.withResolvers();
 
     frame.addEventListener("load", () => {
-      this.info(`Observed load event`);
+      TestHarness.debug(`Observed load event`);
       frame.contentWindow.addEventListener("pageshow", () => {
-        this.info(`Observed pageshow event`);
+        TestHarness.debug(`Observed pageshow event`);
         pageshowEvent.resolve();
       }, { once: true });
       loadEvent.resolve();
@@ -246,7 +250,7 @@ class TestUtils {
    *        The text for the element.
    */
   static setText(elem, text) {
-    this.info(`Setting text ${text}`);
+    TestHarness.debug(`Setting text ${text}`);
 
     elem.value = text;
     const ev = new InputEvent("input", { bubbles: true });
@@ -260,7 +264,7 @@ class TestUtils {
    *        The input element.
    */
   static clickCheckbox(elem) {
-    this.info(`Clicking checkbox`);
+    TestHarness.debug(`Clicking checkbox`);
 
     elem.checked = !elem.checked;
     const ev = new Event("change", { bubbles: true });
@@ -274,7 +278,7 @@ class TestUtils {
    *        The element to be clicked.
    */
   static click(elem) {
-    this.info(`Clicking`);
+    TestHarness.debug(`Clicking`);
 
     const ev = new MouseEvent("click", { bubbles: true });
     elem.dispatchEvent(ev);
@@ -289,7 +293,7 @@ class TestUtils {
    *        The value for the option.
    */
   static selectMenu(elem, value) {
-    this.info(`Selecting value ${value}`);
+    TestHarness.debug(`Selecting value ${value}`);
 
     elem.value = value;
     const ev = new Event("change", { bubbles: true });
@@ -325,7 +329,7 @@ class TestUtils {
    *         Rejects if timeout is exceeded or condition ever throws.
    */
   static async waitForCondition(condition, msg, interval=100, maxTries=50) {
-    this.info(`Waiting for condition: ${msg}`);
+    TestHarness.debug(`Waiting for condition: ${msg}`);
 
     for (let i = 0; i < maxTries; i ++) {
       if (condition()) {

--- a/tests/webtest/test_CopyAsMarkdown.js
+++ b/tests/webtest/test_CopyAsMarkdown.js
@@ -143,7 +143,7 @@ add_task(async function test_CopyAsMarkdown() {
      "[copy_as_markdown::CopyAsMarkdown::SomeMethod](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#19)",
      "Method symbol is copied instead of local variable symbol");
 
-  // Select the local variable
+  // Shift-select from the start of the class to the currently selected local variable.
   selectLine(11, { bubbles: true, shiftKey: true });
 
   ok(!filenameButton.disabled, "Filename Link should always be enabled");
@@ -166,7 +166,7 @@ add_task(async function test_CopyAsMarkdown() {
      "```",
      "Code block with multiple lines are copied");
 
-  // Select lines in side a block
+  // Select lines inside a block
   selectLine(15);
   selectLine(17, { bubbles: true, metaKey: true });
   selectLine(19, { bubbles: true, metaKey: true });

--- a/tests/webtest/test_CopyAsMarkdown.js
+++ b/tests/webtest/test_CopyAsMarkdown.js
@@ -1,0 +1,246 @@
+"use strict";
+
+function selectLine(lineno, options = undefined) {
+  const elem = frame.contentDocument.querySelector(`div[data-line-number="${lineno}"]`);
+
+  TestUtils.click(elem, options);
+}
+
+function sanitizeURL(text) {
+  return text.replace(/https?:\/\/[^\/]+\//, "BASE_URL/");
+}
+
+add_task(async function test_CopyAsMarkdown() {
+  await TestUtils.loadPath("/tests/source/webtest/CopyAsMarkdown.cpp");
+
+  // Hook the clipboard API for 2 reasons:
+  //   * in order to check the copied text
+  //   * given there's no user activity, the original writeText will throw
+  let copiedText = null;
+  frame.contentWindow.navigator.clipboard.writeText = async function(text) {
+    copiedText = text;
+  };
+
+  const filenameButton = frame.contentDocument.querySelector(`button[title="Filename Link"]`);
+  const symbolButton = frame.contentDocument.querySelector(`button[title="Symbol Link"]`);
+  const codeButton = frame.contentDocument.querySelector(`button[title="Code Block"]`);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(symbolButton.disabled, "Symbol Link should be disabled if nothing is selected");
+  ok(codeButton.disabled, "Code Block should be disabled if nothing is selected");
+
+  TestUtils.click(filenameButton);
+  is(sanitizeURL(copiedText),
+     "[CopyAsMarkdown.cpp](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp)",
+     "Filename is copied");
+
+  copiedText = "";
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "F" });
+  is(sanitizeURL(copiedText),
+     "[CopyAsMarkdown.cpp](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp)",
+     "Filename is copied");
+
+  copiedText = "*unmodified*";
+  TestUtils.click(symbolButton);
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Symbol Link button");
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "S" });
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Symbol Link accel");
+
+  TestUtils.click(codeButton);
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Code Block button");
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "C" });
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Code Block accel");
+
+  // Select the top level comment.
+  selectLine(3);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(symbolButton.disabled, "Symbol Link should be disabled if no symbol is selected");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  TestUtils.click(codeButton);
+  is(copiedText.replace(/https?:\/\/[^\/]+\//, "BASE_URL/"),
+     "BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#3\n" +
+     "```cpp\n" +
+     "// Comment at the top level.\n" +
+     "```",
+     "Code block with single line is copied");
+
+  copiedText = "";
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "C" });
+  is(copiedText.replace(/https?:\/\/[^\/]+\//, "BASE_URL/"),
+     "BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#3\n" +
+     "```cpp\n" +
+     "// Comment at the top level.\n" +
+     "```",
+     "Code block with single line is copied");
+
+  copiedText = "*unmodified*";
+  TestUtils.click(symbolButton);
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Symbol Link button");
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "S" });
+  is(copiedText, "*unmodified*", "Copy does not happen for disabled Symbol Link accel");
+
+  // Select the global variable.
+  selectLine(5);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when a symbol exists in the selected line");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  TestUtils.click(symbolButton);
+  is(sanitizeURL(copiedText),
+     "[globalVariable](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#5)",
+     "Global variable symbol is copied");
+
+  copiedText = "";
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "S" });
+  is(sanitizeURL(copiedText),
+     "[globalVariable](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#5)",
+     "Global variable symbol is copied");
+
+  // Select the namespace.
+
+  selectLine(7);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when the selected line is inside a nesting line");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  TestUtils.click(symbolButton);
+  is(sanitizeURL(copiedText),
+     "[copy_as_markdown](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#7)",
+     "Namespace symbol is copied");
+
+  // Select the comment inside namespace.
+  selectLine(9);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when the selected line is inside a nesting line");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  // Select the method
+  selectLine(15);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when the selected line is inside a nesting line");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  TestUtils.click(symbolButton);
+  is(sanitizeURL(copiedText),
+     "[copy_as_markdown::CopyAsMarkdown::SomeMethod](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#15)",
+     "Method symbol is copied");
+
+  // Select the local variable
+  selectLine(19);
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when the selected line is inside a nesting line");
+  ok(!codeButton.disabled, "Code Block should be enabled when a line is selected");
+
+  TestUtils.click(symbolButton);
+  is(sanitizeURL(copiedText),
+     "[copy_as_markdown::CopyAsMarkdown::SomeMethod](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#19)",
+     "Method symbol is copied instead of local variable symbol");
+
+  // Select the local variable
+  selectLine(11, { bubbles: true, shiftKey: true });
+
+  ok(!filenameButton.disabled, "Filename Link should always be enabled");
+  ok(!symbolButton.disabled, "Symbol Link should be enabled when the selected lines have symbol");
+  ok(!codeButton.disabled, "Code Block should be enabled when lines are selected");
+
+  TestUtils.click(codeButton);
+  is(copiedText.replace(/https?:\/\/[^\/]+\//, "BASE_URL/"),
+     "BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#11-19\n" +
+     "```cpp\n" +
+     "class CopyAsMarkdown {\n" +
+     "\n" +
+     "  // Comment inside class.\n" +
+     "\n" +
+     "  void SomeMethod() {\n" +
+     "\n" +
+     "    // Comment inside method.\n" +
+     "\n" +
+     "    bool LocalVariable = true;\n" +
+     "```",
+     "Code block with multiple lines are copied");
+
+  // Select lines in side a block
+  selectLine(15);
+  selectLine(17, { bubbles: true, metaKey: true });
+  selectLine(19, { bubbles: true, metaKey: true });
+
+  TestUtils.click(codeButton);
+  is(copiedText.replace(/https?:\/\/[^\/]+\//, "BASE_URL/"),
+     "BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#15,17,19\n" +
+     "```cpp\n" +
+     "void SomeMethod() {\n" +
+     "...\n" +
+     "  // Comment inside method.\n" +
+     "...\n" +
+     "  bool LocalVariable = true;\n" +
+     "```",
+     "Code block with multiple lines are copied with dedent");
+
+  // Disable accel
+
+  const accelCheckbox = frame.contentDocument.querySelector("#panel-accel-enable");
+  TestUtils.clickCheckbox(accelCheckbox);
+  registerCleanupFunction(() => {
+    TestUtils.clickCheckbox(accelCheckbox);
+  });
+
+  copiedText = "*unmodified*";
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "F" });
+  is(copiedText, "*unmodified*", "Copy does not happen if accel is disabled");
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "S" });
+  is(copiedText, "*unmodified*", "Copy does not happen if accel is disabled");
+  TestUtils.keypress(frame.contentDocument.documentElement, { bubbles: true, key: "C" });
+  is(copiedText, "*unmodified*", "Copy does not happen if accel is disabled");
+});
+
+add_task(async function test_CopyAsMarkdown_clicked() {
+  registerCleanupFunction(async () => {
+    await TestUtils.resetFeatureGate("fancyBar");
+  });
+
+  const tests = [
+    { value: "release", enabled: false },
+    { value: "beta", enabled: false },
+    { value: "alpha", enabled: true },
+  ];
+  for (const { value, enabled } of tests) {
+    await TestUtils.setFeatureGate("fancyBar", value);
+    await TestUtils.loadPath("/tests/source/webtest/CopyAsMarkdown.cpp");
+
+    const symbolButton = frame.contentDocument.querySelector(`button[title="Symbol Link"]`);
+
+    let copiedText = null;
+    frame.contentWindow.navigator.clipboard.writeText = async function(text) {
+      copiedText = text;
+    };
+
+    selectLine(5);
+
+    TestUtils.click(symbolButton);
+    is(sanitizeURL(copiedText),
+       "[globalVariable](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#5)",
+       "Global variable symbol is copied");
+
+    const methodName = frame.contentDocument.querySelector(`span.syn_def[data-symbols="_ZN16copy_as_markdown14CopyAsMarkdown10SomeMethodEv"]`);
+    TestUtils.click(methodName);
+
+    copiedText = "*unmodified*";
+    TestUtils.click(symbolButton);
+    if (enabled) {
+      is(sanitizeURL(copiedText),
+         "[copy_as_markdown::CopyAsMarkdown::SomeMethod](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#5,15)",
+         "Method symbol is copied if clicked-symbol is enabled, with global variable line number in URL");
+    } else {
+      is(sanitizeURL(copiedText),
+         "[globalVariable](BASE_URL/tests/source/webtest/CopyAsMarkdown.cpp#5)",
+         "Global variable symbol is copied if clicked-symbol is disabled");
+    }
+  }
+});

--- a/tests/webtest/test_FieldLayoutContextMenu.js
+++ b/tests/webtest/test_FieldLayoutContextMenu.js
@@ -11,6 +11,8 @@ function findClassLayoutMenuItem(menu) {
 }
 
 add_task(async function test_FieldLayoutContextMenu() {
+  // Enabled by default on the test config.
+  await TestUtils.resetFeatureGate("semanticInfo");
   await TestUtils.loadPath("/tests/source/field-layout/field-type.cpp");
 
   const className = frame.contentDocument.querySelector(`span.syn_def[data-symbols="T_field_layout::field_type::S"]`);

--- a/tests/webtest/test_SymbolSectionInPanel.js
+++ b/tests/webtest/test_SymbolSectionInPanel.js
@@ -1,0 +1,84 @@
+"use strict";
+
+function selectLine(lineno, options = undefined) {
+  const elem = frame.contentDocument.querySelector(`div[data-line-number="${lineno}"]`);
+
+  TestUtils.click(elem, options);
+}
+
+add_task(async function test_SymbolSectionInPanel() {
+  await TestUtils.resetFeatureGate("fancyBar");
+  await TestUtils.loadPath("/tests/source/webtest/CopyAsMarkdown.cpp");
+
+  // Hook the clipboard API for 2 reasons:
+  //   * in order to check the copied text
+  //   * given there's no user activity, the original writeText will throw
+  let copiedText = null;
+  frame.contentWindow.navigator.clipboard.writeText = async function(text) {
+    copiedText = text;
+  };
+
+  const symBox = frame.contentDocument.querySelector(".selected-symbol-box");
+
+  is(symBox.textContent,
+     "(no symbol clicked)",
+     "No symbol is shown when nothing is selected");
+
+  // Select the top level comment.
+  selectLine(3);
+
+  is(symBox.textContent,
+     "(no symbol clicked)",
+     "No symbol is shown when nothing is selected");
+
+  // Select the global variable.
+  selectLine(5);
+
+  is(symBox.textContent,
+     "globalVariable",
+     "Selected global variable name is shown");
+
+  // Select class name.
+  selectLine(11);
+
+  is(symBox.textContent,
+     "copy_as_markdown::CopyAsMarkdown",
+     "Selected class's qualified name is shown");
+
+  // Click method name.
+    const methodName = frame.contentDocument.querySelector(`span.syn_def[data-symbols="_ZN16copy_as_markdown14CopyAsMarkdown10SomeMethodEv"]`);
+  TestUtils.click(methodName);
+
+  is(symBox.textContent,
+     "copy_as_markdown::CopyAsMarkdown::SomeMethod",
+     "Selected method's qualified name is shown");
+
+  const copyButton = frame.contentDocument.querySelector(".copy-box .indicator");
+  TestUtils.click(copyButton);
+  is(copiedText,
+     "copy_as_markdown::CopyAsMarkdown::SomeMethod",
+     "The selected symbol is copied");
+});
+
+add_task(async function test_SymbolSectionInPanel_gate() {
+  registerCleanupFunction(async () => {
+    await TestUtils.resetFeatureGate("fancyBar");
+  });
+
+  const tests = [
+    { value: "release", shown: false },
+    { value: "beta", shown: false },
+    { value: "alpha", shown: true },
+  ];
+  for (const { value, shown } of tests) {
+    await TestUtils.setFeatureGate("fancyBar", value);
+    await TestUtils.loadPath("/tests/source/webtest/CopyAsMarkdown.cpp");
+
+    const symBox = frame.contentDocument.querySelector(".selected-symbol-box");
+    if (shown) {
+      ok(!!symBox, "Symbol section should be shown if enabled");
+    } else {
+      ok(!symBox, "Symbol section should be shown if disabled");
+    }
+  }
+});

--- a/tools/src/cmd_pipeline/cmd_webtest.rs
+++ b/tools/src/cmd_pipeline/cmd_webtest.rs
@@ -29,9 +29,11 @@ pub struct WebtestCommand {
 fn print_log(ty: &str, msg: String) {
     let mut stderr = StandardStream::stderr(ColorChoice::Always);
 
+    let mut spec = ColorSpec::new();
+
     let color = match ty {
         "INFO" => Color::Blue,
-        "DEBUG" => Color::Cyan,
+        "DEBUG" => Color::Black,
         "PASS" => Color::Green,
         "FAIL" => Color::Red,
         "STACK" => Color::Red,
@@ -39,8 +41,16 @@ fn print_log(ty: &str, msg: String) {
         "TEST_END" => Color::Yellow,
         _ => Color::Cyan,
     };
+    spec.set_fg(Some(color));
 
-    stderr.set_color(ColorSpec::new().set_fg(Some(color))).unwrap();
+    match ty {
+        "DEBUG" => {
+            spec.set_dimmed(true);
+        },
+        _ => {},
+    }
+
+    stderr.set_color(&spec).unwrap();
     write!(&mut stderr, "{}", ty).unwrap();
 
     stderr.reset().unwrap();


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1905491

This does the following:
  * Use DEBUG type for logging for TestUtils internal and make it less appealing than other INFO
  * Add no-cache header to webtest files
  * Apply color to logging in web console [1], this helps debugging tests on browser
  * Add tests for Copy as Markdown menu items and accel keys
  * Add tests for Symbol section
  
[1] colored messages, compatible with both light and dark theme
![log](https://github.com/mozsearch/mozsearch/assets/6299746/3320e920-9ea8-4cfc-a317-ade8c1e13613)
