### PR TITLE
Bug 1910279 - Properly handle non-ASCII filenames in JS indexer

### DIFF
--- a/scripts/find-repo-files.py
+++ b/scripts/find-repo-files.py
@@ -23,7 +23,7 @@ except FileNotFoundError:
 
 tree_config = config['trees'][tree_name]
 tree_repo = tree_config['files_path']
-lines = run(['git', 'ls-files', '--recurse-submodules'], cwd=tree_repo).splitlines()
+lines = run(['git', 'ls-files', '-z', '--recurse-submodules'], cwd=tree_repo).split(b'\0')
 if len(lines) == 0:
     # find . -type f -printf '%P\n'
     lines = run(['/usr/bin/find', '.', '-type', 'f', '-printf', '%P\n'], cwd=tree_repo).splitlines()
@@ -47,12 +47,6 @@ for line in lines:
     if not path:
         continue
     path = path.decode()
-
-    if path.startswith('"') and path.endswith('"'):
-        # `git ls-files` prints files with non-ASCII escaped and quoted.
-        # Do not index them for now.
-        # Each indexer script needs to be tweaked to support them.
-        continue
 
     fullpath = os.path.join(tree_repo, path)
 

--- a/scripts/find-repo-files.py
+++ b/scripts/find-repo-files.py
@@ -48,6 +48,16 @@ for line in lines:
         continue
     path = path.decode()
 
+    # NOTE: `path` is raw filename, which can contain any character allowed by
+    # the OS and the file system.
+    #
+    # For safety, ignore the path with characters that may have special meaning
+    # in the HTML context or the shell command context.
+    # They are not allowed on Windows, but allowed on other OS.
+    for c in ['"', '<', '>', '\\']:
+        if c in path:
+            continue
+
     fullpath = os.path.join(tree_repo, path)
 
     elts = path.split('/')

--- a/scripts/html-analyze.sh
+++ b/scripts/html-analyze.sh
@@ -13,6 +13,9 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
+# Required by std::wcsrtombs, used in os.file.redirect.
+export LC_CTYPE=C.UTF-8
+
 # Add line number for the file list with `nl`, which is used as a global
 # fileIndex and used for local variable symbols.
 #

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -2428,6 +2428,17 @@ function resetState() {
   Analyzer.resetState();
 }
 
+
+function decodeUTF8(s) {
+  if (s.match(/[^\x00-\x7F]/)) {
+    return decodeURIComponent(s.replace(/./g, m => {
+      return "%" + m.charCodeAt(0).toString(16).padStart(2, '0');
+    }));
+  }
+
+  return s;
+}
+
 mozSearchRoot = scriptArgs[0];
 const localRoot = scriptArgs[1];
 const analysisRoot = scriptArgs[2];
@@ -2445,7 +2456,10 @@ while (true) {
     continue;
   }
   fileIndex = m[1];
-  const sourcePath = m[2];
+
+  // readline() returns raw byte sequence.
+  // The filename is UTF-8 encoded in the js-files file.
+  const sourcePath = decodeUTF8(m[2]);
 
   localFile = localRoot + "/" + sourcePath;
   const analysisFile = analysisRoot + "/" + sourcePath;

--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -13,6 +13,9 @@ fi
 CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
+# Required by std::wcsrtombs, used in os.file.redirect.
+export LC_CTYPE=C.UTF-8
+
 # Add line number for the file list with `nl`, which is used as a global
 # fileIndex, and used for local variable symbols.
 #

--- a/tests/tests/files/js/with-UTF8-ファイル.js
+++ b/tests/tests/files/js/with-UTF8-ファイル.js
@@ -1,0 +1,1 @@
+var SymbolInFilenameWithUTF8 = 20;

--- a/tests/webtest/test_UTF8InFilename.js
+++ b/tests/webtest/test_UTF8InFilename.js
@@ -1,0 +1,36 @@
+add_task(async function test_UTF8InFilename_Search() {
+  await TestUtils.loadPath("/");
+  TestUtils.shortenSearchTimeouts();
+
+  const query = frame.contentDocument.querySelector("#query");
+  TestUtils.setText(query, "SymbolInFilenameWithUTF8");
+
+  const content = frame.contentDocument.querySelector("#content");
+
+  await waitForCondition(
+    () => content.textContent.includes("Core code (1 lines") &&
+      content.textContent.includes("Definitions (SymbolInFilenameWithUTF8) (1 lines") &&
+      content.textContent.includes("var SymbolInFilenameWithUTF8"),
+    "symbol in file with space in filename matches as definition");
+});
+
+add_task(async function test_UTF8InFilename_DirAndFile() {
+  await TestUtils.loadPath("/tests/source/js");
+
+  const link = frame.contentDocument.querySelector(`.folder-content a[href*="with-UTF8-"]`);
+  ok(!!link, "UTF-8 filename is listed");
+  is(link.getAttribute("href"), "/tests/source/js/with-UTF8-ファイル.js",
+     "UTF-8 path is used with raw text");
+
+  const loadPromise = TestUtils.waitForLoad();
+  TestUtils.click(link);
+  await loadPromise;
+
+  ok(frame.contentDocument.location.href.includes(
+       "with-UTF8-%E3%83%95%E3%82%A1%E3%82%A4%E3%83%AB.js"),
+     "Navigated to the file page with URL-encoded path");
+
+  const breadcrumbs = frame.contentDocument.querySelector(`.breadcrumbs`);
+  ok(breadcrumbs.textContent.includes("/js/with-UTF8-ファイル.js"),
+     "UTF-8 path is written in breadcrumbs with raw text");
+});


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1910279

This does:
  * Handle non-ASCII filenames in `js-analyze.js`:
    * input: decode the raw bytecode sequence from `readline()`
    * output: set `LC_TYPE` environment variable to make `std::wcsrtombs` called inside `os.file.redirect` work
  * Put raw non-ASCII paths into `*-files` files
    * things required escape/quote are re-enabled (they're skipped by [bug 1910279](https://bugzilla.mozilla.org/show_bug.cgi?id=1910279))
    * paths with special characters are still skipped
