### PR TITLE
Bug 1909096 - Fix selector for tree switcher

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -1044,7 +1044,7 @@ var TreeSwitcherMenu = new (class TreeSwitcherMenu extends ContextMenuBase {
 
   focusCurrentTree() {
     const tree = this.getCurrentTree();
-    const item = this.menu.querySelector(`a[data-tree="${tree}"`);
+    const item = this.menu.querySelector(`a[data-tree="${tree}"]`);
     if (!item) {
       this.menu.focus();
     }


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1909096

This does:
  * fix the selector syntax to be standard compliant
