### PR TITLE
Bug 1835692 - Mark DependentScopeDeclRefExpr locations to be visited in instantiations.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2526,6 +2526,20 @@ public:
     for (const NamedDecl *D : Resolver->resolveDeclRefExpr(E)) {
       visitHeuristicResult(Loc, D);
     }
+
+    // Also record this location so that if we have instantiations, we can
+    // gather more accurate results from them.
+    if (TemplateStack) {
+      TemplateStack->visitDependent(Loc);
+
+      // Also record the dependent NestedNameSpecifier locations
+      for (auto NestedNameLoc = E->getQualifierLoc();
+           NestedNameLoc && NestedNameLoc.getNestedNameSpecifier()->isDependent();
+           NestedNameLoc = NestedNameLoc.getPrefix()) {
+        TemplateStack->visitDependent(NestedNameLoc.getLocalBeginLoc());
+      }
+    }
+
     return true;
   }
 

--- a/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Foo_E
+++ b/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/Foo_E
@@ -1,0 +1,1 @@
+filter-analysis bug1781178.cpp -i Foo::E

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E.snap
@@ -1,0 +1,61 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+snapshot_kind: text
+---
+[
+  {
+    "loc": "00012:7-8",
+    "source": 1,
+    "nestingRange": "12:9-14:2",
+    "syntax": "def,type",
+    "pretty": "type Foo::E",
+    "sym": "T_Foo::E"
+  },
+  {
+    "loc": "00012:7-8",
+    "target": 1,
+    "kind": "def",
+    "pretty": "Foo::E",
+    "sym": "T_Foo::E",
+    "context": "Foo",
+    "contextsym": "T_Foo",
+    "peekRange": "12-12"
+  },
+  {
+    "loc": "00036:10-11",
+    "source": 1,
+    "syntax": "use,type",
+    "type": "enum Foo::E",
+    "typesym": "T_Foo::E",
+    "pretty": "type Foo::E",
+    "sym": "T_Foo::E"
+  },
+  {
+    "loc": "00036:10-11",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Foo::E",
+    "sym": "T_Foo::E",
+    "context": "Foo::Bar",
+    "contextsym": "_ZN3Foo3BarEv"
+  },
+  {
+    "loc": "00071:22-23",
+    "source": 1,
+    "syntax": "use,type",
+    "type": "enum Foo<int>::E",
+    "typesym": "T_Foo::E",
+    "pretty": "type Foo::E",
+    "sym": "T_Foo::E"
+  },
+  {
+    "loc": "00071:22-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Foo::E",
+    "sym": "T_Foo::E",
+    "context": "func",
+    "contextsym": "_Z4funcv"
+  }
+]

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E_Waldo.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E_Waldo.snap
@@ -1,6 +1,7 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&json_results"
+snapshot_kind: text
 ---
 [
   {
@@ -38,5 +39,23 @@ expression: "&json_results"
     "sym": "E_<T_Foo::E>_Waldo",
     "context": "Foo::Bar",
     "contextsym": "_ZN3Foo3BarEv"
+  },
+  {
+    "loc": "00071:25-30",
+    "source": 1,
+    "syntax": "use,enum",
+    "type": "enum Foo<int>::E",
+    "typesym": "T_Foo::E",
+    "pretty": "enum Foo::E::Waldo",
+    "sym": "E_<T_Foo::E>_Waldo"
+  },
+  {
+    "loc": "00071:25-30",
+    "target": 1,
+    "kind": "use",
+    "pretty": "Foo::E::Waldo",
+    "sym": "E_<T_Foo::E>_Waldo",
+    "context": "func",
+    "contextsym": "_Z4funcv"
   }
 ]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -217,7 +217,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/bug1781178.cpp" class="mimetype-fixed-container mimetype-icon-cpp">bug1781178.cpp</a></td>
           <td class="description"><a href="/tests/source/bug1781178.cpp" title=""></td>
-          <td><a href="/tests/source/bug1781178.cpp">951</a></td>
+          <td><a href="/tests/source/bug1781178.cpp">1060</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/bug1781178.cpp
+++ b/tests/tests/files/bug1781178.cpp
@@ -64,3 +64,14 @@ template <typename T> struct DerivedPoint : Pint<T> {
     this->IsThereOne();
   }
 };
+
+template<typename T>
+void func()
+{
+    const auto _ = T::E::Waldo;
+}
+
+void test()
+{
+    func<Foo<int>>();
+}


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1835692

This adds DependentScopeDeclRefExpr locations as well as their dependent nested qualifiers to the DependentLocations set in GatherDependent mode.