### PR TITLE
Bug 1925207 - Convert the livegrep warning for the file size to INFO

### DIFF
--- a/scripts/build-codesearch.py
+++ b/scripts/build-codesearch.py
@@ -84,6 +84,18 @@ json.dump(livegrep_config, open('/tmp/livegrep.json', 'w'))
 # for debugging assistance, dump what we wrote to disk to stdout
 run_showing_output(['/usr/bin/jq', '.', '/tmp/livegrep.json'])
 
+
+def convert_size_warn_to_info(line):
+    if line.startswith("WARN:") and line.endswith(" is too large to be indexed."):
+        return "INFO" + line[4:]
+
+    return line
+
+
+def output_filter(text):
+    return '\n'.join(map(convert_size_warn_to_info, text.split('\n')))
+
+
 # we also want to see the output of what codesearch is doing
 run_showing_output(
     ['codesearch', '/tmp/livegrep.json',
@@ -102,7 +114,8 @@ run_showing_output(
      # better to give each thread potentialy 8 work units where we currently
      # only see 1.)
      '-chunk_power', '24',
-     '-line_limit', '4096'], stdin=open('/dev/null'), cwd='/tmp/dummy')
+     '-line_limit', '4096'], stdin=open('/dev/null'), cwd='/tmp/dummy',
+     output_filter=output_filter)
 
 run(['rm', '-rf', '/tmp/dummy'])
 run(['rm', '-rf', '/tmp/livegrep.json'])

--- a/scripts/lib.py
+++ b/scripts/lib.py
@@ -17,7 +17,7 @@ def run(cmd, **extra):
 
     return stdout
 
-def run_showing_output(cmd, **extra):
+def run_showing_output(cmd, output_filter=None, **extra):
     print('running', repr(cmd))
     p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, **extra)
     (stdout, stderr) = p.communicate()
@@ -30,10 +30,17 @@ def run_showing_output(cmd, **extra):
         print(stderr, file=sys.stderr)
         sys.exit(p.returncode)
     else:
+        stdout = stdout.decode()
+        stderr = stderr.decode()
+
+        if output_filter is not None:
+            stdout = output_filter(stdout)
+            stderr = output_filter(stderr)
+
         print('--- stdout')
-        print(stdout.decode())
+        print(stdout)
         print('--- stderr')
-        print(stderr.decode())
+        print(stderr)
         print('--- (end output)')
 
     return stdout


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1925207

This adds a filter for the `run_showing_output` function, and pass a filter to convert "WARN:" to "INFO:" for the filesize warning.