### PR TITLE
Bug 1910254 - Support generated files in fetch_raw_source

### DIFF
--- a/tests/tests/build
+++ b/tests/tests/build
@@ -155,5 +155,17 @@ $CXX -DTEST_MACRO1 -DTEST_MACRO2 $BUILD_TIME_FILE -std=c++17 -c -o $OBJDIR/Build
 rm BuildTimeFile.cpp
 
 GENERATED_FILE=$OBJDIR/GeneratedFile.cpp
-echo "int main() { return 0; }" > $GENERATED_FILE
+cat <<EOF > $GENERATED_FILE
+namespace generated {
+struct GeneratedStruct {
+  int x;
+  int y;
+};
+}
+int main() {
+  generated::GeneratedStruct s;
+  s.x = 10;
+  return s.x;
+}
+EOF
 $CXX -DTEST_MACRO1 -DTEST_MACRO2 $GENERATED_FILE -std=c++17 -c -o $OBJDIR/GeneratedFile.o -Wall

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
@@ -88,7 +88,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/__GENERATED__/GeneratedFile.cpp" class="mimetype-fixed-container mimetype-icon-cpp">GeneratedFile.cpp</a></td>
           <td class="description"><a href="/tests/source/__GENERATED__/GeneratedFile.cpp" title=""></td>
-          <td><a href="/tests/source/__GENERATED__/GeneratedFile.cpp">25</a></td>
+          <td><a href="/tests/source/__GENERATED__/GeneratedFile.cpp">143</a></td>
         </tr>
 
         <tr>

--- a/tests/webtest/test_FieldLayoutForGenerated.js
+++ b/tests/webtest/test_FieldLayoutForGenerated.js
@@ -1,0 +1,10 @@
+"use strict";
+
+add_task(async function test_FieldLayoutForGenerated() {
+  const sym = "generated::GeneratedStruct";
+
+  await TestUtils.loadPath(`/tests/query/default?q=field-layout:'${sym}'`);
+
+  const symInLine = document.querySelectorAll(`span.syn_def[data-symbols="F_<T_generated::GeneratedStruct>_x"]`);
+  ok(!!symInLine, "Symbol in the definition line exists");
+});

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -192,7 +192,12 @@ impl AbstractServer for LocalIndex {
 
     async fn fetch_raw_source(&self, sf_path: &str) -> Result<String> {
         let norm_path = self.normalize_and_validate_path(sf_path)?;
-        let full_path = format!("{}/{}", self.config_paths.files_path, norm_path);
+        let full_path = if norm_path.starts_with("__GENERATED__/") {
+            format!("{}/{}", self.config_paths.objdir_path,
+                    norm_path.strip_prefix("__GENERATED__/").unwrap())
+        } else {
+            format!("{}/{}", self.config_paths.files_path, norm_path)
+        };
 
         let mut f = File::open(full_path).await?;
         let mut raw_str = String::new();

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -898,7 +898,12 @@ impl ClassMap {
             return Ok(());
         }
 
-        let (lines, sym_json) = server.fetch_formatted_lines(path).await?;
+        let result = server.fetch_formatted_lines(path).await;
+        if result.is_err() {
+            return Ok(());
+        }
+
+        let (lines, sym_json) = result.unwrap();
 
         let syms: serde_json::Result<HashMap<String, Value>> = from_str(&sym_json);
         match syms {


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1910254

The issue is caused by accessing missing file while fetching the source lines, due to mis-handling `__GENERATED__/*` path.

This patch stack does:
  * Ignore missing file in field layout table, so that similar case results in empty line cell, instead of error page
  * Support fetching generated files
