### PR TITLE
Bug 1931631- C++ indexer should treat constructor member initializer list field uses as having a contextsym of the constructor

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2393,8 +2393,13 @@ public:
 
       FieldDecl *Member = Ci->getMember();
       std::string Mangled = getMangledName(CurMangleContext, Member);
+      // We want the constructor to be the context of the field use and
+      // `getContext(D)` would skip the current context.  An alternate approach
+      // would be `getContext(Loc)` but the heuristic to omit a context if we're
+      // in a macro body expansion seems incorrect for field initializations; if
+      // code is using macros to initialize the fields, we still care.
       visitIdentifier("use", "field", getQualifiedName(Member), Loc, Mangled,
-                      Member->getType(), getContext(D));
+                      Member->getType(), translateContext(D));
     }
 
     return true;

--- a/tests/tests/checks/inputs/crossref/crossref/big_cpp.cpp/thing_mHP__json
+++ b/tests/tests/checks/inputs/crossref/crossref/big_cpp.cpp/thing_mHP__json
@@ -1,0 +1,1 @@
+search-identifiers outerNS::Thing::mHP | crossref-lookup

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@stackartholder__json.snap
@@ -28,12 +28,6 @@ expression: "&to_value(scil).unwrap()"
         ],
         "callees": [
           {
-            "jump": "big_cpp.cpp#463",
-            "kind": "field",
-            "pretty": "outerNS::StackArtHolder::mHeldArt",
-            "sym": "F_<T_outerNS::StackArtHolder>_mHeldArt"
-          },
-          {
             "jump": "big_cpp.cpp#460",
             "kind": "class",
             "pretty": "outerNS::PracticalArt",

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing__json.snap
@@ -144,20 +144,6 @@ expression: "&to_value(scil).unwrap()"
             ]
           }
         ],
-        "callees": [
-          {
-            "jump": "big_cpp.cpp#156",
-            "kind": "field",
-            "pretty": "outerNS::Thing::mDefunct",
-            "sym": "F_<T_outerNS::Thing>_mDefunct"
-          },
-          {
-            "jump": "big_cpp.cpp#155",
-            "kind": "field",
-            "pretty": "outerNS::Thing::mHP",
-            "sym": "F_<T_outerNS::Thing>_mHP"
-          }
-        ],
         "meta": {
           "structured": 1,
           "pretty": "outerNS::Thing",

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing_mHP__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing_mHP__json.snap
@@ -1,0 +1,94 @@
+---
+source: tests/test_check_insta.rs
+expression: "&to_value(scil).unwrap()"
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "F_<T_outerNS::Thing>_mHP",
+      "crossref_info": {
+        "uses": [
+          {
+            "path": "big_cpp.cpp",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 155,
+                "bounds": [
+                  2,
+                  5
+                ],
+                "line": ": mHP(baseHP)",
+                "context": "outerNS::Thing",
+                "contextsym": "T_outerNS::Thing"
+              },
+              {
+                "lno": 163,
+                "bounds": [
+                  0,
+                  3
+                ],
+                "line": "mHP -= damage;",
+                "context": "outerNS::Thing::takeDamage",
+                "contextsym": "_ZN7outerNS5Thing10takeDamageEi"
+              },
+              {
+                "lno": 455,
+                "bounds": [
+                  0,
+                  3
+                ],
+                "line": "mHP++;",
+                "context": "outerNS::PracticalArt::beArt",
+                "contextsym": "_ZN7outerNS12PracticalArt5beArtEv"
+              }
+            ]
+          }
+        ],
+        "defs": [
+          {
+            "path": "big_cpp.cpp",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 147,
+                "bounds": [
+                  4,
+                  7
+                ],
+                "line": "int mHP;",
+                "context": "outerNS::Thing",
+                "contextsym": "T_outerNS::Thing",
+                "peekRange": "143-147"
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "outerNS::Thing::mHP",
+          "sym": "F_<T_outerNS::Thing>_mHP",
+          "type_pretty": null,
+          "kind": "field",
+          "subsystem": "Core/Big",
+          "parentsym": "T_outerNS::Thing",
+          "implKind": "",
+          "sizeBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        }
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing_mHP__json.snap
+++ b/tests/tests/checks/snapshots/crossref/crossref/big_cpp.cpp/check_glob@thing_mHP__json.snap
@@ -19,8 +19,8 @@ expression: "&to_value(scil).unwrap()"
                   5
                 ],
                 "line": ": mHP(baseHP)",
-                "context": "outerNS::Thing",
-                "contextsym": "T_outerNS::Thing"
+                "context": "outerNS::Thing::Thing",
+                "contextsym": "_ZN7outerNS5ThingC1Ei"
               },
               {
                 "lno": 163,

--- a/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
+++ b/tests/tests/checks/snapshots/crossref/expand/big_cpp.cpp/check_glob@outercat__json.snap
@@ -56,18 +56,6 @@ expression: "&to_value(scil).unwrap()"
         ],
         "callees": [
           {
-            "jump": "big_cpp.cpp#268",
-            "kind": "field",
-            "pretty": "outerNS::OuterCat::mIsFriendly",
-            "sym": "F_<T_outerNS::OuterCat>_mIsFriendly"
-          },
-          {
-            "jump": "big_cpp.cpp#272",
-            "kind": "field",
-            "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
-            "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly"
-          },
-          {
             "jump": "big_cpp.cpp#245",
             "kind": "class",
             "pretty": "outerNS::Couch",
@@ -440,20 +428,6 @@ expression: "&to_value(scil).unwrap()"
                 "peekRange": "141-141"
               }
             ]
-          }
-        ],
-        "callees": [
-          {
-            "jump": "big_cpp.cpp#156",
-            "kind": "field",
-            "pretty": "outerNS::Thing::mDefunct",
-            "sym": "F_<T_outerNS::Thing>_mDefunct"
-          },
-          {
-            "jump": "big_cpp.cpp#155",
-            "kind": "field",
-            "pretty": "outerNS::Thing::mHP",
-            "sym": "F_<T_outerNS::Thing>_mHP"
           }
         ],
         "meta": {

--- a/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/check_glob@merge__big_cpp.snap
@@ -255,8 +255,8 @@ expression: "&json_results"
     "kind": "use",
     "pretty": "outerNS::Thing::mHP",
     "sym": "F_<T_outerNS::Thing>_mHP",
-    "context": "outerNS::Thing",
-    "contextsym": "T_outerNS::Thing"
+    "context": "outerNS::Thing::Thing",
+    "contextsym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00156:4-12",
@@ -264,8 +264,8 @@ expression: "&json_results"
     "kind": "use",
     "pretty": "outerNS::Thing::mDefunct",
     "sym": "F_<T_outerNS::Thing>_mDefunct",
-    "context": "outerNS::Thing",
-    "contextsym": "T_outerNS::Thing"
+    "context": "outerNS::Thing::Thing",
+    "contextsym": "_ZN7outerNS5ThingC1Ei"
   },
   {
     "loc": "00160:7-13",
@@ -720,8 +720,8 @@ expression: "&json_results"
     "kind": "use",
     "pretty": "outerNS::OuterCat::mIsFriendly",
     "sym": "F_<T_outerNS::OuterCat>_mIsFriendly",
-    "context": "outerNS::OuterCat",
-    "contextsym": "T_outerNS::OuterCat"
+    "context": "outerNS::OuterCat::OuterCat",
+    "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
   },
   {
     "loc": "00272:4-25",
@@ -729,8 +729,8 @@ expression: "&json_results"
     "kind": "use",
     "pretty": "outerNS::OuterCat::mIsSecretlyUnfriendly",
     "sym": "F_<T_outerNS::OuterCat>_mIsSecretlyUnfriendly",
-    "context": "outerNS::OuterCat",
-    "contextsym": "T_outerNS::OuterCat"
+    "context": "outerNS::OuterCat::OuterCat",
+    "contextsym": "_ZN7outerNS8OuterCatC1Ebb"
   },
   {
     "loc": "00320:7-20",
@@ -1288,8 +1288,8 @@ expression: "&json_results"
     "kind": "use",
     "pretty": "outerNS::StackArtHolder::mHeldArt",
     "sym": "F_<T_outerNS::StackArtHolder>_mHeldArt",
-    "context": "outerNS::StackArtHolder",
-    "contextsym": "T_outerNS::StackArtHolder"
+    "context": "outerNS::StackArtHolder::StackArtHolder",
+    "contextsym": "_ZN7outerNS14StackArtHolderC1ERNS_12PracticalArtE"
   },
   {
     "loc": "00466:10-17",


### PR DESCRIPTION
(see specific commit messages; commit 1 adds a check that captures our currently wrong logic and commit 2 then lets us see the effects of the fix.)