### PR TITLE
Bug 1906580 - followuo: Add the padding back to the search results.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -479,6 +479,15 @@ body {
 }
 /* Search results */
 
+.search-result-header {
+  padding: 0 2rem;
+}
+
+table.results {
+  margin: 0.5rem 2rem;
+  width: calc(100% - 4rem);
+}
+
 /* Make context lines more subtle. */
 .results tr.before-context-line,
 .results tr.after-context-line {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -662,15 +662,19 @@ function populateResults(data, full, jumpToSingle) {
     } catch {}
   }
 
+  const header = document.createElement("div");
+  header.classList.add("search-result-header");
+  items.push(header);
+
   if (!fileCount) {
     const div = document.createElement("div");
     div.textContent = "No results for current query.";
-    items.push(div);
+    header.append(div);
   } else {
     if (count) {
       const div = document.createElement("div");
       div.textContent = `Number of results: ${count} (maximum is around 4000)`;
-      items.push(div);
+      header.append(div);
     }
   }
 
@@ -680,7 +684,7 @@ function populateResults(data, full, jumpToSingle) {
     b.textContent = "Warning";
     div.append(b);
     div.append(`: The following limits were hit in your search: ${limits_hit.join(", ")}`);
-    items.push(div);
+    header.append(div);
   }
 
   let timeoutWarning = null;
@@ -690,7 +694,7 @@ function populateResults(data, full, jumpToSingle) {
     b.textContent = "Warning";
     div.append(b);
     div.append(": Results may be incomplete due to server-side search timeout!");
-    items.push(div);
+    header.append(div);
   }
 
   if (fileCount) {


### PR DESCRIPTION
Addresses the issue mentioned in https://github.com/mozsearch/mozsearch/pull/790#issuecomment-2245693054

This does the following:
  * Add `div.search-result-header` box for the number of result and warning message etc, with padding
  * Add margin to the search result table
