### PR TITLE
Bug 1911062 - Move BlamePopup from `<html>` to `<body>`.

### DIFF
--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -10,7 +10,7 @@ var BlamePopup = new (class BlamePopup {
     this.popup.id = "blame-popup";
     this.popup.className = "blame-popup";
     this.popup.style.display = "none";
-    document.documentElement.appendChild(this.popup);
+    document.body.appendChild(this.popup);
 
     // The .blame-strip element for which blame is currently being displayed.
     this._blameElement = null;


### PR DESCRIPTION
The BlamePopup was living outside `<body>`, as pointed out in https://github.com/mozsearch/mozsearch/pull/679#issuecomment-2245545358 this caused surprising behaviour, like test in the BlamePopup not being selected on Ctrl+A.