### PR TITLE
Bug 1910230 - Do not try to access blame data when no blame info is provided.

### DIFF
--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -70,7 +70,8 @@ var BlamePopup = new (class BlamePopup {
   async update() {
     // If there's no current element, just bail.
     if (!this.blameElement) {
-      return this.hide();
+      this.hide();
+      return;
     }
 
     // Latch the current element in case by the time our fetch comes back it's

--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -100,7 +100,11 @@ var BlamePopup = new (class BlamePopup {
       } else {
         content = await this.generateCoverageContent(elt);
         // This obviously assumes the known hard-coded DOM from `format.rs`.
-        hoverRightOfElt = elt.parentElement.nextElementSibling.firstElementChild;
+        hoverRightOfElt = elt.parentElement.nextElementSibling?.firstElementChild;
+      }
+
+      if (!hoverRightOfElt) {
+        return;
       }
 
       let rect = hoverRightOfElt.getBoundingClientRect();


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1910230

This does:
  * skip blame info popup handling when there's no blame info
  * minor style fix