### PR TITLE
Bug 1858453 - Index mozsearch and mozsearch-mozilla

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,30 @@ serve-mozilla-repo: check-in-vagrant build-clang-plugin build-rust-tools
 	/vagrant/infrastructure/web-server-setup.sh ~/mozilla-config just-mc.json ~/mozilla-index ~
 	/vagrant/infrastructure/web-server-run.sh ~/mozilla-config ~/mozilla-index ~
 
+# This builds both mozsearch and mozsearch-mozilla using the trees as they exist
+# on github rather than your local copies.  This differs from the
+# "build-searchfox-repo" make target which uses your current tree, which can be
+# useful but where anything that isn't checked-in can cause failures.  (That is,
+# if you run `git status` and anything is modified, output-files can crash when
+# the local checked-out status does not have the same number of lines as the
+# blame repo says there should be.)
+#
+# Notes:
+# - If you want to use a modified version of mozsearch-mozilla, such as one
+#   checked out under "config" in the check-out repo, you can create a symlink
+#   in the VM's home directory via `pushd ~; ln -s /vagrant/config mozsearch-config`.
+build-mozsearch-repo: check-in-vagrant build-clang-plugin build-rust-tools
+	[ -e ~/mozsearch-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/mozsearch-config
+	mkdir -p ~/mozsearch-index
+	/vagrant/infrastructure/indexer-setup.sh ~/mozsearch-config just-mozsearch.json ~/mozsearch-index
+	/vagrant/infrastructure/indexer-run.sh ~/mozsearch-config ~/mozsearch-index
+	/vagrant/infrastructure/web-server-setup.sh ~/mozsearch-config just-mozsearch.json ~/mozsearch-index ~
+	/vagrant/infrastructure/web-server-run.sh ~/mozsearch-config ~/mozsearch-index ~
+
+serve-mozsearch-repo: check-in-vagrant build-clang-plugin build-rust-tools
+	/vagrant/infrastructure/web-server-setup.sh ~/mozsearch-config just-mozsearch.json ~/mozsearch-index ~
+	/vagrant/infrastructure/web-server-run.sh ~/mozsearch-config ~/mozsearch-index ~
+
 # Notes:
 # - If you want to use a modified version of mozsearch-mozilla, such as one
 #   checked out under "config" in the check-out repo, you can create a symlink

--- a/docs/newrepo.md
+++ b/docs/newrepo.md
@@ -5,14 +5,14 @@ that you have set up the Vagrant VM as documented in the [top level README](../R
 
 ## 1. Create a tarball with the git repo
 
-This is as simple as running `git clone` to clone the repo locally, and then running `tar` to make a tarball.
-Note that it's best to do this inside your mozsearch folder so that it's automatically mirrored inside the
-vagrant VM instance for other steps below. For example:
+This is as simple as running `git clone` to clone the repo locally, and then running `tar` and `lz4`
+to make an lz4-compressed tarball.  Note that it's best to do this inside your mozsearch folder so
+that it's automatically mirrored inside the vagrant VM instance for other steps below. For example:
 
 ```
 cd $MOZSEARCH
 git clone https://github.com/mozilla/glean git
-tar cf glean.tar git
+tar cf - git | lz4 - glean.tar.lz4
 ```
 
 If you're cloning a hg repo, use cinnabar:
@@ -23,7 +23,7 @@ pushd git
 git branch -m master
 git config fetch.prune true
 popd
-tar cf version-control-tools.tar git
+tar cf - git | lz4 - version-control-tools.tar.lz4
 ```
 
 ## 2. Create a tarball of the blame repo
@@ -40,7 +40,7 @@ pushd tools && cargo +nightly build --release && popd
 mkdir blame
 pushd blame && git init . && popd
 tools/target/release/build-blame ./git ./blame # this might take a while, depending on your repo size
-tar cf glean-blame.tar blame
+tar cf - blame | lz4 - glean-blame.tar.lz4
 ```
 
 ## 3. Upload the two tarballs to the S3 bucket
@@ -53,8 +53,8 @@ and testing the setup.
 
 ```
 cd $MOZSEARCH
-infrastructure/aws/upload.py ./glean.tar searchfox.repositories glean.tar
-infrastructure/aws/upload.py ./glean-blame.tar searchfox.repositories glean-blame.tar
+infrastructure/aws/upload.py ./glean.tar.lz4 searchfox.repositories glean.tar.lz4
+infrastructure/aws/upload.py ./glean-blame.tar.lz4 searchfox.repositories glean-blame.tar.lz4
 ```
 
 The above commands don't provide progress output. You can equivalently do the upload with

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -128,22 +128,6 @@ done
 # Leave the objdir now that we're done normalizing build-dir paths.
 popd
 
-
-## Normalize the save-analysis paths.
-# Normalize the source root off to make source paths relative.
-NORMALIZE_EXPR='s#/vagrant/tests/tests/files/##g'
-# Normalize the OBJDIR root off to make relative __GENERATED__ paths.  OBJDIR
-# will look like "/home/vagrant/index/tests/objdir" and so will not overlap
-# at all with the source path, prefix-wise.
-NORMALIZE_EXPR+=";s#$OBJDIR#__GENERATED__#g"
-# Apply the equivalent of the __RUST_BUILD_SCRIPT__ transform from the preceding
-# section.  We're including the __GENERATED__ in the input and output for extra
-# paranoia.
-NORMALIZE_EXPR+=';s#"__GENERATED__/(debug|release)/build/([^/]+)-[0-9a-f]+/out/([^"]+)"#"__GENERATED__/__RUST_BUILD_SCRIPT__/\2/\3"#g'
-
-# parallel -q quotes the semicolons
-find $OBJDIR -type f -name "*.json" | parallel -q --halt now,fail=1 sed --in-place -Ee "$NORMALIZE_EXPR" {}
-
 # Firefox generates files named something like Configure.cpp during
 # the build process, but their source files are not around by the time
 # we run the analysis. crossref.rs needs to be able to deal with this

--- a/tests/tests/files/Cargo.toml
+++ b/tests/tests/files/Cargo.toml
@@ -3,6 +3,7 @@ name = "files"
 version = "0.1.0"
 authors = ["Emilio Cobos Álvarez <emilio@crisal.io>"]
 build = "build.rs"
+edition = "2018"
 
 [lib]
 name = "simple"

--- a/tests/tests/files/build.rs
+++ b/tests/tests/files/build.rs
@@ -6,5 +6,5 @@ use std::io::Write;
 fn main() {
     let path = Path::new(&env::var_os("OUT_DIR").unwrap()).join("generated.rs");
     let mut file = File::create(path).unwrap();
-    file.write_all("#[derive(Copy, Clone)]\npub struct GeneratedType {\n  pub some_num: i32,\n}".as_bytes()).unwrap();
+    file.write_all("#[derive(Copy, Clone)]\n#[allow(dead_code)]\npub struct GeneratedType {\n  pub some_num: i32,\n}".as_bytes()).unwrap();
 }

--- a/tests/tests/files/simple.rs
+++ b/tests/tests/files/simple.rs
@@ -2,6 +2,7 @@ extern crate test_rust_dependency;
 
 use std::path::{Path, PathBuf};
 use test_rust_dependency::{MyType, MyTrait};
+#[allow(unused_imports)]
 use test_rust_dependency::my_mod::MyOtherType;
 
 /* A grab-bug of rust code to exercise the searchfox indexer.
@@ -13,6 +14,7 @@ mod build_time_generated {
 }
 
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct Loader {
     #[allow(unused)]
     whatever: build_time_generated::GeneratedType,
@@ -28,11 +30,13 @@ impl MyTrait for Loader {
     }
 }
 
+#[allow(dead_code, non_snake_case)]
 extern "C" fn WithoutNoMangle() {}
 
 #[no_mangle]
 extern "C" fn WithNoMangle() {}
 
+#[allow(dead_code)]
 impl Loader {
     pub fn new(deps_dir: PathBuf) -> Self {
         Self {
@@ -59,11 +63,13 @@ impl Loader {
     }
 }
 
+#[allow(dead_code)]
 enum AnEnum {
     Variant1,
     Variant2,
 }
 
+#[allow(dead_code)]
 fn simple_fn() {
     let my_enum = AnEnum::Variant1;
     match my_enum {
@@ -72,11 +78,13 @@ fn simple_fn() {
     }
 }
 
+#[allow(dead_code)]
 struct MultiParams<'a, T> {
     myvar: T,
     another_var: &'a u32,
 }
 
+#[allow(dead_code)]
 impl<'a, T> MultiParams<'a, T> {
     fn fn_with_params_in_signature(&self) {
     }


### PR DESCRIPTION
Try run for config1.json with trees is up on asuth.searchfox.org :
- https://asuth.searchfox.org/mozsearch/source/
- https://asuth.searchfox.org/mozsearch-tests/source/
- https://asuth.searchfox.org/mozsearch-mozilla/source/

The commit to quiet the test repo warnings works locally but the try run still generated the warnings because it was checking out the current status of the master branch which did not include the fixes, of course.