### PR TITLE
Bug 1699048 - Index StaticPrefs.

### DIFF
--- a/scripts/find-repo-files.py
+++ b/scripts/find-repo-files.py
@@ -38,6 +38,7 @@ css = []
 idl = []
 webidl = []
 ipdl = []
+staticprefs = []
 
 dirs = collections.OrderedDict()
 ipdl_dirs = collections.OrderedDict()
@@ -114,6 +115,11 @@ for line in lines:
 
         css.append(path + '\n')
 
+    name = os.path.basename(path)
+
+    if name == 'StaticPrefList.yaml':
+        staticprefs.append(path + '\n')
+
 index_path = tree_config['index_path']
 open(os.path.join(index_path, 'repo-files'), 'w').writelines(files)
 open(os.path.join(index_path, 'repo-dirs'), 'w').writelines([d + '\n' for d in dirs])
@@ -124,3 +130,4 @@ open(os.path.join(index_path, 'idl-files'), 'w').writelines(idl)
 open(os.path.join(index_path, 'webidl-files'), 'w').writelines(webidl)
 open(os.path.join(index_path, 'ipdl-files'), 'w').writelines(ipdl)
 open(os.path.join(index_path, 'ipdl-includes'), 'w').write(' '.join(['-I ' + d for d in ipdl_dirs]))
+open(os.path.join(index_path, 'staticprefs-files'), 'w').writelines(staticprefs)

--- a/scripts/load-vars.sh
+++ b/scripts/load-vars.sh
@@ -25,6 +25,7 @@ export HISTORY_ROOT=$(jq -r ".trees[\"${TREE_NAME}\"].history_path" ${CONFIG_FIL
 export TREE_ON_ERROR=$(jq -r ".trees[\"${TREE_NAME}\"].on_error" ${CONFIG_FILE})
 export TREE_CACHING=$(jq -r ".trees[\"${TREE_NAME}\"].cache" ${CONFIG_FILE})
 export WEBIDL_BINDINGS_LOCAL_PATH=$(jq -r ".trees[\"${TREE_NAME}\"].webidl_binding_local_path" ${CONFIG_FILE})
+export STATICPREFS_BINDINGS_LOCAL_PATH=$(jq -r ".trees[\"${TREE_NAME}\"].staticprefs_binding_local_path" ${CONFIG_FILE})
 
 handle_tree_error() {
     local msg=$1

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -94,6 +94,10 @@ $MOZSEARCH_PATH/scripts/idl-analyze.sh $CONFIG_FILE $TREE_NAME || handle_tree_er
 
 date
 
+$MOZSEARCH_PATH/scripts/staticprefs-analyze.sh $CONFIG_FILE $TREE_NAME || handle_tree_error "idl-analyze.sh"
+
+date
+
 $MOZSEARCH_PATH/scripts/ipdl-analyze.sh $CONFIG_FILE $TREE_NAME || handle_tree_error "ipdl-analyze.sh"
 
 date

--- a/scripts/staticprefs-analyze.py
+++ b/scripts/staticprefs-analyze.py
@@ -39,11 +39,18 @@ def read_cpp_analysis_one(path, cpp_symbols):
 
         sym = j['sym']
         m = re.match('.+StaticPrefs[0-9]+(.+)Ev$', sym)
-        if not m:
-            continue
+        if m:
+            id = m.group(1)
+        else:
+            m = re.match('.+JS5Prefs[0-9]+(.+)Ev$', sym)
+            if m:
+                id = f'javascript_options_{m.group(1)}'
+            else:
+                continue
 
-        id = m.group(1)
-        cpp_symbols[id] = sym
+        if id not in cpp_symbols:
+            cpp_symbols[id] = set()
+        cpp_symbols[id].add(sym)
 
 
 def read_cpp_analysis(ns, yaml_path, bindings_local_path, analysis_root):
@@ -69,15 +76,27 @@ def read_cpp_analysis(ns, yaml_path, bindings_local_path, analysis_root):
                 p = os.path.join(generated_dir, name, header_local_path)
                 read_cpp_analysis_one(p, cpp_symbols)
 
+        if ns == 'javascript':
+            # Load SpiderMonkey-specific binding.
+            header_local_path = 'js/public/PrefsGenerated.h'
+
+            p = os.path.join(generated_dir, header_local_path)
+            read_cpp_analysis_one(p, cpp_symbols)
+
+            for name in os.listdir(generated_dir):
+                if name.startswith('__'):
+                    p = os.path.join(generated_dir, name, header_local_path)
+                    read_cpp_analysis_one(p, cpp_symbols)
+
     return cpp_symbols
 
 
 pref_bindings_map = {}
 
 
-def get_cpp_symbol(name, yaml_path, bindings_local_path, analysis_root):
-    '''Get the corresponding binding C++ symbol for the preference name.
-    Returns None if no binding is found.'''
+def get_cpp_symbols(name, yaml_path, bindings_local_path, analysis_root):
+    '''Get the corresponding binding C++ symbols for the preference name.
+    Returns an empty list if no binding is found.'''
     ns = name.split('.')[0]
 
     if ns in pref_bindings_map:
@@ -89,7 +108,7 @@ def get_cpp_symbol(name, yaml_path, bindings_local_path, analysis_root):
     id = mk_id(name)
 
     if id not in cpp_symbols:
-        return None
+        return []
 
     return cpp_symbols[id]
 
@@ -115,8 +134,8 @@ def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
 
                 slots = []
 
-                cpp_sym = get_cpp_symbol(name, yaml_path, bindings_local_path, analysis_root)
-                if cpp_sym is not None:
+                cpp_syms = get_cpp_symbols(name, yaml_path, bindings_local_path, analysis_root)
+                for cpp_sym in cpp_syms:
                     slots.append({
                         'slotKind': 'getter',
                         'slotLang': 'cpp',

--- a/scripts/staticprefs-analyze.py
+++ b/scripts/staticprefs-analyze.py
@@ -129,7 +129,6 @@ def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
                 name = m.group(2)
 
                 loc = to_loc_with(lineno, len(prefix), len(name))
-                pretty = f'StaticPrefs {name}'
                 sym = f'PREFS_{mk_id(name)}'
 
                 slots = []
@@ -147,7 +146,7 @@ def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
                     'loc': loc,
                     'source': 1,
                     'syntax': 'def',
-                    'pretty': pretty,
+                    'pretty': f'StaticPrefs {name}',
                     'sym': sym,
                 })
 
@@ -155,14 +154,14 @@ def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
                     'loc': loc,
                     'target': 1,
                     'kind': 'def',
-                    'pretty': pretty,
+                    'pretty': name,
                     'sym': sym,
                 })
 
                 records.append({
                     'loc': loc,
                     'structured': 1,
-                    'pretty': pretty,
+                    'pretty': name,
                     'sym': sym,
                     'kind': 'prefs',
                     'implKind': 'StaticPrefs',

--- a/scripts/staticprefs-analyze.py
+++ b/scripts/staticprefs-analyze.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+
+import json
+import os
+import re
+import sys
+
+
+# imported from m-c/modules/libpref/init/generate_static_pref_list.py
+def mk_id(name):
+    "Replace '.' and '-' with '_', e.g. 'foo.bar-baz' becomes 'foo_bar_baz'."
+    return name.replace('.', '_').replace('-', '_')
+
+
+def read_cpp_analysis_one(path, cpp_symbols):
+    '''Read given analysis file and collect C++ symbols for generated code.'''
+
+    if not os.path.exists(path):
+        print('no', path)
+        return
+
+    try:
+        lines = open(path).readlines()
+    except IOError as e:
+        return
+
+    for line in lines:
+        try:
+            j = json.loads(line.strip())
+        except ValueError as e:
+            print('Syntax error in JSON file', path, line.strip(), file=sys.stderr)
+            raise e
+
+        if 'target' not in j:
+            continue
+
+        if j['kind'] != 'def':
+            continue
+
+        sym = j['sym']
+        m = re.match('.+StaticPrefs[0-9]+(.+)Ev$', sym)
+        if not m:
+            continue
+
+        id = m.group(1)
+        cpp_symbols[id] = sym
+
+
+def read_cpp_analysis(ns, yaml_path, bindings_local_path, analysis_root):
+    '''Read analysis files for given StaticPrefs file and collect C++ symbols
+    for generated code.'''
+
+    header_name = f'StaticPrefList_{ns}.h'
+    cpp_symbols = {}
+
+    if bindings_local_path:
+        # Override the paths for bindings for testing.
+        p = os.path.join(analysis_root, bindings_local_path, header_name)
+        read_cpp_analysis_one(p, cpp_symbols)
+    else:
+        generated_dir = os.path.join(analysis_root, '__GENERATED__')
+        header_local_path = os.path.join(os.path.dirname(yaml_path), header_name)
+
+        p = os.path.join(generated_dir, header_local_path)
+        read_cpp_analysis_one(p, cpp_symbols)
+
+        for name in os.listdir(generated_dir):
+            if name.startswith('__'):
+                p = os.path.join(generated_dir, name, header_local_path)
+                read_cpp_analysis_one(p, cpp_symbols)
+
+    return cpp_symbols
+
+
+pref_bindings_map = {}
+
+
+def get_cpp_symbol(name, yaml_path, bindings_local_path, analysis_root):
+    '''Get the corresponding binding C++ symbol for the preference name.
+    Returns None if no binding is found.'''
+    ns = name.split('.')[0]
+
+    if ns in pref_bindings_map:
+        cpp_symbols = pref_bindings_map[ns]
+    else:
+        cpp_symbols = read_cpp_analysis(ns, yaml_path, bindings_local_path, analysis_root)
+        pref_bindings_map[ns] = cpp_symbols
+
+    id = mk_id(name)
+
+    if id not in cpp_symbols:
+        return None
+
+    return cpp_symbols[id]
+
+
+def to_loc_with(lineno, colno, name_len):
+    return f'{lineno}:{colno}-{colno + name_len}'
+
+
+def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
+    records = []
+
+    with open(os.path.join(files_root, yaml_path), 'r') as f:
+        lineno = 1
+        for line in f:
+            m = re.match('^(- name: )(.+)', line.rstrip())
+            if m:
+                prefix = m.group(1)
+                name = m.group(2)
+
+                loc = to_loc_with(lineno, len(prefix), len(name))
+                pretty = f'StaticPrefs {name}'
+                sym = f'PREFS_{mk_id(name)}'
+
+                slots = []
+
+                cpp_sym = get_cpp_symbol(name, yaml_path, bindings_local_path, analysis_root)
+                if cpp_sym is not None:
+                    slots.append({
+                        'slotKind': 'getter',
+                        'slotLang': 'cpp',
+                        'ownerLang': 'prefs',
+                        'sym': cpp_sym,
+                    })
+
+                records.append({
+                    'loc': loc,
+                    'source': 1,
+                    'syntax': 'def',
+                    'pretty': pretty,
+                    'sym': sym,
+                })
+
+                records.append({
+                    'loc': loc,
+                    'target': 1,
+                    'kind': 'def',
+                    'pretty': pretty,
+                    'sym': sym,
+                })
+
+                records.append({
+                    'loc': loc,
+                    'structured': 1,
+                    'pretty': pretty,
+                    'sym': sym,
+                    'kind': 'prefs',
+                    'implKind': 'StaticPrefs',
+                    'bindingSlots': slots,
+                })
+
+            lineno += 1
+
+    analysis_path = os.path.join(analysis_root, yaml_path)
+    print('StaticPrefs: Generating', analysis_path, file=sys.stderr)
+
+    parent = os.path.dirname(analysis_path)
+    os.makedirs(parent, exist_ok=True)
+
+    with open(analysis_path, 'w') as f:
+        for r in records:
+            print(json.dumps(r), file=f)
+
+
+files_path = sys.argv[1]
+
+bindings_local_path = sys.argv[2]
+if bindings_local_path == 'null':
+    bindings_local_path = ''
+
+files_root = sys.argv[3]
+analysis_root = sys.argv[4]
+
+with open(files_path, 'r') as f:
+    for line in f:
+        process_file(line.strip(), bindings_local_path,
+                     files_root, analysis_root)

--- a/scripts/staticprefs-analyze.py
+++ b/scripts/staticprefs-analyze.py
@@ -123,7 +123,7 @@ def process_file(yaml_path, bindings_local_path, files_root, analysis_root):
     with open(os.path.join(files_root, yaml_path), 'r') as f:
         lineno = 1
         for line in f:
-            m = re.match('^(- name: )(.+)', line.rstrip())
+            m = re.match('^(- +name: )(.+)', line.rstrip())
             if m:
                 prefix = m.group(1)
                 name = m.group(2)

--- a/scripts/staticprefs-analyze.sh
+++ b/scripts/staticprefs-analyze.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -x # Show commands
+set -eu # Errors/undefined vars are fatal
+set -o pipefail # Check all commands in a pipeline
+
+$MOZSEARCH_PATH/scripts/staticprefs-analyze.py \
+    $INDEX_ROOT/staticprefs-files \
+    $STATICPREFS_BINDINGS_LOCAL_PATH \
+    $FILES_ROOT $INDEX_ROOT/analysis

--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -716,7 +716,7 @@ var ContextMenu = new (class ContextMenu extends ContextMenuBase {
 
           // If there were multiple language bindings that we think might exist,
           // then generate a single roll-up search.
-          if (allSearchSyms.length > 1) {
+          if (allSearchSyms.length > 1 && implKind !== "StaticPrefs") {
             // Eat the default search if this was IDL, as currently the "search"
             // endpoint search for the synthetic symbol will only do upsells
             // which is not what people are used to.

--- a/tests/config.json
+++ b/tests/config.json
@@ -12,6 +12,7 @@
       "index_path": "$WORKING/tests",
       "files_path": "$WORKING/tests/files",
       "webidl_binding_local_path": "webidl/bindings",
+      "staticprefs_binding_local_path": "staticprefs/bindings",
       "objdir_path": "$WORKING/tests/objdir",
       "wpt_root": "testing/web-platform",
       "codesearch_path": "$WORKING/tests/livegrep.idx",

--- a/tests/tests/checks/inputs/analysis/staticprefs/staticprefs__json
+++ b/tests/tests/checks/inputs/analysis/staticprefs/staticprefs__json
@@ -1,0 +1,1 @@
+filter-analysis staticprefs/StaticPrefList.yaml

--- a/tests/tests/checks/snapshots/analysis/staticprefs/check_glob@staticprefs__json.snap
+++ b/tests/tests/checks/snapshots/analysis/staticprefs/check_glob@staticprefs__json.snap
@@ -14,13 +14,13 @@ expression: "&json_results"
     "loc": "1:8-16",
     "target": 1,
     "kind": "def",
-    "pretty": "StaticPrefs test.int",
+    "pretty": "test.int",
     "sym": "PREFS_test_int"
   },
   {
     "loc": "1:8-16",
     "structured": 1,
-    "pretty": "StaticPrefs test.int",
+    "pretty": "test.int",
     "sym": "PREFS_test_int",
     "kind": "prefs",
     "implKind": "StaticPrefs",
@@ -44,13 +44,13 @@ expression: "&json_results"
     "loc": "6:8-18",
     "target": 1,
     "kind": "def",
-    "pretty": "StaticPrefs test2.uint",
+    "pretty": "test2.uint",
     "sym": "PREFS_test2_uint"
   },
   {
     "loc": "6:8-18",
     "structured": 1,
-    "pretty": "StaticPrefs test2.uint",
+    "pretty": "test2.uint",
     "sym": "PREFS_test2_uint",
     "kind": "prefs",
     "implKind": "StaticPrefs",
@@ -74,13 +74,13 @@ expression: "&json_results"
     "loc": "11:8-17",
     "target": 1,
     "kind": "def",
-    "pretty": "StaticPrefs test.bool",
+    "pretty": "test.bool",
     "sym": "PREFS_test_bool"
   },
   {
     "loc": "11:8-17",
     "structured": 1,
-    "pretty": "StaticPrefs test.bool",
+    "pretty": "test.bool",
     "sym": "PREFS_test_bool",
     "kind": "prefs",
     "implKind": "StaticPrefs",
@@ -104,13 +104,13 @@ expression: "&json_results"
     "loc": "17:8-16",
     "target": 1,
     "kind": "def",
-    "pretty": "StaticPrefs test.str",
+    "pretty": "test.str",
     "sym": "PREFS_test_str"
   },
   {
     "loc": "17:8-16",
     "structured": 1,
-    "pretty": "StaticPrefs test.str",
+    "pretty": "test.str",
     "sym": "PREFS_test_str",
     "kind": "prefs",
     "implKind": "StaticPrefs",

--- a/tests/tests/checks/snapshots/analysis/staticprefs/check_glob@staticprefs__json.snap
+++ b/tests/tests/checks/snapshots/analysis/staticprefs/check_glob@staticprefs__json.snap
@@ -1,0 +1,119 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+---
+[
+  {
+    "loc": "1:8-16",
+    "source": 1,
+    "syntax": "def",
+    "pretty": "StaticPrefs test.int",
+    "sym": "PREFS_test_int"
+  },
+  {
+    "loc": "1:8-16",
+    "target": 1,
+    "kind": "def",
+    "pretty": "StaticPrefs test.int",
+    "sym": "PREFS_test_int"
+  },
+  {
+    "loc": "1:8-16",
+    "structured": 1,
+    "pretty": "StaticPrefs test.int",
+    "sym": "PREFS_test_int",
+    "kind": "prefs",
+    "implKind": "StaticPrefs",
+    "bindingSlots": [
+      {
+        "slotKind": "getter",
+        "slotLang": "cpp",
+        "ownerLang": "prefs",
+        "sym": "_ZN7mozilla11StaticPrefs8test_intEv"
+      }
+    ]
+  },
+  {
+    "loc": "6:8-18",
+    "source": 1,
+    "syntax": "def",
+    "pretty": "StaticPrefs test2.uint",
+    "sym": "PREFS_test2_uint"
+  },
+  {
+    "loc": "6:8-18",
+    "target": 1,
+    "kind": "def",
+    "pretty": "StaticPrefs test2.uint",
+    "sym": "PREFS_test2_uint"
+  },
+  {
+    "loc": "6:8-18",
+    "structured": 1,
+    "pretty": "StaticPrefs test2.uint",
+    "sym": "PREFS_test2_uint",
+    "kind": "prefs",
+    "implKind": "StaticPrefs",
+    "bindingSlots": [
+      {
+        "slotKind": "getter",
+        "slotLang": "cpp",
+        "ownerLang": "prefs",
+        "sym": "_ZN7mozilla11StaticPrefs10test2_uintEv"
+      }
+    ]
+  },
+  {
+    "loc": "11:8-17",
+    "source": 1,
+    "syntax": "def",
+    "pretty": "StaticPrefs test.bool",
+    "sym": "PREFS_test_bool"
+  },
+  {
+    "loc": "11:8-17",
+    "target": 1,
+    "kind": "def",
+    "pretty": "StaticPrefs test.bool",
+    "sym": "PREFS_test_bool"
+  },
+  {
+    "loc": "11:8-17",
+    "structured": 1,
+    "pretty": "StaticPrefs test.bool",
+    "sym": "PREFS_test_bool",
+    "kind": "prefs",
+    "implKind": "StaticPrefs",
+    "bindingSlots": [
+      {
+        "slotKind": "getter",
+        "slotLang": "cpp",
+        "ownerLang": "prefs",
+        "sym": "_ZN7mozilla11StaticPrefs9test_boolEv"
+      }
+    ]
+  },
+  {
+    "loc": "17:8-16",
+    "source": 1,
+    "syntax": "def",
+    "pretty": "StaticPrefs test.str",
+    "sym": "PREFS_test_str"
+  },
+  {
+    "loc": "17:8-16",
+    "target": 1,
+    "kind": "def",
+    "pretty": "StaticPrefs test.str",
+    "sym": "PREFS_test_str"
+  },
+  {
+    "loc": "17:8-16",
+    "structured": 1,
+    "pretty": "StaticPrefs test.str",
+    "sym": "PREFS_test_str",
+    "kind": "prefs",
+    "implKind": "StaticPrefs",
+    "bindingSlots": []
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -582,6 +582,12 @@ Spread over multiple lines.
         </tr>
 
         <tr>
+          <td><a href="/tests/source/staticprefs" class="mimetype-fixed-container mimetype-icon-folder">staticprefs</a></td>
+          <td class="description"><a href="/tests/source/staticprefs" title=""></td>
+          <td><a href="/tests/source/staticprefs"></a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/subdir" class="mimetype-fixed-container mimetype-icon-folder">subdir</a></td>
           <td class="description"><a href="/tests/source/subdir" title=""></td>
           <td><a href="/tests/source/subdir"></a></td>

--- a/tests/tests/files/staticprefs/StaticPrefList.yaml
+++ b/tests/tests/files/staticprefs/StaticPrefList.yaml
@@ -1,0 +1,20 @@
+- name: test.int
+  type: int32_t
+  value: 10
+  mirror: always
+
+- name: test2.uint
+  type: uint32_t
+  value: 20
+  mirror: always
+
+- name: test.bool
+  type: bool
+  value: false
+  mirror: always
+
+# String won't get binding.
+- name: test.str
+  type: String
+  value: "Hello"
+  mirror: never

--- a/tests/tests/files/staticprefs/StaticPrefsConsumer.cpp
+++ b/tests/tests/files/staticprefs/StaticPrefsConsumer.cpp
@@ -1,0 +1,13 @@
+#include <stdint.h>
+
+#include "bindings/StaticPrefList_test.h"
+#include "bindings/StaticPrefList_test2.h"
+
+int32_t
+StaticPrefsConsumer() {
+  int32_t v1 = mozilla::StaticPrefs::test_int();
+  uint32_t v2 = mozilla::StaticPrefs::test2_uint();
+  bool v3 = mozilla::StaticPrefs::test_bool();
+
+  return int32_t(v1) + int32_t(v2) + int32_t(v3);
+}

--- a/tests/tests/files/staticprefs/bindings/StaticPrefList_test.h
+++ b/tests/tests/files/staticprefs/bindings/StaticPrefList_test.h
@@ -1,0 +1,17 @@
+#include <stdint.h>
+
+namespace mozilla {
+namespace StaticPrefs {
+
+inline int32_t
+test_int() {
+  return 10;
+}
+
+inline bool
+test_bool() {
+  return false;
+}
+
+}  // namespace mozilla
+}  // namespace StaticPrefs

--- a/tests/tests/files/staticprefs/bindings/StaticPrefList_test2.h
+++ b/tests/tests/files/staticprefs/bindings/StaticPrefList_test2.h
@@ -1,0 +1,12 @@
+#include <stdint.h>
+
+namespace mozilla {
+namespace StaticPrefs {
+
+inline uint32_t
+test2_uint() {
+  return 20;
+}
+
+}  // namespace mozilla
+}  // namespace StaticPrefs

--- a/tests/webtest-config.json
+++ b/tests/webtest-config.json
@@ -12,6 +12,7 @@
       "index_path": "$WORKING/tests",
       "files_path": "$WORKING/tests/files",
       "webidl_binding_local_path": "webidl/bindings",
+      "staticprefs_binding_local_path": "staticprefs/bindings",
       "objdir_path": "$WORKING/tests/objdir",
       "wpt_root": "testing/web-platform",
       "codesearch_path": "$WORKING/tests/livegrep.idx",

--- a/tools/src/describe.rs
+++ b/tools/src/describe.rs
@@ -33,6 +33,7 @@ pub fn describe_file(contents: &str, path: &Path, format: &FormatAs) -> Option<S
             }
         }
         FormatAs::Binary => None,
+        FormatAs::StaticPrefs => None,
         FormatAs::Plain => {
             let stem = path.file_stem()?.to_str()?;
             if stem.eq_ignore_ascii_case("README") {

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -370,6 +370,7 @@ pub enum BindingSlotLang {
 #[serde(rename_all = "lowercase")]
 pub enum BindingOwnerLang {
     Idl,
+    Prefs,
     Cpp,
     JS,
     Rust,

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -55,6 +55,7 @@ pub fn format_code(
         FormatAs::Binary => panic!("Unexpected binary file"),
         FormatAs::CSS => tokenize::tokenize_css(&input),
         FormatAs::Plain => tokenize::tokenize_plain(&input),
+        FormatAs::StaticPrefs => tokenize::tokenize_static_prefs(&input),
         FormatAs::FormatCLike(spec) => tokenize::tokenize_c_like(&input, spec),
         FormatAs::FormatTagLike(script_spec) => tokenize::tokenize_tag_like(&input, script_spec),
     };
@@ -392,6 +393,7 @@ pub fn format_code(
                 FormatAs::Binary => panic!("Unexpected binary file"),
                 FormatAs::CSS => tokenize::tokenize_css(input),
                 FormatAs::Plain => tokenize::tokenize_plain(input),
+                FormatAs::StaticPrefs => tokenize::tokenize_static_prefs(&input),
                 FormatAs::FormatCLike(spec) => tokenize::tokenize_c_like(input, spec),
                 FormatAs::FormatTagLike(script_spec) => {
                     tokenize::tokenize_tag_like(input, script_spec)

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -653,6 +653,7 @@ pub enum FormatAs {
     FormatTagLike(&'static LanguageSpec),
     CSS,
     Plain,
+    StaticPrefs,
     Binary,
 }
 
@@ -684,6 +685,16 @@ pub fn select_formatting(filename: &str) -> FormatAs {
         | "icns" | "ico" | "mp4" | "sqlite" | "jar" | "webm" | "webp" | "woff" | "class"
         | "m4s" | "mgif" | "wav" | "opus" | "mp3" | "otf" => FormatAs::Binary,
 
-        _ => FormatAs::Plain,
+        _ => {
+            let name = match Path::new(filename).file_name() {
+                Some(name) => name.to_str().unwrap(),
+                None => "",
+            };
+
+            match name {
+                "StaticPrefList.yaml" => FormatAs::StaticPrefs,
+                _ => FormatAs::Plain,
+            }
+        }
     }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1699048

This does:
  * Index each item in `StaticPrefList.yaml`, with `PREFS_{id}` symbol
  * Create structured record for the `StaticPrefList.yaml` items, adding the C++ binding to the getter binding slot.
  * Support tokenizing `StaticPrefList.yaml`, with treating the pref name as identifier, supporting comments and strings

Example in `StaticPrefList.yaml`:
https://arai.searchfox.org/mozilla-central/source/modules/libpref/init/StaticPrefList.yaml#213

<img width="697" alt="pref-menu" src="https://github.com/user-attachments/assets/fa23c44e-4f1c-4c7e-828f-419d6a12d605">

Example in the consumer of the binding:
https://arai.searchfox.org/mozilla-central/source/dom/base/FocusModel.h#36

<img width="735" alt="binding-menu" src="https://github.com/user-attachments/assets/c7414ffe-785f-49ed-9e93-8c2783fe805f">
