### PR TITLE
Bug 1906144 - Show class layout menu item for empty subclass.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -716,7 +716,7 @@ var ContextMenu = new (class ContextMenu extends ContextMenuBase {
         if (Settings.semanticInfo.enabled) {
           for (const jumpref of diagrammableSyms) {
             if ((jumpref?.meta?.kind === "class" || jumpref?.meta?.kind === "struct") &&
-                jumpref?.meta?.fields?.length) {
+                (jumpref?.meta?.fields?.length || jumpref?.meta?.supers?.length)) {
               let queryString = `field-layout:'${jumpref.pretty}'`;
               searchMenuItems.push({
                 html: this.fmt("Class layout of <strong>_</strong>", jumpref.pretty),

--- a/tests/tests/files/field-layout/empty-subclass.cpp
+++ b/tests/tests/files/field-layout/empty-subclass.cpp
@@ -1,0 +1,21 @@
+#include <stdint.h>
+
+namespace field_layout {
+
+namespace empty_subclass {
+
+struct S {
+  uint32_t x;
+};
+
+struct T : public S {
+};
+
+T f() {
+  T t;
+  return t;
+}
+
+}
+
+}

--- a/tests/webtest/test_FieldLayoutContextMenu.js
+++ b/tests/webtest/test_FieldLayoutContextMenu.js
@@ -66,3 +66,31 @@ add_task(async function test_FieldLayoutContextMenu_gate() {
     }
   }
 });
+
+add_task(async function test_FieldLayoutContextMenu_emptySubClass() {
+  // Enabled by default on the test config.
+  await TestUtils.resetFeatureGate("semanticInfo");
+  await TestUtils.loadPath("/tests/source/field-layout/empty-subclass.cpp");
+
+  const className = frame.contentDocument.querySelector(`span.syn_def[data-symbols="T_field_layout::empty_subclass::T"]`);
+  TestUtils.click(className);
+
+  const menu = frame.contentDocument.querySelector("#context-menu");
+  await waitForShown(menu, "Context menu is shown for symbol click");
+
+  let layoutRow = findClassLayoutMenuItem(menu);
+  ok(!!layoutRow, "Class layout menu item exists for empty subclass");
+  is(layoutRow.textContent, "Class layout of field_layout::empty_subclass::T",
+     "Menu item shows the qualified class name");
+
+  const loadPromise = TestUtils.waitForLoad();
+  const link = layoutRow.querySelector(".contextmenu-link");
+  TestUtils.click(link);
+  await loadPromise;
+  ok(frame.contentDocument.location.href.includes("/query/"),
+     "Navigated to query page");
+
+  const query = frame.contentDocument.querySelector("#query");
+  is(query.value, "field-layout:'field_layout::empty_subclass::T'",
+     "Query for field layout is set");
+});


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1906144

This does:
  * Show "Show class layout of" menu item for class which has superclasses
    * this is shown regardless of the number of superclass fields for simplicity
