### PR TITLE
Bug 1904320 - Support interface mixin

### DIFF
--- a/scripts/idl-analyze.sh
+++ b/scripts/idl-analyze.sh
@@ -71,5 +71,6 @@ cat $INDEX_ROOT/idl-files | \
 
 cat $INDEX_ROOT/webidl-files | \
     $MOZSEARCH_PATH/scripts/webidl-analyze.py \
-    $INDEX_ROOT $FILES_ROOT $INDEX_ROOT/analysis /tmp
+    $INDEX_ROOT $FILES_ROOT $INDEX_ROOT/analysis /tmp \
+    $WEBIDL_BINDINGS_LOCAL_PATH
 echo $?

--- a/scripts/load-vars.sh
+++ b/scripts/load-vars.sh
@@ -24,6 +24,7 @@ export BLAME_ROOT=$(jq -r ".trees[\"${TREE_NAME}\"].git_blame_path" ${CONFIG_FIL
 export HISTORY_ROOT=$(jq -r ".trees[\"${TREE_NAME}\"].history_path" ${CONFIG_FILE})
 export TREE_ON_ERROR=$(jq -r ".trees[\"${TREE_NAME}\"].on_error" ${CONFIG_FILE})
 export TREE_CACHING=$(jq -r ".trees[\"${TREE_NAME}\"].cache" ${CONFIG_FILE})
+export WEBIDL_BINDINGS_LOCAL_PATH=$(jq -r ".trees[\"${TREE_NAME}\"].webidl_binding_local_path" ${CONFIG_FILE})
 
 handle_tree_error() {
     local msg=$1

--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -221,7 +221,7 @@ def read_cpp_analysis_one(path, cpp_symbols):
             builder.maybe_add_impl(j['sym'], j.get('contextsym', ''))
 
 
-def read_cpp_analysis(index_root, local_path, bindings_local_path):
+def read_cpp_analysis(analysis_root, local_path, bindings_local_path):
     '''Read analysis files for given WebIDL file and collect C++ symbols
     for generated code.'''
 
@@ -233,13 +233,12 @@ def read_cpp_analysis(index_root, local_path, bindings_local_path):
 
     if bindings_local_path:
         # Override the paths for bindings for testing.
-        analysis_dir = os.path.join(index_root, 'analysis')
-        p = os.path.join(analysis_dir, bindings_local_path, 'include', header_name)
+        p = os.path.join(analysis_root, bindings_local_path, 'include', header_name)
         read_cpp_analysis_one(p, cpp_symbols)
-        p = os.path.join(analysis_dir, bindings_local_path, 'src', cpp_name)
+        p = os.path.join(analysis_root, bindings_local_path, 'src', cpp_name)
         read_cpp_analysis_one(p, cpp_symbols)
     else:
-        generated_dir = os.path.join(index_root, 'analysis', '__GENERATED__')
+        generated_dir = os.path.join(analysis_root, '__GENERATED__')
         header_local_path = os.path.join('dist', 'include', 'mozilla', 'dom', header_name)
         cpp_local_path = os.path.join('dom', 'bindings', cpp_name)
 
@@ -820,7 +819,7 @@ def preprocess(lines):
     return result
 
 
-def parse_files(index_root, files_root, cache_dir, bindings_local_path):
+def parse_files(index_root, files_root, analysis_root, cache_dir, bindings_local_path):
     '''Parse all WebIDL files and load corresponding C++ analysis files.'''
 
     parser = WebIDL.Parser(cache_dir)
@@ -835,7 +834,7 @@ def parse_files(index_root, files_root, cache_dir, bindings_local_path):
 
         lines = preprocess(open(fname).readlines())
         text = ''.join(lines)
-        cpp_analysis_map[local_path] = read_cpp_analysis(index_root, local_path, bindings_local_path)
+        cpp_analysis_map[local_path] = read_cpp_analysis(analysis_root, local_path, bindings_local_path)
 
         try:
             parser.parse(text, local_path)
@@ -907,6 +906,6 @@ bindings_local_path = sys.argv[5]
 if bindings_local_path == 'null':
     bindings_local_path = None
 
-productions = parse_files(index_root, files_root, cache_dir, bindings_local_path)
+productions = parse_files(index_root, files_root, analysis_root, cache_dir, bindings_local_path)
 handle_productions(productions)
 write_files(analysis_root)

--- a/tests/config.json
+++ b/tests/config.json
@@ -11,6 +11,7 @@
       "cache": "everything",
       "index_path": "$WORKING/tests",
       "files_path": "$WORKING/tests/files",
+      "webidl_binding_local_path": "webidl/bindings",
       "objdir_path": "$WORKING/tests/objdir",
       "wpt_root": "testing/web-platform",
       "codesearch_path": "$WORKING/tests/livegrep.idx",

--- a/tests/tests/checks/snapshots/analysis/webidl/interface-mixin.webidl/check_glob@webidl_interface_mixin__json.snap
+++ b/tests/tests/checks/snapshots/analysis/webidl/interface-mixin.webidl/check_glob@webidl_interface_mixin__json.snap
@@ -70,12 +70,6 @@ expression: "&json_results"
     "implKind": "idl",
     "bindingSlots": [
       {
-        "slotKind": "class",
-        "slotLang": "cpp",
-        "ownerLang": "idl",
-        "sym": "NS_mozilla::dom::TestInterfaceMixin_Binding"
-      },
-      {
         "slotKind": "interface_name",
         "slotLang": "js",
         "ownerLang": "idl",

--- a/tests/tests/files/webidl/BindingTest.webidl
+++ b/tests/tests/files/webidl/BindingTest.webidl
@@ -1,0 +1,18 @@
+interface BindingTest {
+  constructor();
+
+  const unsigned long CONST_1 = 10;
+
+  attribute any attr1;
+
+  any method1();
+};
+
+dictionary BindingTestDict {
+  unsigned long prop1;
+};
+
+enum BindingTestEnum {
+  "variant1",
+  "variant2",
+};

--- a/tests/tests/files/webidl/BindingTestMixed1.webidl
+++ b/tests/tests/files/webidl/BindingTestMixed1.webidl
@@ -1,0 +1,7 @@
+interface BindingTestMixed1 {
+  constructor();
+
+  any ownedMethod1();
+};
+
+BindingTestMixed1 includes BindingTestMixin;

--- a/tests/tests/files/webidl/BindingTestMixed2.webidl
+++ b/tests/tests/files/webidl/BindingTestMixed2.webidl
@@ -1,0 +1,7 @@
+interface BindingTestMixed2 {
+  constructor();
+
+  any ownedMethod2();
+};
+
+BindingTestMixed2 includes BindingTestMixin;

--- a/tests/tests/files/webidl/BindingTestMixin.webidl
+++ b/tests/tests/files/webidl/BindingTestMixin.webidl
@@ -1,0 +1,7 @@
+interface mixin BindingTestMixin {
+  const unsigned long MIXIN_CONST = 10;
+
+  attribute any mixinAttr;
+
+  any mixinMethod();
+};

--- a/tests/tests/files/webidl/bindings/include/BindingTestBinding.h
+++ b/tests/tests/files/webidl/bindings/include/BindingTestBinding.h
@@ -1,0 +1,22 @@
+#include <stdint.h>
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTest_Binding {
+
+static const uint32_t CONST_1 = 10;
+
+} // BindingTest_Binding
+
+struct BindingTestDict {
+  unsigned long mProp1;
+};
+
+enum class BindingTestEnum {
+  Variant1,
+  Variant2,
+};
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/include/BindingTestMixed1Binding.h
+++ b/tests/tests/files/webidl/bindings/include/BindingTestMixed1Binding.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTestMixed1_Binding {
+
+static const uint32_t MIXIN_CONST = 10;
+
+} // BindingTestMixed1_Binding
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/include/BindingTestMixed2Binding.h
+++ b/tests/tests/files/webidl/bindings/include/BindingTestMixed2Binding.h
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTestMixed2_Binding {
+
+static const uint32_t MIXIN_CONST = 10;
+
+} // BindingTestMixed2_Binding
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/src/BindingTest.h
+++ b/tests/tests/files/webidl/bindings/src/BindingTest.h
@@ -1,0 +1,13 @@
+namespace mozilla {
+namespace dom {
+
+class BindingTest {
+ public:
+  void GetAttr1() {}
+  void SetAttr1() {}
+
+  void Method1() {}
+};
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/src/BindingTestBinding.cpp
+++ b/tests/tests/files/webidl/bindings/src/BindingTestBinding.cpp
@@ -1,0 +1,39 @@
+#include "../include/BindingTestBinding.h"
+#include "./BindingTest.h"
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTest_Binding {
+
+static bool
+_constructor() {
+  return true;
+}
+
+static bool
+get_attr1(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTest*>(void_self);
+  self->GetAttr1();
+  return true;
+}
+
+static bool
+set_attr1(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTest*>(void_self);
+  self->SetAttr1();
+  return true;
+}
+
+static bool
+method1(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTest*>(void_self);
+  self->Method1();
+  return true;
+}
+
+} // BindingTest_Binding
+
+} // namespace dom
+} // namespace mozilla
+

--- a/tests/tests/files/webidl/bindings/src/BindingTestMixed1.h
+++ b/tests/tests/files/webidl/bindings/src/BindingTestMixed1.h
@@ -1,0 +1,15 @@
+namespace mozilla {
+namespace dom {
+
+class BindingTestMixed1 {
+ public:
+  void OwnedMethod1() {}
+
+  void GetMixinAttr() {}
+  void SetMixinAttr() {}
+
+  void MixinMethod() {}
+};
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/src/BindingTestMixed1Binding.cpp
+++ b/tests/tests/files/webidl/bindings/src/BindingTestMixed1Binding.cpp
@@ -1,0 +1,46 @@
+#include "../include/BindingTestMixed1Binding.h"
+#include "./BindingTestMixed1.h"
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTestMixed1_Binding {
+
+static bool
+_constructor() {
+  return true;
+}
+
+static bool
+ownedMethod1(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed1*>(void_self);
+  self->OwnedMethod1();
+  return true;
+}
+
+static bool
+get_mixinAttr(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed1*>(void_self);
+  self->GetMixinAttr();
+  return true;
+}
+
+static bool
+set_mixinAttr(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed1*>(void_self);
+  self->SetMixinAttr();
+  return true;
+}
+
+static bool
+mixinMethod(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed1*>(void_self);
+  self->MixinMethod();
+  return true;
+}
+
+} // BindingTestMixed1_Binding
+
+} // namespace dom
+} // namespace mozilla
+

--- a/tests/tests/files/webidl/bindings/src/BindingTestMixed2.h
+++ b/tests/tests/files/webidl/bindings/src/BindingTestMixed2.h
@@ -1,0 +1,15 @@
+namespace mozilla {
+namespace dom {
+
+class BindingTestMixed2 {
+ public:
+  void OwnedMethod2() {}
+
+  void GetMixinAttr() {}
+  void SetMixinAttr() {}
+
+  void MixinMethod() {}
+};
+
+} // namespace dom
+} // namespace mozilla

--- a/tests/tests/files/webidl/bindings/src/BindingTestMixed2Binding.cpp
+++ b/tests/tests/files/webidl/bindings/src/BindingTestMixed2Binding.cpp
@@ -1,0 +1,46 @@
+#include "../include/BindingTestMixed2Binding.h"
+#include "./BindingTestMixed2.h"
+
+namespace mozilla {
+namespace dom {
+
+namespace BindingTestMixed2_Binding {
+
+static bool
+_constructor() {
+  return true;
+}
+
+static bool
+ownedMethod2(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed2*>(void_self);
+  self->OwnedMethod2();
+  return true;
+}
+
+static bool
+get_mixinAttr(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed2*>(void_self);
+  self->GetMixinAttr();
+  return true;
+}
+
+static bool
+set_mixinAttr(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed2*>(void_self);
+  self->SetMixinAttr();
+  return true;
+}
+
+static bool
+mixinMethod(void* void_self) {
+  auto* self = static_cast<mozilla::dom::BindingTestMixed2*>(void_self);
+  self->MixinMethod();
+  return true;
+}
+
+} // BindingTestMixed2_Binding
+
+} // namespace dom
+} // namespace mozilla
+

--- a/tests/webtest-config.json
+++ b/tests/webtest-config.json
@@ -11,6 +11,7 @@
       "cache": "everything",
       "index_path": "$WORKING/tests",
       "files_path": "$WORKING/tests/files",
+      "webidl_binding_local_path": "webidl/bindings",
       "objdir_path": "$WORKING/tests/objdir",
       "wpt_root": "testing/web-platform",
       "codesearch_path": "$WORKING/tests/livegrep.idx",

--- a/tests/webtest/test_WebIDLBindings.js
+++ b/tests/webtest/test_WebIDLBindings.js
@@ -82,3 +82,53 @@ add_task(async function test_WebIDLBindings() {
     }
   }
 });
+
+add_task(async function test_WebIDLBindingsWithMixin() {
+  await TestUtils.loadPath("/tests/source/webidl/BindingTestMixin.webidl");
+
+  const tests = [
+    {
+      sym: "WEBIDL_BindingTestMixin_MIXIN_CONST",
+      items: [
+        "mozilla::dom::BindingTestMixed1_Binding::MIXIN_CONST",
+        "mozilla::dom::BindingTestMixed2_Binding::MIXIN_CONST",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTestMixin_mixinAttr",
+      items: [
+        "mozilla::dom::BindingTestMixed1_Binding::get_mixinAttr",
+        "mozilla::dom::BindingTestMixed1_Binding::set_mixinAttr",
+        "mozilla::dom::BindingTestMixed1::GetMixinAttr",
+        "mozilla::dom::BindingTestMixed1::SetMixinAttr",
+        "mozilla::dom::BindingTestMixed2_Binding::get_mixinAttr",
+        "mozilla::dom::BindingTestMixed2_Binding::set_mixinAttr",
+        "mozilla::dom::BindingTestMixed2::GetMixinAttr",
+        "mozilla::dom::BindingTestMixed2::SetMixinAttr",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTestMixin_mixinMethod",
+      items: [
+        "mozilla::dom::BindingTestMixed1_Binding::mixinMethod",
+        "mozilla::dom::BindingTestMixed1::MixinMethod",
+        "mozilla::dom::BindingTestMixed2_Binding::mixinMethod",
+        "mozilla::dom::BindingTestMixed2::MixinMethod",
+      ],
+    },
+  ];
+  for (const { sym, items } of tests) {
+    const elem = frame.contentDocument.querySelector(`span.syn_def[data-symbols="${sym}"]`);
+    ok(!!elem, `Symbol element exists for ${sym}`);
+
+    TestUtils.click(elem);
+
+    const menu = frame.contentDocument.querySelector("#context-menu");
+    await waitForShown(menu, `Context menu is shown when clicking ${sym} symbol`);
+
+    for (const item of items) {
+      const row = findMenuItem(menu, item);
+      ok(!!row, `Menu item for ${item} exists`);
+    }
+  }
+});

--- a/tests/webtest/test_WebIDLBindings.js
+++ b/tests/webtest/test_WebIDLBindings.js
@@ -1,0 +1,84 @@
+"use strict";
+
+function findMenuItem(menu, text) {
+  for (const row of menu.querySelectorAll(".contextmenu-row")) {
+    if (row.textContent.includes(text)) {
+      return row;
+    }
+  }
+
+  return null;
+}
+
+add_task(async function test_WebIDLBindings() {
+  await TestUtils.loadPath("/tests/source/webidl/BindingTest.webidl");
+
+  const tests = [
+    {
+      sym: "WEBIDL_BindingTest",
+      items: [
+        "mozilla::dom::BindingTest_Binding",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTest_constructor",
+      items: [
+        "mozilla::dom::BindingTest_Binding::_constructor",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTest_CONST_1",
+      items: [
+        "mozilla::dom::BindingTest_Binding::CONST_1",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTest_attr1",
+      items: [
+        "mozilla::dom::BindingTest_Binding::get_attr1",
+        "mozilla::dom::BindingTest_Binding::set_attr1",
+        "mozilla::dom::BindingTest::GetAttr1",
+        "mozilla::dom::BindingTest::SetAttr1",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTest_method1",
+      items: [
+        "mozilla::dom::BindingTest_Binding::method1",
+        "mozilla::dom::BindingTest::Method1",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTestDict",
+      items: [
+        "mozilla::dom::BindingTestDict",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTestDict_prop1",
+      items: [
+        "mozilla::dom::BindingTestDict::mProp1",
+      ],
+    },
+    {
+      sym: "WEBIDL_BindingTestEnum",
+      items: [
+        "mozilla::dom::BindingTestEnum",
+      ],
+    },
+  ];
+  for (const { sym, items } of tests) {
+    const elem = frame.contentDocument.querySelector(`span.syn_def[data-symbols="${sym}"]`);
+    ok(!!elem, `Symbol element exists for ${sym}`);
+
+    TestUtils.click(elem);
+
+    const menu = frame.contentDocument.querySelector("#context-menu");
+    await waitForShown(menu, `Context menu is shown when clicking ${sym} symbol`);
+
+    for (const item of items) {
+      const row = findMenuItem(menu, item);
+      ok(!!row, `Menu item for ${item} exists`);
+    }
+  }
+});


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1904320

This does:
  * Add testcase for existing WebIDL bindings, with pseudo binding code
    * Add testing-only config entry `webidl_binding_local_path` to override the webidl binding path, to simplify the automated tests
  * Support indexing interface mixins, with associating to the binding code for the interfaces that include the mixin