### PR TITLE
Bug 1912189 - Detect clang and clang-plugin version mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ clang-plugin/testfiles
 clang-plugin/analysis
 clang-plugin/.cache
 clang-plugin/compile_commands.json
+clang-plugin/clang-version.cache
+clang-plugin/clang-version.cache.tmp
 /js
 tools/target
 /scripts/web-analyze/wasm-css-analyzer/target

--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -6,7 +6,25 @@ CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing 
 	$(if $(DEBUG),-O0 -g)
 LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
 
-build: libclang-index-plugin.so
+build: clang-version-guard libclang-index-plugin.so
+
+clang-version-guard:
+	@$(CXX) --version > clang-version.cache.tmp
+	@if [ -f clang-version.cache ]; then \
+		if ! diff -q clang-version.cache clang-version.cache.tmp; then \
+			echo "Clang version mismatch is detected."; \
+			echo "Rebuilding from scratch..."; \
+			mv clang-version.cache.tmp clang-version.cache; \
+			make clean; \
+		else \
+			rm clang-version.cache.tmp; \
+		fi; \
+	else \
+		echo "Previous clang version is not found."; \
+		echo "Rebuilding from scratch..."; \
+		mv clang-version.cache.tmp clang-version.cache; \
+		make clean; \
+	fi
 
 %.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
@@ -48,4 +66,4 @@ analyze: build
 	@echo "maybe type:"
 	@echo "vim ${ANALYSIS_DIR}/test.cpp"
 
-.PHONY: build clean
+.PHONY: build clean clang-version-guard


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1912189

This makes the clang-plugin Makefile verify the clang version for the previous build (written into `clang-version.cache` file, which is not version-controlled), and rebuild from scratch if the version mismatch is detected.

I was about to add the `clang-version.cache` file to the dependency of each rule, but that results in putting the file in the compile/link command lines, so I made it to just perform `make clean` to perform full rebuild.