### PR TITLE
Bug 1910266 - Do not index files with non-ASCII characters in filename

### DIFF
--- a/scripts/find-repo-files.py
+++ b/scripts/find-repo-files.py
@@ -48,6 +48,12 @@ for line in lines:
         continue
     path = path.decode()
 
+    if path.startswith('"') and path.endswith('"'):
+        # `git ls-files` prints files with non-ASCII escaped and quoted.
+        # Do not index them for now.
+        # Each indexer script needs to be tweaked to support them.
+        continue
+
     fullpath = os.path.join(tree_repo, path)
 
     elts = path.split('/')


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1910266

Most of the indexer scripts and server scripts don't actually expect non-ASCII (especially JS indexer), and each of them needs to be tweaked to properly support non-ASCII.
This makes the indexer simply ignore files with non-ASCII filename, to suppress warnings, as a first step.