### PR TITLE
Understand some android runnable idioms by better understanding external SCIP symbols

### DIFF
--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -25,34 +25,34 @@
 # itself.
 
 [pretty."nsIRunnable::Run"]
-runnable = true
+runnable = "constructor"
 
 [pretty."mozilla::dom::WorkerRunnable::WorkerRun"]
-runnable = true
+runnable = "constructor"
 
 [pretty."mozilla::dom::WorkerMainThreadRunnable::MainThreadRun"]
-runnable = true
+runnable = "constructor"
 
 [pretty."mozilla::dom::WorkerThreadProxySyncRunnable::RunOnMainThread"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIProgressEventSink::OnProgress"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIProgressEventSink::OnStatus"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIRequestObserver::OnStartRequest"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIRequestObserver::OnStopRequest"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIStreamListener::OnDataAavailable"]
-runnable = true
+runnable = "constructor"
 
 [pretty."nsIStreamLoaderObserver::OnStreamComplete"]
-runnable = true
+runnable = "constructor"
 
 # Treating nsITimerCallback as a runnable is an improvement on the current
 # behavior of citing `nsTimerImpl::Fire` plus random implementations that
@@ -61,8 +61,20 @@ runnable = true
 # used.  For larger monolithic classes, it would be better to specialize on the
 # call to setup the timer, and this would also work for the smaller classes too.
 [pretty."nsITimerCallback::Notify"]
-runnable = true
+runnable = "constructor"
 
+# #### Java / Kotlin Runnable Things ####
+#
+# These seem like they use reflection to construct the class and so we don't
+# actually see the constructor invoked, so our edges here need to be to
+# references to the class.  We of course also see references to the classes
+# when they are imported, but those thankfully lack a contextsym and so end up
+# being moot.
+[pretty."androidx::work::Worker::doWork"]
+runnable = "class"
+
+[pretty."androidx::work::CoroutineWorker::doWork"]
+runnable = "class"
 
 # ### Class Diagram Directives ###
 #

--- a/config_defaults/ontology-mapping.toml
+++ b/config_defaults/ontology-mapping.toml
@@ -76,6 +76,9 @@ runnable = "class"
 [pretty."androidx::work::CoroutineWorker::doWork"]
 runnable = "class"
 
+[pretty."kotlin::Function3::invoke"]
+runnable = "constructor"
+
 # ### Class Diagram Directives ###
 #
 # - "class-diagram:stop" - This is used for cases where the type is notable and

--- a/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
+++ b/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
@@ -396,13 +396,13 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ dependencies = [
  "atty",
  "humantime",
  "log 0.4.21",
- "regex 1.10.4",
+ "regex 1.10.6",
  "termcolor",
 ]
 
@@ -998,7 +998,7 @@ dependencies = [
  "bstr",
  "log 0.4.21",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1397,7 +1397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c7940d3c84d2079306c176c7b2b37622b6bc5e43fbd1541b1e4a4e1fd02045"
 dependencies = [
  "difflib",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde_json",
 ]
 
@@ -1424,8 +1424,8 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "pico-args",
- "regex 1.10.4",
- "regex-syntax 0.8.3",
+ "regex 1.10.6",
+ "regex-syntax 0.8.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1572,7 +1572,7 @@ dependencies = [
  "num-traits",
  "pest",
  "pest_derive",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde",
  "time 0.3.36",
 ]
@@ -1598,7 +1598,7 @@ dependencies = [
  "liquid-core",
  "once_cell",
  "percent-encoding 2.3.1",
- "regex 1.10.4",
+ "regex 1.10.6",
  "time 0.3.36",
  "unicode-segmentation",
 ]
@@ -2222,7 +2222,7 @@ dependencies = [
  "petgraph",
  "prost",
  "prost-types",
- "regex 1.10.4",
+ "regex 1.10.6",
  "tempfile",
  "which",
 ]
@@ -2407,14 +2407,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr 2.7.2",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2434,7 +2434,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr 2.7.2",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2454,9 +2454,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2780,6 +2780,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3256,7 +3262,7 @@ dependencies = [
  "prost",
  "protobuf",
  "query-parser",
- "regex 1.10.4",
+ "regex 1.10.6",
  "reqwest",
  "rls-analysis",
  "rls-data",
@@ -3274,10 +3280,10 @@ dependencies = [
  "tracing",
  "tracing-forest",
  "tracing-subscriber",
- "tree-sitter 0.20.9",
+ "tree-sitter",
+ "tree-sitter-cpp",
  "tree-sitter-java",
- "tree-sitter-kotlin",
- "tree-sitter-mozcpp",
+ "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -3426,7 +3432,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -3447,92 +3453,80 @@ checksum = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.9"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4423c784fe11398ca91e505cdc71356b07b1a924fc8735cfab5333afe3e18bc"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
 dependencies = [
  "cc",
- "regex 1.10.4",
-]
-
-[[package]]
-name = "tree-sitter"
-version = "0.22.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7cc499ceadd4dcdf7ec6d4cbc34ece92c3fa07821e287aedecd4416c516dca"
-dependencies = [
- "cc",
- "regex 1.10.4",
+ "regex 1.10.6",
+ "regex-syntax 0.8.4",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-cpp"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbedbf4066bfab725b3f9e2a21530507419a7d2f98621d3c13213502b734ec0"
+checksum = "c0a588a816017469b69f2e3544742e34a5a59dddfb4b9457b657a6052e2ea39c"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-java"
-version = "0.20.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653"
+checksum = "b38b26736e6e97421760201f7a91c859f3b0d44382d48ac18aa963828f784ebf"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-kotlin"
-version = "0.3.2"
-source = "git+https://github.com/fwcd/tree-sitter-kotlin.git?rev=5b7ca7a611eac3234cd0a38b6257effa8888f89d#5b7ca7a611eac3234cd0a38b6257effa8888f89d"
+name = "tree-sitter-kotlin-ng"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d3870b8f8e8d48212484c85c837e38161298e1524638b52d63942d28c4d97c"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-mozcpp"
-version = "0.20.2"
+name = "tree-sitter-language"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9514ebbde0a575c43027fffa2702788ae7fb967be5e1a43daae92667400d13e"
-dependencies = [
- "cc",
- "tree-sitter 0.20.9",
- "tree-sitter-cpp",
-]
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.20.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47ebd9cac632764b2f4389b08517bf2ef895431dd163eb562e3d2062cc23a14"
+checksum = "65661b1a3e24139e2e54207e47d910ab07e28790d78efc7d5dc3a11ce2a110eb"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
+checksum = "cffbbcb780348fbae8395742ae5b34c1fd794e4085d43aac9f259387f9a84dc8"
 dependencies = [
  "cc",
- "tree-sitter 0.22.6",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.20.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75049f0aafabb2aac205d7bb24da162b53dcd0cfb326785f25a2f32efa8071a"
+checksum = "aecf1585ae2a9dddc2b1d4c0e2140b2ec9876e2a25fd79de47fcf7dae0384685"
 dependencies = [
  "cc",
- "tree-sitter 0.20.9",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/tests/tests/checks/snapshots/crossref/java/check_glob@package__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/check_glob@package__json.snap
@@ -112,7 +112,7 @@ expression: "&to_value(scil).unwrap()"
           "type_pretty": null,
           "kind": "",
           "subsystem": null,
-          "implKind": "impl",
+          "implKind": "external",
           "sizeBytes": null,
           "ownVFPtrBytes": null,
           "bindingSlots": [],

--- a/tests/tests/checks/snapshots/crossref/java/check_glob@package__json.snap
+++ b/tests/tests/checks/snapshots/crossref/java/check_glob@package__json.snap
@@ -104,7 +104,26 @@ expression: "&to_value(scil).unwrap()"
               }
             ]
           }
-        ]
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "sample",
+          "sym": "S_jvm_sample/",
+          "type_pretty": null,
+          "kind": "",
+          "subsystem": null,
+          "implKind": "impl",
+          "sizeBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        }
       },
       "relation": "Queried",
       "quality": "ExactIdentifier",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -396,13 +396,13 @@ checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
-version = "1.0.98"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41c270e7540d725e65ac7f1b212ac8ce349719624d7bcff99f8e2e488e8cf03f"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
+ "shlex",
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ dependencies = [
  "atty",
  "humantime",
  "log 0.4.21",
- "regex 1.10.4",
+ "regex 1.10.6",
  "termcolor",
 ]
 
@@ -996,7 +996,7 @@ dependencies = [
  "bstr",
  "log 0.4.21",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -1395,7 +1395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25c7940d3c84d2079306c176c7b2b37622b6bc5e43fbd1541b1e4a4e1fd02045"
 dependencies = [
  "difflib",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde_json",
 ]
 
@@ -1422,8 +1422,8 @@ dependencies = [
  "lalrpop-util",
  "petgraph",
  "pico-args",
- "regex 1.10.4",
- "regex-syntax 0.8.3",
+ "regex 1.10.6",
+ "regex-syntax 0.8.4",
  "string_cache",
  "term",
  "tiny-keccak",
@@ -1570,7 +1570,7 @@ dependencies = [
  "num-traits",
  "pest",
  "pest_derive",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde",
  "time 0.3.36",
 ]
@@ -1596,7 +1596,7 @@ dependencies = [
  "liquid-core",
  "once_cell",
  "percent-encoding 2.3.1",
- "regex 1.10.4",
+ "regex 1.10.6",
  "time 0.3.36",
  "unicode-segmentation",
 ]
@@ -2220,7 +2220,7 @@ dependencies = [
  "petgraph",
  "prost",
  "prost-types",
- "regex 1.10.4",
+ "regex 1.10.6",
  "tempfile",
  "which",
 ]
@@ -2405,14 +2405,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr 2.7.2",
  "regex-automata 0.4.6",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2432,7 +2432,7 @@ checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick 1.1.3",
  "memchr 2.7.2",
- "regex-syntax 0.8.3",
+ "regex-syntax 0.8.4",
 ]
 
 [[package]]
@@ -2452,9 +2452,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
@@ -2778,6 +2778,12 @@ name = "shell-words"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24188a676b6ae68c3b2cb3a01be17fbf7240ce009799bb56d5b1409051e78fde"
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3254,7 +3260,7 @@ dependencies = [
  "prost",
  "protobuf",
  "query-parser",
- "regex 1.10.4",
+ "regex 1.10.6",
  "reqwest",
  "rls-analysis",
  "rls-data",
@@ -3273,9 +3279,9 @@ dependencies = [
  "tracing-forest",
  "tracing-subscriber",
  "tree-sitter",
+ "tree-sitter-cpp",
  "tree-sitter-java",
- "tree-sitter-kotlin",
- "tree-sitter-mozcpp",
+ "tree-sitter-kotlin-ng",
  "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
@@ -3424,7 +3430,7 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex 1.10.4",
+ "regex 1.10.6",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -3444,82 +3450,80 @@ source = "git+https://github.com/philip-peterson/destructure_traitobject?rev=d49
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.9"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4423c784fe11398ca91e505cdc71356b07b1a924fc8735cfab5333afe3e18bc"
+checksum = "20f4cd3642c47a85052a887d86704f4eac272969f61b686bdd3f772122aabaff"
 dependencies = [
  "cc",
- "regex 1.10.4",
+ "regex 1.10.6",
+ "regex-syntax 0.8.4",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-cpp"
-version = "0.20.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dbedbf4066bfab725b3f9e2a21530507419a7d2f98621d3c13213502b734ec0"
+checksum = "c0a588a816017469b69f2e3544742e34a5a59dddfb4b9457b657a6052e2ea39c"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-java"
-version = "0.20.2"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2adc5696bf5abf761081d7457d2bb82d0e3b28964f4214f63fd7e720ef462653"
+checksum = "b38b26736e6e97421760201f7a91c859f3b0d44382d48ac18aa963828f784ebf"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-kotlin"
-version = "0.3.2"
-source = "git+https://github.com/fwcd/tree-sitter-kotlin.git?rev=5b7ca7a611eac3234cd0a38b6257effa8888f89d#5b7ca7a611eac3234cd0a38b6257effa8888f89d"
+name = "tree-sitter-kotlin-ng"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d3870b8f8e8d48212484c85c837e38161298e1524638b52d63942d28c4d97c"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
-name = "tree-sitter-mozcpp"
-version = "0.20.2"
+name = "tree-sitter-language"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9514ebbde0a575c43027fffa2702788ae7fb967be5e1a43daae92667400d13e"
-dependencies = [
- "cc",
- "tree-sitter",
- "tree-sitter-cpp",
-]
+checksum = "2545046bd1473dac6c626659cc2567c6c0ff302fc8b84a56c4243378276f7f57"
 
 [[package]]
 name = "tree-sitter-python"
-version = "0.20.3"
+version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f47ebd9cac632764b2f4389b08517bf2ef895431dd163eb562e3d2062cc23a14"
+checksum = "65661b1a3e24139e2e54207e47d910ab07e28790d78efc7d5dc3a11ce2a110eb"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-rust"
-version = "0.20.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "797842733e252dc11ae5d403a18060bf337b822fc2ae5ddfaa6ff4d9cc20bda6"
+checksum = "cffbbcb780348fbae8395742ae5b34c1fd794e4085d43aac9f259387f9a84dc8"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]
 name = "tree-sitter-typescript"
-version = "0.20.3"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75049f0aafabb2aac205d7bb24da162b53dcd0cfb326785f25a2f32efa8071a"
+checksum = "aecf1585ae2a9dddc2b1d4c0e2140b2ec9876e2a25fd79de47fcf7dae0384685"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -64,13 +64,17 @@ shell-words = "1.0.0"
 termcolor = "1.4.1"
 tokio = { version = "1.6.0", features = ["rt-multi-thread", "net", "macros", "fs", "io-util", "signal"] }
 tokio-stream = "0.1.8"
-tree-sitter = "0.20.9"
-tree-sitter-mozcpp = "0.20.2"
-tree-sitter-python = "0.20.2"
-tree-sitter-rust = "0.20.3"
-tree-sitter-typescript = "0.20.2"
-tree-sitter-java = "0.20.2"
-tree-sitter-kotlin = { git = "https://github.com/fwcd/tree-sitter-kotlin.git", rev = "5b7ca7a611eac3234cd0a38b6257effa8888f89d" }
+tree-sitter = "0.23.0"
+# We previously used tree-sitter-mozcpp because it understands our XPCOM
+# macrology and doesn't freak out, but since it is only used for our WIP
+# hyperblame implementation and lags behind on updates, we are switching to
+# tree-sitter-cpp for now.
+tree-sitter-cpp = "0.23.0"
+tree-sitter-python = "0.23.2"
+tree-sitter-rust = "0.23.0"
+tree-sitter-typescript = "0.23.0"
+tree-sitter-java = "0.23.2"
+tree-sitter-kotlin-ng = "1.0.1"
 toml = "0.7.3"
 tonic = "0.7.1"
 tracing = "0.1.37"

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -205,6 +205,7 @@ struct SitterNesting {
     root_node_type: Vec<&'static str>,
     name_field: &'static str,
     body_field: &'static str,
+    body_node: &'static str,
 }
 
 lazy_static! {
@@ -215,11 +216,13 @@ lazy_static! {
             root_node_type: vec!["class_definition"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["function_definition"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
     ];
     // our list is manually derived from the tags.scm file:
@@ -229,31 +232,37 @@ lazy_static! {
             root_node_type: vec!["struct_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["enum_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["union_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["function_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["trait_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["mod_item"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         // TODO macro_definition lacks a body so the body needs to be the parent
         // node maybe?
@@ -264,6 +273,7 @@ lazy_static! {
             root_node_type: vec!["impl_item"],
             name_field: "type",
             body_field: "body",
+            body_node: "",
         },
     ];
     // tree-sitter support for typescript is a little weird because the
@@ -279,6 +289,7 @@ lazy_static! {
             root_node_type: vec!["method_definition"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         // There's an alt over class and class_declaration; class_declaration
         // becomes "class" if we add a "let blah = " ahead of it (and it stops
@@ -287,6 +298,7 @@ lazy_static! {
             root_node_type: vec!["class", "class_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         // There's also an alt over function/generators
         SitterNesting {
@@ -298,6 +310,7 @@ lazy_static! {
             ],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         // TODO: tags.scm has logic for lexical binds on arrow functions and
         // this is worth considering, although arguably this might also resemble
@@ -317,16 +330,19 @@ lazy_static! {
             root_node_type: vec!["abstract_class_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["module"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["interface_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
     ];
     // https://github.com/tree-sitter/tree-sitter-java/blob/master/queries/tags.scm
@@ -335,16 +351,19 @@ lazy_static! {
             root_node_type: vec!["class_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["method_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["interface_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
     ];
     // no tags.scm in tree-sitter-kotlin
@@ -353,11 +372,13 @@ lazy_static! {
             root_node_type: vec!["class_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
         SitterNesting {
             root_node_type: vec!["function_declaration"],
             name_field: "name",
             body_field: "body",
+            body_node: "",
         },
     ];
 }

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -726,20 +726,6 @@ fn analyze_using_scip(
             &doc.relative_path,
         );
 
-        // XXX next steps
-        // finish up the loop before to populate the structured things:
-        // - was thinking we just re-derive the descriptor string ourselves as
-        //   we go and we hold onto the previous state of the derived string so
-        //   that we can do the parent lookup for fields/methods.
-        // - the previous descriptor isn't particularly useful because it's
-        //   always going to be a type.
-        // - extra things:
-        //   - we do want to handle the relationship
-        //   - it could be good to have a basic approach for the documentation
-        //     - for rust that does give us size and alignment which is nice
-        //     - for JS we get the inferred type as well, plus the extracted
-        //       comment as a second string after the type info.
-
         for scip_sym_info in &doc.symbols {
             // Process each symbol to:
             // - Derive a canonical mozsearch symbol name and map it.

--- a/tools/src/file_format/ontology_mapping.rs
+++ b/tools/src/file_format/ontology_mapping.rs
@@ -17,9 +17,9 @@ pub struct OntologyMappingConfig {
 pub struct OntologyRule {
     /// When specified, treats the given symbol/identifier as an nsIRunnable::Run
     /// style method where overrides should be treated as runnables and have
-    /// ontology slots allocated to point to the concrete constructors.
-    #[serde(default)]
-    pub runnable: bool,
+    /// ontology slots allocated to point to the concrete constructors (C++) or
+    /// the class (Java/Kotlin reflection idiom)
+    pub runnable: Option<OntologyRunnableMode>,
     /// Given a base class, find all of its subclasses which are expected to be
     /// inner classes and label the outer class that contains them.  This mainly
     /// exists for detecting cycle collection where we have an inner class that
@@ -42,6 +42,18 @@ pub struct OntologyRule {
     /// Labels that we always apply to the class.
     #[serde(default)]
     pub labels: Vec<Ustr>,
+}
+
+#[derive(Eq, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OntologyRunnableMode {
+    /// The original mode, appropriate for C++ and XPCOM, we assume a reference
+    /// to the constructor will result in the runnable subequently running.
+    Constructor,
+    /// Introduce for the "androidx::work::Worker::doWork" Kotlin idiom where
+    /// we only see references to the class in the analysis data, and not the
+    /// constructor.
+    Class,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Note this also includes https://github.com/mozsearch/mozsearch/pull/816

The canon example is [the searchfox.org query of calls-to:'org::mozilla::fenix::utils::NotificationBaseKt::createBaseNotification' depth:10](https://searchfox.org/mozilla-central/query/default?q=calls-to%3A%27org%3A%3Amozilla%3A%3Afenix%3A%3Autils%3A%3ANotificationBaseKt%3A%3AcreateBaseNotification%27+depth%3A10) versus the [same thing with this patch applied on asuth.searchfox.org](https://asuth.searchfox.org/mozilla-central/query/default?q=calls-to%3A%27org%3A%3Amozilla%3A%3Afenix%3A%3Autils%3A%3ANotificationBaseKt%3A%3AcreateBaseNotification%27+depth%3A10) where we understand "androidx::work::Worker::doWork" as a runnable idiom.

Most of the work here (beyond the work in https://github.com/mozsearch/mozsearch/pull/816 to get better tree-sitter contextsym parses) is to emit the external structured symbols that scip-indexer sees but which aren't referenced by an occurrence to be processed by crossref and emitted as crossref.