### PR TITLE
Bug 1915563 - Fix intro/settings page size syntax.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -866,7 +866,7 @@ span[data-symbols].selected {
 
 /* Help screen */
 .intro, .settings-page {
-  font: 14px/var(--base-line-height).5 Arial, Helvetica, sans-serif;
+  font: 14px/var(--base-line-height) Arial, Helvetica, sans-serif;
   margin-left: 10%;
   margin-right: 10%;
   margin-bottom: 10%;


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1915563

This fixes the invalid syntax introduced by bug 1906146.