### PR TITLE
Bug 1910314 - URL-encode link path, and support URL-encoded path in the server

### DIFF
--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -240,19 +240,19 @@ var BlamePopup = new (class BlamePopup {
       rendered += json[i].header;
 
       let diffLink = `/${tree}/diff/${revList[i]}/${revPath}#${linenoList[i]}`;
-      rendered += `<br>Show <a href="${diffLink}">annotated diff</a>`;
+      rendered += `<br>Show <a href="${encodeURI(diffLink)}">annotated diff</a>`;
 
       if (json[i].fulldiff) {
-        rendered += ` or <a href="${json[i].fulldiff}">full diff</a>`;
+        rendered += ` or <a href="${encodeURI(json[i].fulldiff)}">full diff</a>`;
       }
 
       if (json[i].parent) {
         let parentLink = `/${tree}/rev/${json[i].parent}/${revPath}#${linenoList[i]}`;
-        rendered += `<br><a href="${parentLink}" class="deemphasize">Show latest version without this line</a>`;
+        rendered += `<br><a href="${encodeURI(parentLink)}" class="deemphasize">Show latest version without this line</a>`;
       }
 
       let revLink = `/${tree}/rev/${revList[i]}/${revPath}#${linenoList[i]}`;
-      rendered += `<br><a href="${revLink}" class="deemphasize">Show earliest version with this line</a>`;
+      rendered += `<br><a href="${encodeURI(revLink)}" class="deemphasize">Show earliest version with this line</a>`;
       rendered += "</div>";
 
       if (i < revList.length - 1) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -413,7 +413,7 @@ function populateResults(data, full, jumpToSingle) {
   window.scrollTo(0, 0);
 
   function makeURL(path) {
-    return "/" + Dxr.tree + "/source/" + path;
+    return "/" + Dxr.tree + "/source/" + encodeURI(path);
   }
 
   function makeSearchUrl(q) {

--- a/tests/tests/files/js/with space.js
+++ b/tests/tests/files/js/with space.js
@@ -1,1 +1,3 @@
 var SymbolInFilenameWithSpace = 10;
+
+// A comment to create a previous revision.

--- a/tests/webtest/head.js
+++ b/tests/webtest/head.js
@@ -319,9 +319,13 @@ class TestUtils {
    *        The options for the mouse event.
    */
   static click(elem, options = { bubbles: true }) {
-    TestHarness.debug(`Clicking`);
+    TestUtils.dispatchMouseEvent("click", elem, options);
+  }
 
-    const ev = new MouseEvent("click", options);
+  static dispatchMouseEvent(name, elem, options = { bubbles: true }) {
+    TestHarness.debug(`Dispatching MouseEvent ${name}`);
+
+    const ev = new MouseEvent(name, options);
     elem.dispatchEvent(ev);
   }
 

--- a/tests/webtest/head.js
+++ b/tests/webtest/head.js
@@ -61,8 +61,8 @@ class TestHarness {
         // magenta
         // color = "light-dark(#B200B2, #D040D0)";
     }
-    console.log(`%c${type}%c - ${msg}`,
-                `color: ${color};`, "");
+    console.log(`%c${type}%c - %s`,
+                `color: ${color};`, "", msg);
     this.pendingLogs.push([type, `${msg}`]);
   }
 

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -1,4 +1,4 @@
-add_task(async function test_SpaceInFilename() {
+add_task(async function test_SpaceInFilenameInSearch() {
   await TestUtils.loadPath("/");
   TestUtils.shortenSearchTimeouts();
 
@@ -16,5 +16,15 @@ add_task(async function test_SpaceInFilename() {
   const links = frame.contentDocument.querySelectorAll(".result-head a");
   is(links.length, 2);
   is(links[1].getAttribute("href"), "/tests/source/js/with%20space.js",
+     "The space in the href should be escaped");
+});
+
+add_task(async function test_SpaceInFilenameInFileView() {
+  await TestUtils.loadPath("/tests/source/js/with%20space.js");
+
+  const links = frame.contentDocument.querySelectorAll(".breadcrumbs a");
+
+  is(links.length, 3);
+  is(links[2].getAttribute("href"), "/tests/source/js/with%20space.js",
      "The space in the href should be escaped");
 });

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -60,6 +60,8 @@ add_task(async function test_SpaceInFilenameInBlameAndOldRevision() {
   ok(links[1].getAttribute("href").includes("/js/with%20space.js"),
      "The space in the href should be escaped");
 
+  const annotatedDiffURL = links[1].href;
+
   is(links[2].textContent, "Show latest version without this line");
   ok(links[2].getAttribute("href").includes("/js/with%20space.js"),
      "The space in the href should be escaped");
@@ -76,6 +78,50 @@ add_task(async function test_SpaceInFilenameInBlameAndOldRevision() {
 
   // In order to avoid hard-coding the old version's hash, continue testing
   // the UI part of the old version page here.
+
+  // Test breadcrumbs.
+  {
+    const links = frame.contentDocument.querySelectorAll(".breadcrumbs a");
+
+    is(links.length, 6);
+    is(links[5].getAttribute("href"), "/searchfox/source/tests/tests/files/js/with%20space.js",
+       "The space in the href should be escaped");
+  }
+
+  // Test navigation panel.
+  {
+    const panel = frame.contentDocument.getElementById("panel");
+    const goToLatestLink = panel.querySelector(`.item[title="Go to latest version"]`);
+
+    ok(goToLatestLink.getAttribute("href").includes("/js/with%20space.js"),
+       "The space in the href should be escaped");
+  }
+});
+
+add_task(async function test_SpaceInFilenameInAnnotatedDiff() {
+  await TestUtils.loadPath("/searchfox/source/tests/tests/files/js/with%20space.js");
+
+  const blameStrip = frame.contentDocument.querySelector(`#line-2 .blame-strip`);
+
+  TestUtils.dispatchMouseEvent("mouseenter", blameStrip);
+
+  function getLinks() {
+    return frame.contentDocument.querySelectorAll(`#blame-popup a`);
+  }
+
+  await waitForCondition(() => getLinks().length > 0);
+
+  const links = getLinks();
+  is(links.length, 4);
+  is(links[1].textContent, "annotated diff");
+  ok(links[1].getAttribute("href").includes("/js/with%20space.js"),
+     "The space in the href should be escaped");
+
+  TestUtils.click(links[1]);
+
+  await waitForCondition(
+    () => frame.contentDocument.location.href.includes("/searchfox/diff"),
+    "Navigates to the previous version");
 
   // Test breadcrumbs.
   {

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -28,3 +28,13 @@ add_task(async function test_SpaceInFilenameInFileView() {
   is(links[2].getAttribute("href"), "/tests/source/js/with%20space.js",
      "The space in the href should be escaped");
 });
+
+add_task(async function test_SpaceInFilenameInNavigationPanel() {
+  await TestUtils.loadPath("/searchfox/source/tests/tests/files/js/with%20space.js");
+
+  const panel = frame.contentDocument.getElementById("panel");
+  const permalink = panel.querySelector(`.item[title="Permalink"]`);
+
+  ok(permalink.getAttribute("href").includes("/js/with%20space.js"),
+     "The space in the href should be escaped");
+});

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -12,4 +12,9 @@ add_task(async function test_SpaceInFilename() {
       content.textContent.includes("Definitions (SymbolInFilenameWithSpace) (1 lines") &&
       content.textContent.includes("var SymbolInFilenameWithSpace"),
     "symbol in file with space in filename matches as definition");
+
+  const links = frame.contentDocument.querySelectorAll(".result-head a");
+  is(links.length, 2);
+  is(links[1].getAttribute("href"), "/tests/source/js/with%20space.js",
+     "The space in the href should be escaped");
 });

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -38,3 +38,51 @@ add_task(async function test_SpaceInFilenameInNavigationPanel() {
   ok(permalink.getAttribute("href").includes("/js/with%20space.js"),
      "The space in the href should be escaped");
 });
+
+add_task(async function test_SpaceInFilenameInBlameAndOldRevision() {
+  await TestUtils.loadPath("/searchfox/source/tests/tests/files/js/with%20space.js");
+
+  // Test the blame popup
+
+  const blameStrip = frame.contentDocument.querySelector(`#line-2 .blame-strip`);
+
+  TestUtils.dispatchMouseEvent("mouseenter", blameStrip);
+
+  function getLinks() {
+    return frame.contentDocument.querySelectorAll(`#blame-popup a`);
+  }
+
+  await waitForCondition(() => getLinks().length > 0);
+
+  const links = getLinks();
+  is(links.length, 4);
+  is(links[1].textContent, "annotated diff");
+  ok(links[1].getAttribute("href").includes("/js/with%20space.js"),
+     "The space in the href should be escaped");
+
+  is(links[2].textContent, "Show latest version without this line");
+  ok(links[2].getAttribute("href").includes("/js/with%20space.js"),
+     "The space in the href should be escaped");
+
+  is(links[3].textContent, "Show earliest version with this line");
+  ok(links[3].getAttribute("href").includes("/js/with%20space.js"),
+     "The space in the href should be escaped");
+
+  TestUtils.click(links[2]);
+
+  await waitForCondition(
+    () => frame.contentDocument.location.href.includes("/searchfox/rev"),
+    "Navigates to the previous version");
+
+  // In order to avoid hard-coding the old version's hash, continue testing
+  // the UI part of the old version page here.
+
+  // Test breadcrumbs.
+  {
+    const links = frame.contentDocument.querySelectorAll(".breadcrumbs a");
+
+    is(links.length, 6);
+    is(links[5].getAttribute("href"), "/searchfox/source/tests/tests/files/js/with%20space.js",
+       "The space in the href should be escaped");
+  }
+});

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -85,4 +85,13 @@ add_task(async function test_SpaceInFilenameInBlameAndOldRevision() {
     is(links[5].getAttribute("href"), "/searchfox/source/tests/tests/files/js/with%20space.js",
        "The space in the href should be escaped");
   }
+
+  // Test navigation panel.
+  {
+    const panel = frame.contentDocument.getElementById("panel");
+    const goToLatestLink = panel.querySelector(`.item[title="Go to latest version"]`);
+
+    ok(goToLatestLink.getAttribute("href").includes("/js/with%20space.js"),
+       "The space in the href should be escaped");
+  }
 });

--- a/tests/webtest/test_SpaceInFilename.js
+++ b/tests/webtest/test_SpaceInFilename.js
@@ -98,7 +98,7 @@ add_task(async function test_SpaceInFilenameInBlameAndOldRevision() {
   }
 });
 
-add_task(async function test_SpaceInFilenameInAnnotatedDiff() {
+add_task(async function test_SpaceInFilenameInAnnotatedDiffAndChangeset() {
   await TestUtils.loadPath("/searchfox/source/tests/tests/files/js/with%20space.js");
 
   const blameStrip = frame.contentDocument.querySelector(`#line-2 .blame-strip`);
@@ -138,6 +138,25 @@ add_task(async function test_SpaceInFilenameInAnnotatedDiff() {
     const goToLatestLink = panel.querySelector(`.item[title="Go to latest version"]`);
 
     ok(goToLatestLink.getAttribute("href").includes("/js/with%20space.js"),
+       "The space in the href should be escaped");
+
+    // In order to avoid hard-coding the old version's hash, continue testing
+    // the UI part of the changeset view.
+
+    const changesetLink = panel.querySelector(`.item[title="Show changeset"]`);
+
+    TestUtils.click(changesetLink);
+  }
+
+  await waitForCondition(
+    () => frame.contentDocument.location.href.includes("/searchfox/commit"),
+    "Navigates to the changeset view");
+
+  // Test file listing.
+  {
+    const link = frame.contentDocument.querySelector(`#content ul li a[href*="space.js"]`);
+
+    ok(link.getAttribute("href").includes("/js/with%20space.js"),
        "The space in the href should be escaped");
   }
 });

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -29,6 +29,7 @@ use tools::file_format::analysis::{read_analysis, read_source};
 use tools::format::{create_markdown_panel_section, format_file_data};
 use tools::file_format::crossref_lookup::CrossrefLookupMap;
 use tools::languages;
+use tools::url_encode_path::url_encode_path;
 
 use tools::output::{PanelItem, PanelSection};
 
@@ -276,7 +277,7 @@ fn main() {
         if let Some((other_desc, other_path)) = show_header {
             source_panel_items.push(PanelItem {
                 title: format!("Go to {} file", other_desc),
-                link: other_path,
+                link: url_encode_path(other_path.as_str()),
                 update_link_lineno: "",
                 accel_key: None,
                 copyable: false,
@@ -307,19 +308,21 @@ fn main() {
             });
         };
 
+        let encoded_path = url_encode_path(path.as_str());
+
         if let Some(oid) = head_oid {
             if !path.contains("__GENERATED__") {
                 let mut vcs_panel_items = vec![];
                 vcs_panel_items.push(PanelItem {
                     title: "Permalink".to_owned(),
-                    link: format!("/{}/rev/{}/{}", tree_name, oid, path),
+                    link: format!("/{}/rev/{}/{}", tree_name, oid, encoded_path),
                     update_link_lineno: "#{}",
                     accel_key: Some('Y'),
                     copyable: true,
                 });
                 vcs_panel_items.push(PanelItem {
                     title: "Remove the Permalink".to_owned(),
-                    link: format!("/{}/source/{}", tree_name, path),
+                    link: format!("/{}/source/{}", tree_name, encoded_path),
                     update_link_lineno: "#{}",
                     accel_key: None,
                     copyable: false,
@@ -327,14 +330,14 @@ fn main() {
                 if let Some(ref hg_root) = tree_config.paths.hg_root {
                     vcs_panel_items.push(PanelItem {
                         title: "Log".to_owned(),
-                        link: format!("{}/log/tip/{}", hg_root, path),
+                        link: format!("{}/log/tip/{}", hg_root, encoded_path),
                         update_link_lineno: "",
                         accel_key: Some('L'),
                         copyable: true,
                     });
                     vcs_panel_items.push(PanelItem {
                         title: "Raw".to_owned(),
-                        link: format!("{}/raw-file/tip/{}", hg_root, path),
+                        link: format!("{}/raw-file/tip/{}", hg_root, encoded_path),
                         update_link_lineno: "",
                         accel_key: Some('R'),
                         copyable: true,
@@ -363,7 +366,7 @@ fn main() {
         if let Some(ref hg_root) = tree_config.paths.hg_root {
             tools_items.push(PanelItem {
                 title: "HG Web".to_owned(),
-                link: format!("{}/file/tip/{}", hg_root, path),
+                link: format!("{}/file/tip/{}", hg_root, encoded_path),
                 update_link_lineno: "#l{}",
                 accel_key: None,
                 copyable: false,
@@ -372,7 +375,7 @@ fn main() {
         if let Some(ref ccov_root) = tree_config.paths.ccov_root {
             tools_items.push(PanelItem {
                 title: "Code Coverage".to_owned(),
-                link: format!("{}#revision=latest&path={}&view=file", ccov_root, path),
+                link: format!("{}#revision=latest&path={}&view=file", ccov_root, encoded_path),
                 update_link_lineno: "&line={}",
                 accel_key: None,
                 copyable: false,
@@ -387,7 +390,7 @@ fn main() {
                             "{}/blob/{}/{}",
                             github,
                             head_oid.map_or("master".to_string(), |x| x.to_string()),
-                            path
+                            encoded_path
                         ),
                         update_link_lineno: "",
                         accel_key: None,

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -24,6 +24,8 @@ use tools::file_format::identifiers::IdentMap;
 use tools::format;
 use tools::git_ops;
 
+use tools::url_encode_path::url_decode_path;
+
 struct WebRequest<'a> {
     path: &'a str,
 }
@@ -129,7 +131,7 @@ fn handle(
     ident_map: &HashMap<String, IdentMap>,
     req: WebRequest,
 ) -> WebResponse {
-    let path = req.path.to_owned();
+    let path = url_decode_path(req.path);
     let path = path[1..].split('/').collect::<Vec<_>>();
 
     if path.len() > 0 && path[0] == "static" {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -1457,7 +1457,7 @@ fn generate_commit_info(
             file_info[0],
             tree_name,
             commit.id(),
-            file_info[1],
+            url_encode_path(file_info[1]),
             file_info[1]
         ));
         changes.push(f);

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -1199,6 +1199,8 @@ pub fn format_diff(
 
     output::generate_breadcrumbs(&opt, writer, path, false)?;
 
+    let encoded_path = url_encode_path(path);
+
     let mut vcs_panel_items = vec![
         PanelItem {
             title: "Show changeset".to_owned(),
@@ -1209,14 +1211,14 @@ pub fn format_diff(
         },
         PanelItem {
             title: "Show file without diff".to_owned(),
-            link: format!("/{}/rev/{}/{}", tree_name, rev, path),
+            link: format!("/{}/rev/{}/{}", tree_name, rev, encoded_path),
             update_link_lineno: "#{}",
             accel_key: None,
             copyable: true,
         },
         PanelItem {
             title: "Go to latest version".to_owned(),
-            link: format!("/{}/source/{}", tree_name, path),
+            link: format!("/{}/source/{}", tree_name, encoded_path),
             update_link_lineno: "#{}",
             accel_key: None,
             copyable: false,
@@ -1225,7 +1227,7 @@ pub fn format_diff(
     if let Some(ref hg_root) = tree_config.paths.hg_root {
         vcs_panel_items.push(PanelItem {
             title: "Log".to_owned(),
-            link: format!("{}/log/tip/{}", hg_root, path),
+            link: format!("{}/log/tip/{}", hg_root, encoded_path),
             update_link_lineno: "",
             accel_key: Some('L'),
             copyable: true,

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -21,6 +21,7 @@ use crate::tokenize;
 use crate::file_format::analysis::{AnalysisSource, ExpansionInfo, WithLocation};
 use crate::file_format::config::{Config, GitData, TreeConfig};
 use crate::output::{self, Options, PanelItem, PanelSection, F};
+use crate::url_encode_path::url_encode_path;
 
 use chrono::datetime::DateTime;
 use chrono::naive::datetime::NaiveDateTime;
@@ -951,10 +952,12 @@ pub fn format_path(
         .and_then(|rev| Some(rev.as_ref())) // &String to &str conversion
         .unwrap_or(&"tip");
 
+    let encoded_path = url_encode_path(path);
+
     let mut vcs_panel_items = vec![];
     vcs_panel_items.push(PanelItem {
         title: "Go to latest version".to_owned(),
-        link: format!("/{}/source/{}", tree_name, path),
+        link: format!("/{}/source/{}", tree_name, encoded_path),
         update_link_lineno: "#{}",
         accel_key: None,
         copyable: true,
@@ -962,14 +965,14 @@ pub fn format_path(
     if let Some(ref hg_root) = tree_config.paths.hg_root {
         vcs_panel_items.push(PanelItem {
             title: "Log".to_owned(),
-            link: format!("{}/log/{}/{}", hg_root, hg_rev, path),
+            link: format!("{}/log/{}/{}", hg_root, hg_rev, encoded_path),
             update_link_lineno: "",
             accel_key: Some('L'),
             copyable: true,
         });
         vcs_panel_items.push(PanelItem {
             title: "Raw".to_owned(),
-            link: format!("{}/raw-file/{}/{}", hg_root, hg_rev, path),
+            link: format!("{}/raw-file/{}/{}", hg_root, hg_rev, encoded_path),
             update_link_lineno: "",
             accel_key: Some('R'),
             copyable: true,

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -71,6 +71,8 @@ pub mod output;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod tokenize;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod url_encode_path;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod url_map_handler;
 #[cfg(not(target_arch = "wasm32"))]
 mod symbol_graph_edge_kind;

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -6,6 +6,7 @@ use std::path::Path;
 
 extern crate chrono;
 use crate::file_format::analysis_manglings::make_file_sym_from_path;
+use crate::url_encode_path::url_encode_path;
 
 use self::chrono::{DateTime, Local};
 
@@ -38,7 +39,7 @@ pub fn choose_icon(path: &str) -> String {
 }
 
 pub fn file_url(opt: &Options, path: &str) -> String {
-    format!("/{}/source/{}", opt.tree_name, path)
+    format!("/{}/source/{}", opt.tree_name, url_encode_path(path))
 }
 
 pub fn generate_breadcrumbs(

--- a/tools/src/url_encode_path.rs
+++ b/tools/src/url_encode_path.rs
@@ -1,0 +1,10 @@
+use urlencoding;
+use std::borrow::Cow;
+
+pub fn url_encode_path(path: &str) -> String {
+    path
+        .split('/')
+        .map(|p| urlencoding::encode(p))
+        .collect::<Vec<Cow<'_, str>>>()
+        .join("/")
+}

--- a/tools/src/url_encode_path.rs
+++ b/tools/src/url_encode_path.rs
@@ -8,3 +8,10 @@ pub fn url_encode_path(path: &str) -> String {
         .collect::<Vec<Cow<'_, str>>>()
         .join("/")
 }
+
+pub fn url_decode_path(path: &str) -> String {
+    match urlencoding::decode(path) {
+        Ok(s) => s.to_string(),
+        Err(_) => path.to_string()
+    }
+}


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1910314

This does:
  * URL-encode the `href` attribute when the path contains the files in the target repository
  * Decode URL-encoding on the server, for dynamically-generated pages

example:
https://arai.searchfox.org/mozilla-central/source/testing/web-platform/tests/tools/wave/tests/WAVE%20Local.postman_environment.json

Links in the blame popup, the navigation bar, and the breadcrumbs are now URL-encoded, and also the
annotated diff link target shows the correct file (it has been "File not found" error page)
