### PR TITLE
Bug 1906580 - Use consistent padding for .content box

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -276,6 +276,10 @@ table {
   width: 100%;
   overflow: auto;
 }
+table.folder-content {
+  margin: 0.5rem 2rem;
+  width: calc(100% - 4rem);
+}
 table#file {
   width: 100%;
 }
@@ -603,9 +607,6 @@ tr.after-context-line + tr.before-context-line {
   font-weight: bold;
 }
 .content {
-  padding: 1rem 2rem;
-}
-.content.source-listing {
   padding: 0.5rem 0rem;
 }
 
@@ -1416,6 +1417,11 @@ g.true-diag g.node polygon {
 }
 
 /* Field Layout */
+
+#symbol-tree-table-col-selector,
+#symbol-tree-table-list {
+  padding: 0 2rem;
+}
 
 #symbol-tree-table-list .type-cell {
   display: none;


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1906580

Instead of applying wider padding for non-source-listing cases, add padding/margin for items inside it when necessary, so that the breadcrumbs is positioned in the same place across pages.

Spacing for the following are kept by adding extra padding/margin:
  * directory listing table
  * field layout table

Spacing for the top page and the settings page are reduced, but they should already have sufficient padding:

Spacing for other queries (call graph, use graph) are also reduced, but they have spacing in its own.