### PR TITLE
Update log analyzer script for replace-aliases.sh, extend indexer runtime limit to 12 hours from 10 hours

### DIFF
--- a/infrastructure/aws/trigger_indexer.py
+++ b/infrastructure/aws/trigger_indexer.py
@@ -8,7 +8,7 @@ from trigger_common import TriggerCommandBase
 # dynamically generated hard-coded python script thing.
 class TriggerIndexerCommand(TriggerCommandBase):
     def __init__(self):
-        super().__init__('indexer', 'index.sh', 10)
+        super().__init__('indexer', 'index.sh', 12)
 
     def script_args_after_branch_and_channel(self, args):
         return '''"{mozsearch_repo}" "{config_repo}" config "{config_input}"'''.format(

--- a/scripts/indexer-logs-analyze.sh
+++ b/scripts/indexer-logs-analyze.sh
@@ -27,7 +27,7 @@ PARSE_EXPR+=' script == "compress-outputs.sh" or script == "check-index.sh" or'
 PARSE_EXPR+=' script == "html-analyze.sh" or script == "css-analyze.sh", args[1], tree) as tree'
 # scripts where the 1st argument has a path segment which is the tree name we
 # can use.  We split the first argument above to be `args0` for this.
-PARSE_EXPR+=' | if(script == "process-chrome-map.py", args0[2], tree) as tree'
+PARSE_EXPR+=' | if(script == "process-chrome-map.py" or script == "replace-aliases.sh", args0[2], tree) as tree'
 
 # - Grep the log in Perl mode looking for the pattern where a "date" invocation
 #   is followed by a script invocation from mozsearch/scripts.


### PR DESCRIPTION
I will regenerate the lambda tarball for config4 and upload it, as I believe that's necessary for us to see this change actually take effect in production.  As noted in the bug, we could do more to make this something that's specified by the config file.  Although there's always a trade-off in fail-safes like this where the more complexity you add, the more possible it is to fail in a way that the fail-safe never gets put in place.