### PR TITLE
Bug 1923517 - Filter out the warning for protobuf.

### DIFF
--- a/infrastructure/docker-provision.sh
+++ b/infrastructure/docker-provision.sh
@@ -13,6 +13,10 @@ USE_GID=$2
 apt-get update
 apt-get install -y apt-utils lsb-release sudo curl wget
 
+# Create the vagrant user with the same UID/GID as the current host user.
+#
+# Remove the the default "ubuntu" user, because it may conflict with UID.
+userdel ubuntu
 USERNAME=vagrant
 useradd -u $USE_UID -o -ms /bin/bash $USERNAME
 groupmod -o -g $USE_GID $USERNAME

--- a/router/codesearch.py
+++ b/router/codesearch.py
@@ -9,6 +9,10 @@ import os.path
 import time
 from logger import log
 
+# A workaround until https://github.com/grpc/grpc/pull/37666 gets merged.
+import warnings
+warnings.filterwarnings("ignore", "Protobuf gencode version 5.27.2 is older than the runtime version 5.28.2", UserWarning)
+
 import grpc
 from src.proto import livegrep_pb2
 from src.proto import livegrep_pb2_grpc


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1923517 and https://bugzilla.mozilla.org/show_bug.cgi?id=1923516

This does:
  * delete the default "ubuntu" user while setting up the docker image, to avoid the UID conflict with the host user
  * filter out the protobuf's warning, specific to the current version, so that the warning with newer versions will be reported even if we forget to remove the filter