### PR TITLE
Bug 1833695: reset DeclContext stack when analysing out-of-line templated function

### DIFF
--- a/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_InlineShouldHaveContextSym
+++ b/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_InlineShouldHaveContextSym
@@ -1,0 +1,1 @@
+filter-analysis templates7.cpp -k def -i "Theme::InlineShouldHaveContextSym"

--- a/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_InlineTemplateShouldHaveContextSym
+++ b/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_InlineTemplateShouldHaveContextSym
@@ -1,0 +1,1 @@
+filter-analysis templates7.cpp -k def -i "Theme::InlineTemplateShouldHaveContextSym"

--- a/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_OutOfLineShouldntHaveContextSym
+++ b/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_OutOfLineShouldntHaveContextSym
@@ -1,0 +1,1 @@
+filter-analysis templates7.cpp -k def -i "Theme::OutOfLineShouldntHaveContextSym"

--- a/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_OutOfLineTemplateShouldntHaveContextSym
+++ b/tests/tests/checks/inputs/analysis/cpp/templates7.cpp/def_OutOfLineTemplateShouldntHaveContextSym
@@ -1,0 +1,1 @@
+filter-analysis templates7.cpp -k def -i "Theme::OutOfLineTemplateShouldntHaveContextSym"

--- a/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_InlineShouldHaveContextSym.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_InlineShouldHaveContextSym.snap
@@ -1,0 +1,25 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00019:14-40",
+    "source": 1,
+    "nestingRange": "19:46-19:47",
+    "syntax": "def,function",
+    "type": "void (int)",
+    "pretty": "function Theme::InlineShouldHaveContextSym",
+    "sym": "_ZN5Theme26InlineShouldHaveContextSymEi"
+  },
+  {
+    "loc": "00019:14-40",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Theme::InlineShouldHaveContextSym",
+    "sym": "_ZN5Theme26InlineShouldHaveContextSymEi",
+    "context": "Theme",
+    "contextsym": "T_Theme",
+    "peekRange": "19-19"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_InlineTemplateShouldHaveContextSym.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_InlineTemplateShouldHaveContextSym.snap
@@ -1,0 +1,25 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00017:14-48",
+    "source": 1,
+    "nestingRange": "17:52-17:53",
+    "syntax": "def,function",
+    "type": "void (T)",
+    "pretty": "function Theme::InlineTemplateShouldHaveContextSym",
+    "sym": "_ZN5Theme34InlineTemplateShouldHaveContextSymET_"
+  },
+  {
+    "loc": "00017:14-48",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Theme::InlineTemplateShouldHaveContextSym",
+    "sym": "_ZN5Theme34InlineTemplateShouldHaveContextSymET_",
+    "context": "Theme",
+    "contextsym": "T_Theme",
+    "peekRange": "17-17"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_OutOfLineShouldntHaveContextSym.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_OutOfLineShouldntHaveContextSym.snap
@@ -1,0 +1,23 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00025:12-43",
+    "source": 1,
+    "nestingRange": "25:49-25:50",
+    "syntax": "def,function",
+    "type": "void (int)",
+    "pretty": "function Theme::OutOfLineShouldntHaveContextSym",
+    "sym": "_ZN5Theme31OutOfLineShouldntHaveContextSymEi"
+  },
+  {
+    "loc": "00025:12-43",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Theme::OutOfLineShouldntHaveContextSym",
+    "sym": "_ZN5Theme31OutOfLineShouldntHaveContextSymEi",
+    "peekRange": "25-25"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_OutOfLineTemplateShouldntHaveContextSym.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/templates7.cpp/check_glob@def_OutOfLineTemplateShouldntHaveContextSym.snap
@@ -1,0 +1,23 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00023:12-51",
+    "source": 1,
+    "nestingRange": "23:55-23:56",
+    "syntax": "def,function",
+    "type": "void (T)",
+    "pretty": "function Theme::OutOfLineTemplateShouldntHaveContextSym",
+    "sym": "_ZN5Theme39OutOfLineTemplateShouldntHaveContextSymET_"
+  },
+  {
+    "loc": "00023:12-51",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Theme::OutOfLineTemplateShouldntHaveContextSym",
+    "sym": "_ZN5Theme39OutOfLineTemplateShouldntHaveContextSymET_",
+    "peekRange": "23-23"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -642,6 +642,12 @@ Spread over multiple lines.
         </tr>
 
         <tr>
+          <td><a href="/tests/source/templates7.cpp" class="mimetype-fixed-container mimetype-icon-cpp">templates7.cpp</a></td>
+          <td class="description"><a href="/tests/source/templates7.cpp" title=""></td>
+          <td><a href="/tests/source/templates7.cpp">704</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/test_custom_element_base.xul" class="mimetype-fixed-container mimetype-icon-xul">test_custom_element_base.xul</a></td>
           <td class="description"><a href="/tests/source/test_custom_element_base.xul" title=""></td>
           <td><a href="/tests/source/test_custom_element_base.xul">14637</a></td>

--- a/tests/tests/files/templates7.cpp
+++ b/tests/tests/files/templates7.cpp
@@ -1,0 +1,25 @@
+// Testcase proposed by Botond on https://bugzilla.mozilla.org/show_bug.cgi?id=1833695
+
+struct Theme {
+  void CreateWebRenderCommandsForWidget() {
+    OutOfLineTemplateShouldntHaveContextSym(0);
+    OutOfLineShouldntHaveContextSym(0);
+    InlineTemplateShouldHaveContextSym(0);
+    InlineShouldHaveContextSym(0);
+  }
+
+  template<typename T>
+  void OutOfLineTemplateShouldntHaveContextSym(T);
+
+  void OutOfLineShouldntHaveContextSym(int);
+
+  template<typename T>
+  inline void InlineTemplateShouldHaveContextSym(T) {}
+
+  inline void InlineShouldHaveContextSym(int) {}
+};
+
+template <typename T>
+void Theme::OutOfLineTemplateShouldntHaveContextSym(T) {}
+
+void Theme::OutOfLineShouldntHaveContextSym(int) {}


### PR DESCRIPTION
Link to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1833695

Without this, OutOfLineTemplateShouldntHaveContextSym had two definition target records that disagreed on the contextsym:
1. The first one was generated when traversing the declaration, because it forwards to the definition if out-of-line (see comment in TraverseFunctionDecl). We didn't reset CurDeclContext, so it looked as-if the definition appeared inside the declaration, leading to a bogus contextsym (pointing to the function itself).
2. The second one was generated later on when traversing the definition itself. This one had a correct contextsym (ie. none).

This introduces a ValueRollback helper to make sure we don't forget to rollback CurDeclContext afterwards. (inspired by QScopedValueRollback)