### PR TITLE
Bug 1910277 - Support spaces in filename for JS files

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -2440,14 +2440,18 @@ while (true) {
 
   resetState();
 
-  let sourcePath;
-  [fileIndex, sourcePath] = line.split(/ /);
+  const m = line.match(/^([^ ]+) (.+)$/);
+  if (!m) {
+    continue;
+  }
+  fileIndex = m[1];
+  const sourcePath = m[2];
 
   localFile = localRoot + "/" + sourcePath;
   const analysisFile = analysisRoot + "/" + sourcePath;
 
   const origOut = os.file.redirect(analysisFile);
-  
+
   printFileTarget(sourcePath);
 
   analyzeFile(localFile);

--- a/tests/tests/files/js/with space.js
+++ b/tests/tests/files/js/with space.js
@@ -1,0 +1,1 @@
+var SymbolInFilenameWithSpace = 10;

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -1,0 +1,15 @@
+add_task(async function test_SpaceInFilename() {
+  await TestUtils.loadPath("/");
+  TestUtils.shortenSearchTimeouts();
+
+  const query = frame.contentDocument.querySelector("#query");
+  TestUtils.setText(query, "SymbolInFilenameWithSpace");
+
+  const content = frame.contentDocument.querySelector("#content");
+
+  await waitForCondition(
+    () => content.textContent.includes("Core code (1 lines") &&
+      content.textContent.includes("Definitions (SymbolInFilenameWithSpace) (1 lines") &&
+      content.textContent.includes("var SymbolInFilenameWithSpace"),
+    "symbol in file with space in filename matches as definition");
+});


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1910277

This does:
  * in JS indexer, properly split the lines passed from `parallel` command, so that all characters after the first space becomes the filename.