### PR TITLE
Bug 1924329 - Show error when uncommitted changes found while building the searchfox repo

### DIFF
--- a/tests/searchfox/setup
+++ b/tests/searchfox/setup
@@ -7,6 +7,17 @@ set -o pipefail # Check all commands in a pipeline
 # I think we used to try and delete the whole dir but we were messing it up.
 #rm -rf $INDEX_ROOT
 
+pushd $GIT_ROOT
+if ! git diff-index --quiet HEAD --; then
+    set +x
+    echo ""
+    echo "!!! CRITICAL !!!: Uncommitted changes found. Please commit them before building."
+    echo ""
+    git status
+    exit 1
+fi
+popd
+
 rm -rf $BLAME_ROOT
 mkdir -p $BLAME_ROOT
 git init $BLAME_ROOT


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1924329

This adds a check to the setup process of the searchfox repo (used both by build-searchfox-repo and webtest) to check
uncommitted changes, and show error if any, to avoid errors during the output process caused by the inconsistency between the git history and the working tree.
