### PR TITLE
Bug 1908197 - Add role for items inside tree switcher menu

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -989,6 +989,7 @@ var TreeSwitcherMenu = new (class TreeSwitcherMenu extends ContextMenuBase {
 
         const list = document.createElement("ul");
         list.id = groupListId;
+        list.setAttribute("role", "group");
         for (const item of group.items) {
           const label = item.label ? item.label : item.value;
           const tree = item.value;
@@ -1001,11 +1002,13 @@ var TreeSwitcherMenu = new (class TreeSwitcherMenu extends ContextMenuBase {
               + document.location.hash,
             attrs: {
               "data-tree": tree,
+              role: "menuitem",
             },
             useKeys: true,
           });
 
           li.setAttribute("aria-labelledby", groupId);
+          li.setAttribute("role", "none");
 
           list.append(li);
           column.push({


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1908197

This does:
  * Add `role=group` for `ul` for each group in Tree Switcher  (Firefox, Thunderbird)
  * Add `role=menuitem` for `a` for each item
  * Add `role=none` for `li` for each item