### PR TITLE
Bug 1916972 - Fix lifetime annotations to avoid warnings

### DIFF
--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -182,7 +182,7 @@ impl AbstractServer for LocalIndex {
         }
     }
 
-    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
+    async fn fetch_raw_analysis<'a>(&self, sf_path: &str) -> Result<BoxStream<'a, Value>> {
         let norm_path = self.normalize_and_validate_path(sf_path)?;
         let full_path = self.translate_path(
             SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -107,7 +107,7 @@ impl AbstractServer for RemoteServer {
         Err(ServerError::Unsupported)
     }
 
-    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>> {
+    async fn fetch_raw_analysis<'a>(&self, sf_path: &str) -> Result<BoxStream<'a, Value>> {
         let url = self.raw_analysis_base_url.join(sf_path)?;
         let raw_str = get(url).await?.text().await?;
         let values: Result<Vec<Value>> = raw_str

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -293,7 +293,7 @@ pub trait AbstractServer {
 
     /// Fetch the contents of the analysis file for the given searchfox
     /// tree-local path, decompressing if it's compressed.
-    async fn fetch_raw_analysis(&self, sf_path: &str) -> Result<BoxStream<Value>>;
+    async fn fetch_raw_analysis<'a>(&self, sf_path: &str) -> Result<BoxStream<'a, Value>>;
 
     /// Fetch the contents of a raw (not HTML rendered) source file
     /// corresponding to the indexed revision like you would get out of revision

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -2265,7 +2265,7 @@ impl SymbolGraphNodeSet {
         sym: &'a Ustr,
         server: &'a Box<dyn AbstractServer + Send + Sync>,
         depth: u32,
-    ) -> Result<(SymbolGraphNodeId, &mut DerivedSymbolInfo)> {
+    ) -> Result<(SymbolGraphNodeId, &'a mut DerivedSymbolInfo)> {
         if let Some(index) = self.symbol_to_index_map.get(sym) {
             let sym_info = self
                 .symbol_crossref_infos


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1916972

This adds lifetime annotation to avoid the warnings introduced in rust nightly compiler.