### PR TITLE
Bug 1911131 - Forward all relevant jumpref data to SYM_INFO.

### DIFF
--- a/tests/tests/build
+++ b/tests/tests/build
@@ -66,7 +66,8 @@ CPP_FILES=$(
 find . -name '*.cpp' | \
   grep -v /ipdl/ | \
   grep -v /field-layout/ | \
-  grep -v /macro.cpp
+  grep -v /macro.cpp | \
+  grep -v /templates6.cpp
 )
 
 ## C++ Build Stuff
@@ -81,6 +82,7 @@ done
 MULTI_CPP_FILES=$(
   find ./field-layout/ -name '*.cpp'
   echo "macro.cpp"
+  echo "templates6.cpp"
 )
 
 for PLATFORM in linux64 macosx64 win64

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -630,6 +630,18 @@ Spread over multiple lines.
         </tr>
 
         <tr>
+          <td><a href="/tests/source/templates6.cpp" class="mimetype-fixed-container mimetype-icon-cpp">templates6.cpp</a></td>
+          <td class="description"><a href="/tests/source/templates6.cpp" title=""></td>
+          <td><a href="/tests/source/templates6.cpp">142</a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/templates6.h" class="mimetype-fixed-container mimetype-icon-h">templates6.h</a></td>
+          <td class="description"><a href="/tests/source/templates6.h" title=""></td>
+          <td><a href="/tests/source/templates6.h">67</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/test_custom_element_base.xul" class="mimetype-fixed-container mimetype-icon-xul">test_custom_element_base.xul</a></td>
           <td class="description"><a href="/tests/source/test_custom_element_base.xul" title=""></td>
           <td><a href="/tests/source/test_custom_element_base.xul">14637</a></td>

--- a/tests/tests/files/templates6.cpp
+++ b/tests/tests/files/templates6.cpp
@@ -1,0 +1,8 @@
+#include "templates6.h"
+
+template <typename T> void multiplexer(T t) { overloaded(t); }
+
+int main() {
+  multiplexer(1);
+  multiplexer('a');
+}

--- a/tests/tests/files/templates6.h
+++ b/tests/tests/files/templates6.h
@@ -1,0 +1,2 @@
+inline void overloaded(int i) {}
+inline void overloaded(char c) {}

--- a/tests/webtest/test_OverloadInTemplate.js
+++ b/tests/webtest/test_OverloadInTemplate.js
@@ -1,0 +1,29 @@
+"use strict";
+
+function goToDefinitionMenuItems(menu) {
+  const items = []
+
+  for (const row of menu.querySelectorAll(".contextmenu-row")) {
+    if (row.textContent.startsWith("Go to definition of ")) {
+      items.push(row)
+    }
+  }
+
+  return items;
+}
+
+add_task(async function test_OverloadedFunctionInTemplateContextMenuHasMultipleDefs() {
+  await TestUtils.loadPath("/tests/source/templates6.cpp");
+
+  const overloaded = frame.contentDocument.querySelector("span[data-symbols*=overloaded]");
+  TestUtils.click(overloaded);
+
+  const menu = frame.contentDocument.querySelector("#context-menu");
+  await waitForShown(menu, "Context menu is shown");
+
+  const symbols = overloaded.dataset.symbols.split(',');
+  is(symbols.length, 2, "2 symbols are available");
+
+  const goToRows = goToDefinitionMenuItems(menu);
+  is(goToRows.length, 2, "2 go to rows are available");
+});

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -207,11 +207,11 @@ pub fn format_code(
                         nesting_stack.push(a);
                     }
 
-                    // XXX This 0-reference thing should be abandoned.  This was an attempt to be
-                    // be more efficient in the face of cross-platform locals frequently ending up
-                    // providing us with 4 different symbol names
-                    if a.sym.len() >= 1 && !generated_sym_info.contains_key(&a.sym[0]) {
-                        let sym = &a.sym[0];
+                    for sym in &a.sym {
+                        if generated_sym_info.contains_key(sym) {
+                            continue;
+                        }
+
                         // Pass-through local symbol information that won't be available from the
                         // cross-reference database because it was marked no_crossref.  This is only
                         // intended to cover type information about the locals; other info like srcsym


### PR DESCRIPTION
When populating SYM_INFO, only the first symbol of merged symbols was output to HTML. This led to missing “Go to definition” entries in some cases involving macros or templates.

For templates, see the new test files templates6.h/templates6.cpp and the corresponding webtest.

For macros this is especially visible in the atom_list.h use-case, except in our test repo because atom_list.h doesn't go through the merge-analyses step.