### PR TITLE
Bug 1921635 - Add "Go to use of" for diagram edges.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1353,6 +1353,18 @@ g.hovered-in-node > polygon {
   fill: #bfb;
 }
 
+g.hovered-cur-edge > path:not(.clicktarget),
+g.hovered-cur-edge > polygon {
+  stroke: #eae;
+  stroke-opacity: 1;
+  stroke-width: 2px;
+}
+
+g.edge > path.clicktarget {
+  stroke:rgba(0,0,0,0);
+  stroke-width: 10px;
+}
+
 g.edge.hovered-out-edge > path,
 g.edge.hovered-out-edge > polygon {
   stroke: blue;

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -388,12 +388,42 @@ var ContextMenu = new (class ContextMenu extends ContextMenuBase {
         Panel?.onSelectedTokenChanged?.();
       }
 
-      const symbols = symbolToken.getAttribute("data-symbols").split(",");
+      let symbols = symbolToken.getAttribute("data-symbols").split(",");
 
       const seenSyms = new Set();
       // For debugging/investigation purposes, expose the symbols that got
       // clicked on on the window global.
       const exposeSymbolsForDebugging = window.CLICKED_SYMBOLS = [];
+
+      // ## Diagram edge specialization
+      if (symbolToken.id?.startsWith("Gide")) {
+        // The "data-symbols" we have is of the form `A->B` where A is a comma
+        // delimited list of the source symbols that were consolidated into a
+        // single node, and the same deal with B.  This is exactly what was
+        // declared to graphviz.  In acylic dot layouts, this edge will be
+        // pointed downwards even if the arrowhead is visually pointing upwards
+        // (ex: inheritance).
+        const [srcSyms, targSyms] = symbolToken.getAttribute("data-symbols").split("->").map(x => x.split(","));
+
+        // Just clear the normal symbol list as we don't actually want the
+        // normal per-symbol behavior below.
+        symbols = [];
+
+        // We just want a pretty, so let's just use the first symbol of each.
+        let srcSymInfo = SYM_INFO[srcSyms[0]];
+        let targSymInfo = SYM_INFO[targSyms[0]];
+
+        // Generate a "go to use"
+        const edgeExtra = GRAPH_EXTRA[0].edges[symbolToken.id];
+        if (edgeExtra.jump && targSymInfo) {
+          jumpMenuItems.push({
+            html: this.fmt("Go to use of <strong>_</strong>", targSymInfo.pretty),
+            href: `/${tree}/source/${edgeExtra.jump}`,
+            icon: "export-alt",
+            section: "jumps",
+          });
+        }
+      }
 
       // ## First pass: Process symbols and potentially filter out implicit constructors
       //
@@ -1013,6 +1043,41 @@ var Hover = new (class Hover {
     });
   }
 
+  #edgeReverseMap
+  // Derive a map from edges to the source and target nodes by processing the
+  // GRAPH_EXTRA node data on first use.  This could be generated on the server
+  // but since the data is easily derived and we expect our graphs to be
+  // O(1000), we don't expect this computation to be too bad.
+  #ensureEdgeReverseMap() {
+    if (this.#edgeReverseMap) {
+      return;
+    }
+
+    this.#edgeReverseMap = new Map();
+    if (!GRAPH_EXTRA?.[0]) {
+      return;
+    }
+
+    for (const [node, nodeInfo] of Object.entries(GRAPH_EXTRA[0].nodes)) {
+      for (const inEdge of nodeInfo.in_edges) {
+        let edgeInfo = this.#edgeReverseMap.get(inEdge);
+        if (!edgeInfo) {
+          this.#edgeReverseMap.set(inEdge, [undefined, node]);
+        } else {
+          edgeInfo[1] = node;
+        }
+      }
+      for (const outEdge of nodeInfo.out_edges) {
+        let edgeInfo = this.#edgeReverseMap.get(outEdge);
+        if (!edgeInfo) {
+          this.#edgeReverseMap.set(outEdge, [node, undefined]);
+        } else {
+          edgeInfo[0] = node;
+        }
+      }
+    }
+  }
+
   activateDiagram(elem) {
     this.deactivateDiagram();
 
@@ -1024,10 +1089,6 @@ var Hover = new (class Hover {
     }
     if (id.startsWith("a_")) {
       id = id.substring(2);
-    }
-    let nodeExtra = GRAPH_EXTRA[0].nodes[id];
-    if (!nodeExtra) {
-      return;
     }
 
     const applyStyling = (targetId, clazzes) => {
@@ -1047,6 +1108,36 @@ var Hover = new (class Hover {
       this.graphItems.push([maybeTarget, clazzes])
     };
 
+    // ## Hovered Edge
+    if (id.startsWith("Gide")) {
+      const edgeExtra = GRAPH_EXTRA[0].edges[id];
+      if (!edgeExtra) {
+        return;
+      }
+
+      this.#ensureEdgeReverseMap();
+
+      const curEdgeHover = ["hovered-cur-edge"];
+      elem.classList.add(...curEdgeHover);
+      this.graphItems.push([elem, curEdgeHover]);
+
+      let [srcNode, targNode] = this.#edgeReverseMap.get(id);
+
+      const defaultInNodeHover = ["hovered-in-node"];
+      applyStyling(srcNode, defaultInNodeHover);
+
+      const defaultOutNodeHover = ["hovered-out-node"];
+      applyStyling(targNode, defaultOutNodeHover);
+
+      return;
+    }
+
+    let nodeExtra = GRAPH_EXTRA[0].nodes[id];
+    if (!nodeExtra) {
+      return;
+    }
+
+    // ## Hovered Node
     const curNodeHover = ["hovered-cur-node"];
     elem.classList.add(...curNodeHover);
     this.graphItems.push([elem, curNodeHover]);

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -704,6 +704,26 @@ function blurrifyDiagram() {
 // identifiers is creating a pathological situation?
 //blurrifyDiagram();
 
+// In order to provide more useful click/hover targets for diagram edges, we
+// duplicate line body "path" element to create one with a wider stroke that is
+// not visible.
+function makeDiagramHoverEdges() {
+  const diag = document.querySelector("svg");
+  if (!diag) {
+    return;
+  }
+
+  const edges = diag.querySelectorAll("g.edge > path");
+  for (const path of edges) {
+    const dupe = path.cloneNode(false);
+    dupe.classList.add("clicktarget");
+    // let's insert the clicktarget after the actual path so it is always what
+    // the hit test finds.
+    path.insertAdjacentElement("afterend", dupe);
+  }
+}
+makeDiagramHoverEdges();
+
 // Scroll the first root node of the diagram so that it's centered.  Through use
 // of `?.` this won't freak out if there are no matches.  According to
 // performance.now(), this takes 3ms on the 20,765 line indexedDB/ActorsParent.cpp

--- a/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/big_cpp.cpp/check_glob@query__calls_to__takeDamage__svg.snap
@@ -87,16 +87,16 @@ expression: "&to_value(grb).unwrap()"
         },
         "edges": {
           "Gide0": {
-            "jump": ""
+            "jump": "big_cpp.cpp#411"
           },
           "Gide1": {
-            "jump": ""
+            "jump": "big_cpp.cpp#372"
           },
           "Gide2": {
-            "jump": ""
+            "jump": "big_cpp.cpp#419,422,425,428,431"
           },
           "Gide3": {
-            "jump": ""
+            "jump": "big_cpp.cpp#382,403"
           }
         }
       }

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_left_one_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_left_one_right__svg.snap
@@ -77,13 +77,13 @@ expression: "&to_value(grb).unwrap()"
         },
         "edges": {
           "Gide0": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#42"
           },
           "Gide1": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#52"
           },
           "Gide2": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#56"
           }
         }
       }

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_one__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_between__four_one__svg.snap
@@ -133,22 +133,22 @@ expression: "&to_value(grb).unwrap()"
         },
         "edges": {
           "Gide0": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#42"
           },
           "Gide1": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#52"
           },
           "Gide2": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#57"
           },
           "Gide3": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#56"
           },
           "Gide4": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#37"
           },
           "Gide5": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#47"
           }
         }
       }

--- a/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_to__four_left_and_right__svg.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/lots_of_calls.cpp/check_glob@query__calls_to__four_left_and_right__svg.snap
@@ -165,28 +165,28 @@ expression: "&to_value(grb).unwrap()"
         },
         "edges": {
           "Gide0": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#56"
           },
           "Gide1": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#57"
           },
           "Gide2": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#47"
           },
           "Gide3": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#52"
           },
           "Gide4": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#37"
           },
           "Gide5": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#42"
           },
           "Gide6": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#66"
           },
           "Gide7": {
-            "jump": ""
+            "jump": "lots_of_calls.cpp#67"
           }
         }
       }

--- a/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
+++ b/tests/tests/checks/snapshots/web/query/execution/simple/runnables.cpp/check_glob@query__calls_to__common_shoe_related_method__json.snap
@@ -177,10 +177,10 @@ expression: "&to_value(grb).unwrap()"
         },
         "edges": {
           "Gide0": {
-            "jump": ""
+            "jump": "runnables.cpp#29"
           },
           "Gide1": {
-            "jump": ""
+            "jump": "runnables.cpp#52"
           },
           "Gide2": {
             "jump": ""
@@ -189,19 +189,19 @@ expression: "&to_value(grb).unwrap()"
             "jump": ""
           },
           "Gide4": {
-            "jump": ""
+            "jump": "runnables.cpp#40"
           },
           "Gide5": {
-            "jump": ""
+            "jump": "runnables.cpp#60"
           },
           "Gide6": {
             "jump": ""
           },
           "Gide7": {
-            "jump": ""
+            "jump": "runnables.cpp#48"
           },
           "Gide8": {
-            "jump": ""
+            "jump": "runnables.cpp#59"
           }
         }
       }


### PR DESCRIPTION
A notable correctness fix is that the `ensure_edge_in_graph` method was using a lookup map to find already extant edges but never actually populating the lookup map.  I believe this may have not affected anything because calls-to/uses diagrams used the traversal suppression to only add the edge once, and calls-from diagrams used callees edges which were pre-aggregated during crossref.