### PR TITLE
Bug 1922888 - Fix IndexConsumer::getContext(SourceLocation) when Ctxt->Decl is null.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -959,8 +959,12 @@ public:
       return Context();
     }
 
-    if (CurDeclContext) {
-      return translateContext(CurDeclContext->Decl);
+    AutoSetContext *Ctxt = CurDeclContext;
+    while (Ctxt) {
+      if (Ctxt->Decl) {
+        return translateContext(Ctxt->Decl);
+      }
+      Ctxt = Ctxt->Prev;
     }
     return Context();
   }

--- a/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/LambdaFields
+++ b/tests/tests/checks/inputs/analysis/cpp/lambdas.cpp/LambdaFields
@@ -1,0 +1,1 @@
+filter-analysis lambdas.cpp -r structured -i "test::(anonymous)::(anonymous)"

--- a/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@LambdaFields.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/lambdas.cpp/check_glob@LambdaFields.snap
@@ -1,0 +1,54 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "00017:53-59",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_26bb4ec31a255159>_",
+    "kind": "field",
+    "parentsym": "T_26bb4ec31a255159"
+  },
+  {
+    "loc": "00018:49-55",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_8a745ec31a255159>_",
+    "kind": "field",
+    "parentsym": "T_8a745ec31a255159"
+  },
+  {
+    "loc": "00019:44-50",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_424d5ec31a255159>_",
+    "kind": "field",
+    "parentsym": "T_424d5ec31a255159"
+  },
+  {
+    "loc": "00020:39-45",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_12df2fc31a255159>_",
+    "kind": "field",
+    "parentsym": "T_12df2fc31a255159"
+  },
+  {
+    "loc": "00021:46-52",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_f9983fc31a255159>_",
+    "kind": "field",
+    "parentsym": "T_f9983fc31a255159"
+  },
+  {
+    "loc": "00022:41-47",
+    "structured": 1,
+    "pretty": "test::(anonymous)::(anonymous)",
+    "sym": "F_<T_cf514fc31a255159>_",
+    "kind": "field",
+    "parentsym": "T_cf514fc31a255159"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -384,7 +384,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/lambdas.cpp" class="mimetype-fixed-container mimetype-icon-cpp">lambdas.cpp</a></td>
           <td class="description"><a href="/tests/source/lambdas.cpp" title=""></td>
-          <td><a href="/tests/source/lambdas.cpp">219</a></td>
+          <td><a href="/tests/source/lambdas.cpp">636</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/lambdas.cpp
+++ b/tests/tests/files/lambdas.cpp
@@ -13,4 +13,11 @@ void test() {
 
     lambda(Struct0{});
     lambda(Struct1{});
+
+    const auto capture_all_by_reference = [&]{ (void)lambda; };
+    const auto capture_all_by_value = [=]{ (void)lambda; };
+    const auto capture_one_by_reference = [&lambda]{ (void)lambda; };
+    const auto capture_one_by_value = [lambda]{ (void)lambda; };
+    const auto capture_by_named_reference = [&lambda = lambda]{ (void)lambda; };
+    const auto capture_by_named_value = [lambda = lambda]{ (void)lambda; };
 }


### PR DESCRIPTION
Link to bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1922888

Bug 1856762 added support for traversing the implicit declarations created for lambdas. When traversing a lambda, a new context is pushed to the AutoSetContext stack to set the VisitImplicit flag. This context has Decl == nullptr because the lambda is not a NamedDecl.

I modified IndexConsumer::getContext(Decl *D) to support that case, but forgot to modify getContext(SourceLocation Loc) to support it too. In the added test case, the non-catch-all captures triggered a crash.