### PR TITLE
Bug 1912189 - Part 2: Use the version check only in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check-in-vagrant:
 	@[ -d /vagrant ] || (echo "This command must be run inside the vagrant instance" > /dev/stderr; exit 1)
 
 build-clang-plugin: check-in-vagrant
-	$(MAKE) -C clang-plugin
+	$(MAKE) -C clang-plugin build_with_version_check
 
 # This can be built outside the vagrant instance too
 # We specify "--all-targets" in order to minimize rebuilding required when we invoke

--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -6,7 +6,9 @@ CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing 
 	$(if $(DEBUG),-O0 -g)
 LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
 
-build: clang-version-guard libclang-index-plugin.so
+build: libclang-index-plugin.so
+
+build_with_version_check: clang-version-guard build
 
 clang-version-guard:
 	@$(CXX) --version > clang-version.cache.tmp


### PR DESCRIPTION
for the failure in https://github.com/mozsearch/mozsearch/pull/825

This makes the commands used during testing in docker perform the version check, but the command used by server don't