### PR TITLE
Bug 1856762 - Visit implicit code inside lambdas

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -888,6 +888,11 @@ public:
     return Super::TraverseCXXDestructorDecl(D);
   }
 
+  bool TraverseLambdaExpr(LambdaExpr *E) {
+    AutoSetContext Asc(this, nullptr, true);
+    return Super::TraverseLambdaExpr(E);
+  }
+
   // Used to keep track of the context in which a token appears.
   struct Context {
     // Ultimately this becomes the "context" JSON property.
@@ -935,7 +940,7 @@ public:
 
     AutoSetContext *Ctxt = CurDeclContext;
     while (Ctxt) {
-      if (Ctxt->Decl != D) {
+      if (Ctxt->Decl && Ctxt->Decl != D) {
         return translateContext(Ctxt->Decl);
       }
       Ctxt = Ctxt->Prev;

--- a/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/Struct0UsedInLambda
+++ b/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/Struct0UsedInLambda
@@ -1,0 +1,1 @@
+filter-analysis lambdas.cpp -i "Struct0::method"

--- a/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/Struct1UsedInLambda
+++ b/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/Struct1UsedInLambda
@@ -1,0 +1,1 @@
+filter-analysis lambdas.cpp -i "Struct1::method"

--- a/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@Struct0UsedInLambda.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@Struct0UsedInLambda.snap
@@ -1,0 +1,58 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00002:9-15",
+    "source": 1,
+    "nestingRange": "2:18-2:19",
+    "syntax": "def,function",
+    "type": "void (void)",
+    "pretty": "function Struct0::method",
+    "sym": "_ZN7Struct06methodEv"
+  },
+  {
+    "loc": "00002:9-15",
+    "structured": 1,
+    "pretty": "Struct0::method",
+    "sym": "_ZN7Struct06methodEv",
+    "args": [],
+    "kind": "method",
+    "parentsym": "T_Struct0",
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00002:9-15",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Struct0::method",
+    "sym": "_ZN7Struct06methodEv",
+    "context": "Struct0",
+    "contextsym": "T_Struct0",
+    "peekRange": "2-2"
+  },
+  {
+    "loc": "00011:10-16",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void",
+    "pretty": "function Struct0::method",
+    "sym": "_ZN7Struct06methodEv",
+    "argRanges": []
+  },
+  {
+    "loc": "00011:10-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Struct0::method",
+    "sym": "_ZN7Struct06methodEv",
+    "context": "test()::(anonymous class)::operator()",
+    "contextsym": "_ZZ4testvENK3$_0clEOT_",
+    "argRanges": []
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@Struct1UsedInLambda.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@Struct1UsedInLambda.snap
@@ -1,0 +1,58 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00006:9-15",
+    "source": 1,
+    "nestingRange": "6:24-6:25",
+    "syntax": "def,function",
+    "type": "void (void) const",
+    "pretty": "function Struct1::method",
+    "sym": "_ZNK7Struct16methodEv"
+  },
+  {
+    "loc": "00006:9-15",
+    "structured": 1,
+    "pretty": "Struct1::method",
+    "sym": "_ZNK7Struct16methodEv",
+    "args": [],
+    "kind": "method",
+    "parentsym": "T_Struct1",
+    "overrides": [],
+    "props": [
+      "instance",
+      "user"
+    ]
+  },
+  {
+    "loc": "00006:9-15",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Struct1::method",
+    "sym": "_ZNK7Struct16methodEv",
+    "context": "Struct1",
+    "contextsym": "T_Struct1",
+    "peekRange": "6-6"
+  },
+  {
+    "loc": "00011:10-16",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void",
+    "pretty": "function Struct1::method",
+    "sym": "_ZNK7Struct16methodEv",
+    "argRanges": []
+  },
+  {
+    "loc": "00011:10-16",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Struct1::method",
+    "sym": "_ZNK7Struct16methodEv",
+    "context": "test()::(anonymous class)::operator()",
+    "contextsym": "_ZZ4testvENK3$_0clEOT_",
+    "argRanges": []
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -382,6 +382,12 @@ expression: "&fb.contents"
         </tr>
 
         <tr>
+          <td><a href="/tests/source/lambdas.cpp" class="mimetype-fixed-container mimetype-icon-cpp">lambdas.cpp</a></td>
+          <td class="description"><a href="/tests/source/lambdas.cpp" title=""></td>
+          <td><a href="/tests/source/lambdas.cpp">219</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/LightweightThemeManager.jsm" class="mimetype-fixed-container mimetype-icon-jsm">LightweightThemeManager.jsm</a></td>
           <td class="description"><a href="/tests/source/LightweightThemeManager.jsm" title="globals AddonManagerPrivate">globals AddonManagerPrivate</td>
           <td><a href="/tests/source/LightweightThemeManager.jsm">25383</a></td>

--- a/tests/tests/files/lambdas.cpp
+++ b/tests/tests/files/lambdas.cpp
@@ -1,0 +1,16 @@
+struct Struct0 {
+    void method() {}
+};
+
+struct Struct1 {
+    void method() const {}
+};
+
+void test() {
+    const auto lambda = [](auto &&t) {
+        t.method();
+    };
+
+    lambda(Struct0{});
+    lambda(Struct1{});
+}


### PR DESCRIPTION
Link to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1856762

This reuses the AutoSetContext machinery initially implemented for constructors to visit the implicit code generated for lambdas too, giving us the data required to understand the template-dependent code in lambdas.

AutoSetContext is adapted to support AutoSetContext::Decl == nullptr because, contrary to CXXConstructorDecl, LambdaExprs aren't NamedDecls.