### PR TITLE
Bug 1920754 - Stop using global variable and mutable static in url_map_handler.

### DIFF
--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -218,6 +218,7 @@ impl AbstractServer for LocalIndex {
         let jumpref_lookup_map = CrossrefLookupMap::new(&jumpref_path, &jumpref_extra_path);
 
         let (raw_lines, sym_json) = format_code(
+            None,
             &jumpref_lookup_map,
             select_formatting(sf_path),
             sf_path,
@@ -478,7 +479,7 @@ pub fn make_local_server(
     config_path: &str,
     tree_name: &str,
 ) -> Result<Box<dyn AbstractServer + Send + Sync>> {
-    let mut config = load(config_path, false, Some(&tree_name));
+    let mut config = load(config_path, false, Some(&tree_name), None);
     let tree_config = match config.trees.remove(&tree_name.to_string()) {
         Some(t) => t,
         None => {
@@ -495,7 +496,7 @@ pub fn make_local_server(
 pub fn make_all_local_servers(
     config_path: &str,
 ) -> Result<BTreeMap<String, Box<dyn AbstractServer + Send + Sync>>> {
-    let config = load(config_path, false, None);
+    let config = load(config_path, false, None, None);
     let mut servers = BTreeMap::new();
     for (tree_name, tree_config) in config.trees {
         let server = fab_server(tree_config, &tree_name, &config.config_repo_path)?;

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -293,7 +293,7 @@ async fn main() {
     let cli = CrossrefCli::parse();
 
     let tree_name = &cli.tree_name;
-    let cfg = config::load(&cli.config_file, false, Some(&tree_name));
+    let cfg = config::load(&cli.config_file, false, Some(&tree_name), None);
 
     let tree_config = cfg.trees.get(tree_name).unwrap();
 

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -32,8 +32,6 @@ use tools::languages;
 
 use tools::output::{PanelItem, PanelSection};
 
-use tools::url_map_handler::set_url_map_path;
-
 extern crate flate2;
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -49,15 +47,13 @@ fn main() {
 
     let pre_config = Instant::now();
     let tree_name = &base_args[2];
-    let cfg = config::load(&base_args[1], true, Some(&tree_name));
+    let cfg = config::load(&base_args[1], true, Some(&tree_name), Some(base_args[3].to_string()));
     writeln!(
         stdout,
         "Config file read, duration: {}us",
         pre_config.elapsed().as_micros() as u64
     )
     .unwrap();
-
-    set_url_map_path(&base_args[3]);
 
     let tree_config = cfg.trees.get(tree_name).unwrap();
 

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -1442,7 +1442,7 @@ fn main() {
     let cli = ScipIndexerCli::parse();
 
     let tree_name = &cli.tree_name;
-    let cfg = config::load(&cli.config_file, false, Some(&tree_name));
+    let cfg = config::load(&cli.config_file, false, Some(&tree_name), None);
     let tree_config = cfg.trees.get(tree_name).unwrap();
 
     for file in cli.inputs {

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -258,7 +258,7 @@ fn handle(
 fn main() {
     env_logger::init();
 
-    let cfg = config::load(&env::args().nth(1).unwrap(), true, None);
+    let cfg = config::load(&env::args().nth(1).unwrap(), true, None, None);
 
     let ident_map = IdentMap::load(&cfg);
 

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -164,6 +164,7 @@ pub struct Config {
     pub trees: BTreeMap<String, TreeConfig>,
     pub mozsearch_path: String,
     pub config_repo_path: String,
+    pub url_map_path: Option<String>,
 }
 
 impl Config {
@@ -245,7 +246,8 @@ pub fn index_blame(
     (blame_map, hg_map)
 }
 
-pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>) -> Config {
+pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>,
+            url_map_path: Option<String>) -> Config {
     let config_file = File::open(config_path).unwrap();
     let mut reader = BufReader::new(&config_file);
     let mut input = String::new();
@@ -312,6 +314,7 @@ pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>) -> C
         trees,
         mozsearch_path: config.mozsearch_path,
         config_repo_path: config.config_repo,
+        url_map_path: url_map_path,
     }
 }
 

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -164,6 +164,7 @@ pub struct Config {
     pub trees: BTreeMap<String, TreeConfig>,
     pub mozsearch_path: String,
     pub config_repo_path: String,
+    // FIXME: Move this to TreeConfig.
     pub url_map_path: Option<String>,
 }
 

--- a/tools/src/file_format/url_map.rs
+++ b/tools/src/file_format/url_map.rs
@@ -3,12 +3,13 @@ use std::fs::File;
 use serde_json::from_reader;
 use serde::Deserialize;
 
-#[derive(Clone, Deserialize)]
+#[derive(Clone, Deserialize, Debug)]
 pub struct URLMapItem {
     pub pretty: String,
     pub sym: String,
 }
 
+#[derive(Debug)]
 pub struct URLMap {
     data: HashMap<String, Vec<URLMapItem>>,
 }
@@ -20,7 +21,7 @@ impl URLMap {
         }
     }
 
-    fn new_empty() -> Self {
+    pub fn new_empty() -> Self {
         Self {
             data: HashMap::new(),
         }
@@ -32,14 +33,8 @@ impl URLMap {
 }
 
 pub fn read_url_map(
-    maybe_filename: Option<&str>,
+    filename: &String,
 ) -> URLMap {
-    if maybe_filename.is_none() {
-        return URLMap::new_empty();
-    }
-
-    let filename = maybe_filename.unwrap();
-
     let file = match File::open(filename) {
         Ok(f) => f,
         Err(_) => {

--- a/tools/src/links.rs
+++ b/tools/src/links.rs
@@ -3,12 +3,13 @@ use regex::Regex;
 use std::borrow::Cow;
 use itertools::Itertools;
 
+use crate::file_format::config::Config;
 use crate::url_map_handler::get_file_paths_for_url;
 
 /// Turn anything that looks like a link into an actual `<a href>` link using
 /// the `linkify` crate and in-between those links use `linkify_bug_number` to
 /// convert
-pub fn linkify_comment(s: String) -> String {
+pub fn linkify_comment(cfg: Option<&Config>, s: String) -> String {
     let mut finder = LinkFinder::new();
     finder.kinds(&[LinkKind::Url]);
 
@@ -19,7 +20,7 @@ pub fn linkify_comment(s: String) -> String {
         last = link.end();
 
         if link.as_str().starts_with("chrome://") || link.as_str().starts_with("resource://") {
-            if let Some(items) = get_file_paths_for_url(link.as_str()) {
+            if let Some(items) = get_file_paths_for_url(cfg, link.as_str()) {
                 // The corresponding symbol data is not added to SYM_INFO.
                 // The context menu is supposed to generate a pseudo data
                 // for the file.
@@ -128,6 +129,6 @@ fn test_bug_number() {
 #[test]
 fn test_bug_number_inside_link() {
     let link = "http://example.org/browser/editor/libeditor/tests/bug629172.html";
-    let linkified = linkify_comment(link.into());
+    let linkified = linkify_comment(None, link.into());
     assert_eq!(linkified, "<a href=\"http://example.org/browser/editor/libeditor/tests/bug629172.html\">http://example.org/browser/editor/libeditor/tests/<a href=\"https://bugzilla.mozilla.org/show_bug.cgi?id=629172\">bug629172</a>.html</a>");
 }


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1920754

This does the following:
  * instead of using global variable to keep the url map JSON file path, associate it to `Config` and pass it to `linkify_comment` function
  * instead of `lazy_static`, use `OnceLock` to lazily construct the `URLMap` with passed config's url map JSON path

Some places are not passing the config, thus the URLs in comments are not linkified, but that's pre-existing.