### PR TITLE
Bug 1913921 - Attach event listeners before search result table is added to the document

### DIFF
--- a/static/js/search.js
+++ b/static/js/search.js
@@ -815,7 +815,7 @@ function populateResults(data, full, jumpToSingle) {
 
     table.innerHTML = html;
 
-    for (let element of document.querySelectorAll(".expando")) {
+    for (let element of table.querySelectorAll(".expando")) {
       element.addEventListener("click", onExpandoClick);
     }
 

--- a/tests/webtest/test_SearchSection.js
+++ b/tests/webtest/test_SearchSection.js
@@ -1,0 +1,29 @@
+"use strict";
+
+add_task(async function test_CollapseSearchSection() {
+  await TestUtils.loadPath("/");
+  TestUtils.shortenSearchTimeouts();
+
+  const query = frame.contentDocument.querySelector("#query");
+  TestUtils.setText(query, "SimpleSearch");
+
+  const content = frame.contentDocument.querySelector("#content");
+
+  await waitForCondition(
+    () => content.textContent.includes("Core code (1 lines") &&
+      content.textContent.includes("class SimpleSearch"),
+    "1 class matches");
+
+  const expando = frame.contentDocument.querySelector(".expando");
+  ok(!!expando, "Expando button exists");
+  ok(expando.classList.contains("open"), "Expando button is opened");
+
+  const resultHead = frame.contentDocument.querySelector(".result-head");
+  ok(!!resultHead, "Result head exists");
+  ok(TestUtils.isShown(resultHead), "Result head is expanded");
+
+  TestUtils.click(expando);
+
+  ok(!expando.classList.contains("open"), "Expando button is not open");
+  ok(!TestUtils.isShown(resultHead), "Result head is collapsed");
+});


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1913921

This does:
  * search for the "expando" buttons in the `table` node instead of `document`, given the table is not yet added to the document at the point
