### PR TITLE
Bug 1911051 - Fix replace-aliases.py not to filter out all records with URL_ substring match

### DIFF
--- a/scripts/replace-aliases.py
+++ b/scripts/replace-aliases.py
@@ -50,12 +50,20 @@ def replace_aliases(path, alias_map, reverse_map):
     with open(fullpath, "r") as f:
         for line in f:
             line = line.rstrip()
+
+            # Filter out definitely non-target lines.
             if "URL_" not in line and "RELPATH" not in line:
                 lines.append(line)
                 continue
 
             datum = json.loads(line)
             sym = datum["sym"]
+
+            # Actually test if the symbol is the target.
+            if not sym.startswith("URL_") and sym != "RELPATH":
+                lines.append(line)
+                continue
+
             handled_syms = set()
 
             has_alias = True

--- a/tests/tests/checks/inputs/analysis/cpp/URL_sym.cpp/URL_sym__json
+++ b/tests/tests/checks/inputs/analysis/cpp/URL_sym.cpp/URL_sym__json
@@ -1,0 +1,1 @@
+filter-analysis cpp/URL_sym.cpp -i url_sym::S::scriptURL_

--- a/tests/tests/checks/snapshots/analysis/cpp/URL_sym.cpp/check_glob@URL_sym__json.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/URL_sym.cpp/check_glob@URL_sym__json.snap
@@ -1,0 +1,32 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00006:10-20",
+    "source": 1,
+    "syntax": "def,field",
+    "type": "int32_t",
+    "pretty": "field url_sym::S::scriptURL_",
+    "sym": "F_<T_url_sym::S>_scriptURL_"
+  },
+  {
+    "loc": "00006:10-20",
+    "structured": 1,
+    "pretty": "url_sym::S::scriptURL_",
+    "sym": "F_<T_url_sym::S>_scriptURL_",
+    "kind": "field",
+    "parentsym": "T_url_sym::S"
+  },
+  {
+    "loc": "00006:10-20",
+    "target": 1,
+    "kind": "def",
+    "pretty": "url_sym::S::scriptURL_",
+    "sym": "F_<T_url_sym::S>_scriptURL_",
+    "context": "url_sym::S",
+    "contextsym": "T_url_sym::S",
+    "peekRange": "6-6"
+  }
+]

--- a/tests/tests/files/cpp/URL_sym.cpp
+++ b/tests/tests/files/cpp/URL_sym.cpp
@@ -1,0 +1,9 @@
+#include <stdint.h>
+
+namespace url_sym {
+
+struct S {
+  int32_t scriptURL_;
+};
+
+}


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1911051

`replace-aliases.py` tries to replace records with `URL_*` symbols and `RELPATH` symbols,
but I forgot to actually test the symbol after a preliminary test to avoid JSON parse.

This patch does:
  * Add the test for the symbol to actually filter out non-target