### PR TITLE
Bug 1912078 - Failed attempts to make config5 / wubkat happy

### DIFF
--- a/infrastructure/aws/index.sh
+++ b/infrastructure/aws/index.sh
@@ -20,7 +20,7 @@ CONFIG_REPO_URL=$4
 CONFIG_REPO_PATH=$(readlink -f $5)
 CONFIG_FILE_NAME="$6"
 
-EC2_INSTANCE_ID=$(wget -q -O - http://instance-data/latest/meta-data/instance-id)
+EC2_INSTANCE_ID=$(ec2metadata --instance-id)
 
 # Find the revisions we actually checked out so that we can pass these to the
 # web server because indexer and web server are a matched pair and we don't

--- a/infrastructure/aws/rebuild-blame.sh
+++ b/infrastructure/aws/rebuild-blame.sh
@@ -41,5 +41,5 @@ $AWS_ROOT/send-done-email.py "[$CHANNEL/$BRANCH]" "$DEST_EMAIL"
 # Give logger time to catch up
 sleep 30
 
-EC2_INSTANCE_ID=$(wget -q -O - http://instance-data/latest/meta-data/instance-id)
+EC2_INSTANCE_ID=$(ec2metadata --instance-id)
 $AWS_ROOT/terminate-indexer.py $EC2_INSTANCE_ID

--- a/infrastructure/aws/shell-setup.sh
+++ b/infrastructure/aws/shell-setup.sh
@@ -20,7 +20,7 @@ CONFIG_REPO_URL=$4
 CONFIG_REPO_PATH=$(readlink -f $5)
 CONFIG_INPUT="$6"
 
-EC2_INSTANCE_ID=$(wget -q -O - http://instance-data/latest/meta-data/instance-id)
+EC2_INSTANCE_ID=$(ec2metadata --instance-id)
 
 echo "Branch is $BRANCH"
 echo "Channel is $CHANNEL"

--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -140,12 +140,12 @@ if dry_run:
     sys.exit(0)
 
 # Performing lookup from https://cloud-images.ubuntu.com/locator/ec2/ by
-# searching on "20.04 us-west-2 amd64" we get:
+# searching on "22.04 us-west-2 amd64" we get:
 #
-# us-west-2	jammy	22.04	amd64	hvm:ebs-ssd	20220506	ami-0437ae8a23be4e98b	hvm
+# us-west-2	Jammy Jellyfish	22.04 LTS	amd64	hvm:ebs-ssd	20240801	ami-0b33ebbed151cf740	hvm
 #
 # and then we copy the ami ID into here:
-image_id = 'ami-0437ae8a23be4e98b'
+image_id = 'ami-0b33ebbed151cf740'
 
 launch_spec = {
     'ImageId': image_id,

--- a/infrastructure/aws/trigger_common.py
+++ b/infrastructure/aws/trigger_common.py
@@ -79,6 +79,11 @@ class TriggerCommandBase:
         ec2 = boto3.resource('ec2')
         client = boto3.client('ec2')
 
+        if args.channel == "release5":
+            instance_type = 'm5d.4xlarge'
+        else:
+            instance_type = 'm5d.2xlarge'
+
         # Terminate any "running" or "stopped" instances.  We used to only
         # terminate "running" instances with the theory that someone might get
         # around to investigating the "stopped" instance, but the reality is
@@ -129,7 +134,7 @@ class TriggerCommandBase:
             'KeyName': 'Main Key Pair',
             'SecurityGroups': ['indexer-secure'],
             'UserData': user_data,
-            'InstanceType': 'm5d.2xlarge',
+            'InstanceType': instance_type,
             'BlockDeviceMappings': block_devices,
             'IamInstanceProfile': {
                 'Name': 'indexer-role',

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -12,12 +12,12 @@ set -o pipefail # Check all commands in a pipeline
 # Note that for the most recent LLVM/clang release (ex: right now v13), you
 # would actually want to leave this empty.  Check out https://apt.llvm.org/ for
 # the latest info in all cases.
-CLANG_SUFFIX=-17
+CLANG_SUFFIX=-18
 # Bumping the priority with each version upgrade lets running the provisioning
 # script on an already provisioned machine do the right thing alternative-wise.
 # Actually, we no longer support re-provisioning, but it's fun to increment
 # numbers.
-CLANG_PRIORITY=413
+CLANG_PRIORITY=414
 # The clang packages build the Ubuntu release name in; let's dynamically extract
 # it since I, asuth, once forgot to update this.
 UBUNTU_RELEASE=$(lsb_release -cs)


### PR DESCRIPTION
I think the basic situation is that the macro expansion magic is interacting badly with webkit in a way that causes the processes memory usage to bloat to really extreme levels.  This stack provides swap space, and the webkit indexing job had consumed about 190G of swap before I terminated the index.  The swapping was pretty bad, I think, to the extent that basically of the 16 cores, we only ended up with about 1 core's worth of progress moving forward.

The analysis files on disk did not seem to be large; only 222 MiB was written when I shut things down.

I'm landing this stack primarily because I think we do want all these changes[1] and because the IMDS change will break future indexing runs without the last patch in this stack (because the new AMIs got opted in to IMDSv2 with required token).

I have disabled the "everyday-5am" rule from Amazon EventBridge (busses/rules, but accessible from cloudwatch/rules where I guess it used to be) because there's no point in scheduling webkit jobs when we think they're going to fail.

One disclaimer is that the 8 GiB swap logic for non-config5 servers has not been tested and it's conceivable I made an error there.  I can take a look tomorrow if any jobs fail and re-trigger them.

1: In particular, I do think it makes sense to run the webkit build jobs on a more powerful machine.  This potentially might also make sense for our LLVM job too for the same reason.