### PR TITLE
Bug 1924227 - Extract root block device from nvme list rather than hardcoding it

### DIFF
--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -55,12 +55,14 @@ date
 # command.  Note that the select constraint here is intended more as a check
 # that our assumption about partition sizes hasn't changed, as when provisioning
 # there should only be this single EBS mount.
-ROOT_VOL_ID=$(sudo nvme list -o json | jq --raw-output '.Devices[] | select(.PhysicalSize < 9000000000) | .SerialNumber | sub("^vol"; "vol-")')
+ROOT_DEV_INFO=$(sudo nvme list -o json | jq --raw-output '.Devices[] | select(.PhysicalSize < 9000000000)')
+ROOT_VOL_ID=$(jq -M -r '.SerialNumber | sub("^vol"; "vol-")' <<< "$ROOT_DEV_INFO")
+ROOT_DEV=$(jq -M -r '.DevicePath' <<< "$ROOT_DEV_INFO")
+
 AWS_REGION=us-west-2
 # The size is in gigs.
 aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 12
-# Re: hardcoded devices: The devices should currently be stable.
-#
+
 # We use an until loop because it can take some time for the change to
 # propagate to this VM.  The error will look like:
 #   "NOCHANGE: partition 1 is size 16775135. it cannot be grown"
@@ -69,9 +71,11 @@ aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 1
 #
 # The 5 is arbitrary in both cases.
 sleep 5
-until sudo growpart /dev/nvme0n1 1
+# note the partition is the 2nd arg here
+until sudo growpart ${ROOT_DEV} 1
 do
   sleep 5
 done
-sudo resize2fs /dev/nvme0n1p1
+# and here we identify the partition as part of the block device
+sudo resize2fs ${ROOT_DEV}p1
 


### PR DESCRIPTION
In some cases the EBS root volume may not be the previously hardcoded `/dev/nvme0n1` so we should extract it via jq.  The idiom we've been using in cases like this is to run the command that gives us a JSON blob once into an INFO var and then use separate jq invocations that use `<<< "$FOO_INFO"` to then pick the relevant data out of there rather than issue multiple commands which might change dynamically.  I've done that here.

This successfully ran on both provisioning jobs I just kicked off, although the hardcoded values would have worked too, but I did consult the logs and we are using the new logic.