### PR TITLE
Bug 1858453 - support using an objdir for clang-plugin via VPATH

### DIFF
--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -11,6 +11,10 @@ build: libclang-index-plugin.so
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
+from-clangd/%.o: from-clangd/%.cpp
+	mkdir -p from-clangd
+	$(CXX) $(CXXFLAGS) -c $^ -o $@
+
 libclang-index-plugin.so: FileOperations.o StringOperations.o BindingOperations.o MozsearchIndexer.o from-clangd/HeuristicResolver.o
 	$(CXX) $(LDFLAGS) $^ -o $@ -lclangASTMatchers
 


### PR DESCRIPTION
In order to do a try run of indexing mozsearch, this change needs to be landed so that we can use a VPATH to do an objdir-based build.  This does work locally both for indexing mozsearch (by clobbering the Makefile into place) as well as for building the clang-plugin for that indexing.

The stanza in mozsearch/build ends up looking like:
```make
CLANG_PLUGIN_DIR=$FILES_ROOT/clang-plugin
make -f $CLANG_PLUGIN_DIR/Makefile VPATH=$CLANG_PLUGIN_DIR CC="$CC" CXX="$CXX"
```