### PR TITLE
Fix formatting (rustfmt & clang-format) and clippy lints

### DIFF
--- a/clang-plugin/.clang-format
+++ b/clang-plugin/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/clang-plugin/BindingOperations.h
+++ b/clang-plugin/BindingOperations.h
@@ -10,8 +10,10 @@
 
 void findBindingToJavaClass(clang::ASTContext &C, clang::CXXRecordDecl &klass);
 void findBoundAsJavaClasses(clang::ASTContext &C, clang::CXXRecordDecl &klass);
-void findBindingToJavaFunction(clang::ASTContext &C, clang::FunctionDecl &function);
-void findBindingToJavaMember(clang::ASTContext &C, clang::CXXMethodDecl &method);
+void findBindingToJavaFunction(clang::ASTContext &C,
+                               clang::FunctionDecl &function);
+void findBindingToJavaMember(clang::ASTContext &C,
+                             clang::CXXMethodDecl &method);
 void findBindingToJavaConstant(clang::ASTContext &C, clang::VarDecl &field);
 
 void emitBindingAttributes(llvm::json::OStream &json, const clang::Decl &decl);

--- a/clang-plugin/FileOperations.cpp
+++ b/clang-plugin/FileOperations.cpp
@@ -9,10 +9,10 @@
 #include <stdlib.h>
 
 #if defined(_WIN32) || defined(_WIN64)
+#include "StringOperations.h"
 #include <direct.h>
 #include <io.h>
 #include <windows.h>
-#include "StringOperations.h"
 #else
 #include <sys/file.h>
 #include <sys/time.h>
@@ -50,7 +50,8 @@ void ensurePath(std::string Path) {
 }
 
 #if defined(_WIN32) || defined(_WIN64)
-AutoLockFile::AutoLockFile(const std::string &SrcFile, const std::string &DstFile) {
+AutoLockFile::AutoLockFile(const std::string &SrcFile,
+                           const std::string &DstFile) {
   this->Filename = DstFile;
   std::string Hash = hash(SrcFile);
   std::string MutexName = std::string("Local\\searchfox-") + Hash;
@@ -71,12 +72,11 @@ AutoLockFile::~AutoLockFile() {
   CloseHandle(Handle);
 }
 
-bool AutoLockFile::success() {
-  return Handle != NULL;
-}
+bool AutoLockFile::success() { return Handle != NULL; }
 
 FILE *AutoLockFile::openTmp() {
-  int TmpDescriptor = _open((Filename + ".tmp").c_str(), _O_WRONLY | _O_APPEND | _O_CREAT | _O_BINARY, 0666);
+  int TmpDescriptor = _open((Filename + ".tmp").c_str(),
+                            _O_WRONLY | _O_APPEND | _O_CREAT | _O_BINARY, 0666);
   return _fdopen(TmpDescriptor, "ab");
 }
 
@@ -97,7 +97,8 @@ std::string getAbsolutePath(const std::string &Filename) {
   return std::string(Full);
 }
 #else
-AutoLockFile::AutoLockFile(const std::string &SrcFile, const std::string &DstFile) {
+AutoLockFile::AutoLockFile(const std::string &SrcFile,
+                           const std::string &DstFile) {
   this->Filename = DstFile;
   FileDescriptor = open(SrcFile.c_str(), O_RDONLY);
   if (FileDescriptor == -1) {
@@ -116,8 +117,9 @@ AutoLockFile::~AutoLockFile() { close(FileDescriptor); }
 
 bool AutoLockFile::success() { return FileDescriptor != -1; }
 
-FILE* AutoLockFile::openTmp() {
-  int TmpDescriptor = open((Filename + ".tmp").c_str(), O_WRONLY | O_APPEND | O_CREAT, 0666);
+FILE *AutoLockFile::openTmp() {
+  int TmpDescriptor =
+      open((Filename + ".tmp").c_str(), O_WRONLY | O_APPEND | O_CREAT, 0666);
   return fdopen(TmpDescriptor, "ab");
 }
 

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -88,7 +88,7 @@ enum class FileType {
 // Takes an absolute path to a file, and returns the type of file it is. If
 // it's a Source or Generated file, the provided inout path argument is modified
 // in-place so that it is relative to the source dir or objdir, respectively.
-FileType relativizePath(std::string& path) {
+FileType relativizePath(std::string &path) {
   if (path.compare(0, Objdir.length(), Objdir) == 0) {
     path.replace(0, Objdir.length(), GENERATED);
     return FileType::Generated;
@@ -96,7 +96,8 @@ FileType relativizePath(std::string& path) {
   // Empty filenames can get turned into Srcdir when they are resolved as
   // absolute paths, so we should exclude files that are exactly equal to
   // Srcdir or anything outside Srcdir.
-  if (path.length() > Srcdir.length() && path.compare(0, Srcdir.length(), Srcdir) == 0) {
+  if (path.length() > Srcdir.length() &&
+      path.compare(0, Srcdir.length(), Srcdir) == 0) {
     // Remove the trailing `/' as well.
     path.erase(0, Srcdir.length() + 1);
     return FileType::Source;
@@ -127,12 +128,12 @@ static bool isValidIdentifier(std::string Input) {
 }
 
 template <size_t N>
-static bool stringStartsWith(const std::string& Input,
+static bool stringStartsWith(const std::string &Input,
                              const char (&Prefix)[N]) {
   return Input.length() > N - 1 && memcmp(Input.c_str(), Prefix, N - 1) == 0;
 }
 
-static bool isASCII(const std::string& Input) {
+static bool isASCII(const std::string &Input) {
   for (char C : Input) {
     if (C & 0x80) {
       return false;
@@ -142,36 +143,27 @@ static bool isASCII(const std::string& Input) {
 }
 
 struct RAIITracer {
-  RAIITracer(const char *log) : mLog(log) {
-    printf("<%s>\n", mLog);
-  }
+  RAIITracer(const char *log) : mLog(log) { printf("<%s>\n", mLog); }
 
-  ~RAIITracer() {
-    printf("</%s>\n", mLog);
-  }
+  ~RAIITracer() { printf("</%s>\n", mLog); }
 
-  const char* mLog;
+  const char *mLog;
 };
 
 #define TRACEFUNC RAIITracer tracer(__FUNCTION__);
 
 // Sets variable to value on creation then resets variable to its original
 // value on destruction
-template<typename T>
-class ValueRollback {
+template <typename T> class ValueRollback {
 public:
-  template<typename U = T>
+  template <typename U = T>
   ValueRollback(T &variable, U &&value)
-    : mVariable{&variable}
-    , mSavedValue{std::exchange(variable, std::forward<U>(value))}
-  {
-  }
+      : mVariable{&variable},
+        mSavedValue{std::exchange(variable, std::forward<U>(value))} {}
 
   ValueRollback(ValueRollback &&other) noexcept
-    : mVariable{std::exchange(other.mVariable, nullptr)}
-    , mSavedValue{std::move(other.mSavedValue)}
-  {
-  }
+      : mVariable{std::exchange(other.mVariable, nullptr)},
+        mSavedValue{std::move(other.mSavedValue)} {}
 
   ValueRollback(const ValueRollback &) = delete;
   ValueRollback &operator=(ValueRollback &&) = delete;
@@ -189,7 +181,7 @@ private:
 
 class IndexConsumer;
 
-bool isPure(FunctionDecl* D) {
+bool isPure(FunctionDecl *D) {
 #if CLANG_VERSION_MAJOR >= 18
   return D->isPureVirtual();
 #else
@@ -204,18 +196,18 @@ bool isPure(FunctionDecl* D) {
 struct FileInfo {
   FileInfo(std::string &Rname) : Realname(Rname) {
     switch (relativizePath(Realname)) {
-      case FileType::Generated:
-        Interesting = true;
-        Generated = true;
-        break;
-      case FileType::Source:
-        Interesting = true;
-        Generated = false;
-        break;
-      case FileType::Unknown:
-        Interesting = false;
-        Generated = false;
-        break;
+    case FileType::Generated:
+      Interesting = true;
+      Generated = true;
+      break;
+    case FileType::Source:
+      Interesting = true;
+      Generated = false;
+      break;
+    case FileType::Unknown:
+      Interesting = false;
+      Generated = false;
+      break;
     }
   }
   std::string Realname;
@@ -227,7 +219,8 @@ struct FileInfo {
 struct MacroExpansionState {
   Token MacroNameToken;
   const MacroInfo *MacroInfo = nullptr;
-  std::vector<std::string> Dependencies; // other macro symbols this expansions depends on
+  // other macro symbols this expansion depends on
+  std::vector<std::string> Dependencies;
   std::string Expansion;
   std::map<SourceLocation, unsigned> TokenLocations;
   SourceRange Range;
@@ -255,10 +248,8 @@ public:
                            FileID PrevFID) override;
 
   virtual void InclusionDirective(SourceLocation HashLoc,
-                                  const Token &IncludeTok,
-                                  StringRef FileName,
-                                  bool IsAngled,
-                                  CharSourceRange FileNameRange,
+                                  const Token &IncludeTok, StringRef FileName,
+                                  bool IsAngled, CharSourceRange FileNameRange,
 #if CLANG_VERSION_MAJOR >= 16
                                   OptionalFileEntryRef File,
 #elif CLANG_VERSION_MAJOR >= 15
@@ -266,8 +257,7 @@ public:
 #else
                                   const FileEntry *File,
 #endif
-                                  StringRef SearchPath,
-                                  StringRef RelativePath,
+                                  StringRef SearchPath, StringRef RelativePath,
 #if CLANG_VERSION_MAJOR >= 19
                                   const Module *SuggestedModule,
                                   bool ModuleImported,
@@ -314,9 +304,11 @@ private:
   // Tracks the set of declarations that the current expression/statement is
   // nested inside of.
   struct AutoSetContext {
-    AutoSetContext(IndexConsumer *Self, NamedDecl *Context, bool VisitImplicit = false)
+    AutoSetContext(IndexConsumer *Self, NamedDecl *Context,
+                   bool VisitImplicit = false)
         : Self(Self), Prev(Self->CurDeclContext), Decl(Context) {
-      this->VisitImplicit = VisitImplicit || (Prev ? Prev->VisitImplicit : false);
+      this->VisitImplicit =
+          VisitImplicit || (Prev ? Prev->VisitImplicit : false);
       Self->CurDeclContext = this;
     }
 
@@ -419,8 +411,8 @@ private:
   // Convert SourceRange to "PATH#line-line" or "PATH#line".
   // If Range's file is same as fromFileID, PATH is omitted.
   std::string pathAndLineRangeToString(FileID fromFileID, SourceRange Range) {
-    FileInfo* toFile = getFileInfo(Range.getBegin());
-    FileInfo* fromFile = FileMap.find(fromFileID)->second.get();
+    FileInfo *toFile = getFileInfo(Range.getBegin());
+    FileInfo *fromFile = FileMap.find(fromFileID)->second.get();
 
     auto lineRange = lineRangeToString(Range, true);
 
@@ -453,7 +445,8 @@ private:
     if (IsInvalid) {
       return "";
     }
-    unsigned Column1 = SM.getColumnNumber(Begin.first, Begin.second, &IsInvalid);
+    unsigned Column1 =
+        SM.getColumnNumber(Begin.first, Begin.second, &IsInvalid);
     if (IsInvalid) {
       return "";
     }
@@ -496,8 +489,8 @@ private:
           std::string Backing;
           llvm::raw_string_ostream Stream(Backing);
           const TemplateArgumentList &TemplateArgs = Spec->getTemplateArgs();
-          printTemplateArgumentList(
-              Stream, TemplateArgs.asArray(), PrintingPolicy(CI.getLangOpts()));
+          printTemplateArgumentList(Stream, TemplateArgs.asArray(),
+                                    PrintingPolicy(CI.getLangOpts()));
           Result += Stream.str();
         }
       } else if (const auto *Nd = dyn_cast<NamespaceDecl>(DC)) {
@@ -548,8 +541,9 @@ private:
       // we need to include a platform-specific thing in the hash. Otherwise
       // we can end up with hash collisions where different symbols from
       // different platforms map to the same thing.
-      char* Platform = getenv("MOZSEARCH_PLATFORM");
-      Filename = std::string(Platform ? Platform : "") + std::string("@") + Filename;
+      char *Platform = getenv("MOZSEARCH_PLATFORM");
+      Filename =
+          std::string(Platform ? Platform : "") + std::string("@") + Filename;
     }
     return hash(Filename + std::string("@") + locationToString(Loc));
   }
@@ -569,8 +563,8 @@ private:
     // The majority of path characters are letters and slashes which don't get
     // encoded, so that satisfies (1). Since "@" characters in the unsanitized
     // path get encoded, there should be no "@" characters in the sanitized path
-    // that got preserved from the unsanitized input, so that should satisfy (2).
-    // And (3) was done by trial-and-error. Note in particular the dot (.)
+    // that got preserved from the unsanitized input, so that should satisfy
+    // (2). And (3) was done by trial-and-error. Note in particular the dot (.)
     // character needs to be encoded, or the symbol-search feature of mozsearch
     // doesn't work correctly, as all dot characters in the symbol query get
     // replaced by #.
@@ -590,8 +584,9 @@ private:
       // we need to include a platform-specific thing in the hash. Otherwise
       // we can end up with hash collisions where different symbols from
       // different platforms map to the same thing.
-      char* Platform = getenv("MOZSEARCH_PLATFORM");
-      Filename = std::string(Platform ? Platform : "") + std::string("@") + Filename;
+      char *Platform = getenv("MOZSEARCH_PLATFORM");
+      Filename =
+          std::string(Platform ? Platform : "") + std::string("@") + Filename;
     }
     return Filename;
   }
@@ -708,11 +703,11 @@ private:
 
 public:
   IndexConsumer(CompilerInstance &CI)
-      : CI(CI), SM(CI.getSourceManager()), LO(CI.getLangOpts()), CurMangleContext(nullptr),
-        AstContext(nullptr), ConcatInfo(CI.getPreprocessor()), CurDeclContext(nullptr),
+      : CI(CI), SM(CI.getSourceManager()), LO(CI.getLangOpts()),
+        CurMangleContext(nullptr), AstContext(nullptr),
+        ConcatInfo(CI.getPreprocessor()), CurDeclContext(nullptr),
         TemplateStack(nullptr) {
-    CI.getPreprocessor().addPPCallbacks(
-        make_unique<PreprocessorHook>(this));
+    CI.getPreprocessor().addPPCallbacks(make_unique<PreprocessorHook>(this));
     CI.getPreprocessor().setTokenWatcher(
         [this](const auto &token) { onTokenLexed(token); });
   }
@@ -741,7 +736,7 @@ public:
   // All we need is to follow the final declaration.
   virtual void HandleTranslationUnit(ASTContext &Ctx) {
     CurMangleContext =
-      clang::ItaniumMangleContext::create(Ctx, CI.getDiagnostics());
+        clang::ItaniumMangleContext::create(Ctx, CI.getDiagnostics());
 
     AstContext = &Ctx;
     Resolver = std::make_unique<clangd::HeuristicResolver>(Ctx);
@@ -757,9 +752,9 @@ public:
       FileInfo &Info = *It->second;
 
       std::string Filename = Outdir + Info.Realname;
-      std::string SrcFilename = Info.Generated
-        ? Objdir + Info.Realname.substr(GENERATED.length())
-        : Srcdir + PATHSEP_STRING + Info.Realname;
+      std::string SrcFilename =
+          Info.Generated ? Objdir + Info.Realname.substr(GENERATED.length())
+                         : Srcdir + PATHSEP_STRING + Info.Realname;
 
       ensurePath(Filename);
 
@@ -778,19 +773,21 @@ public:
       std::ifstream Fin(Filename.c_str(), std::ios::in | std::ios::binary);
       FILE *OutFp = Lock.openTmp();
       if (!OutFp) {
-        fprintf(stderr, "Unable to open tmp out file for %s\n", Filename.c_str());
+        fprintf(stderr, "Unable to open tmp out file for %s\n",
+                Filename.c_str());
         exit(1);
       }
 
       // Sort our new results and get an iterator to them
       std::sort(Info.Output.begin(), Info.Output.end());
-      std::vector<std::string>::const_iterator NewLinesIter = Info.Output.begin();
+      std::vector<std::string>::const_iterator NewLinesIter =
+          Info.Output.begin();
       std::string LastNewWritten;
 
       // Loop over the existing (sorted) lines in the analysis output file.
       // (The good() check also handles the case where Fin did not exist when we
       // went to open it.)
-      while(Fin.good()) {
+      while (Fin.good()) {
         std::string OldLine;
         std::getline(Fin, OldLine);
         // Skip blank lines.
@@ -815,8 +812,10 @@ public:
             // dedupe the new entries being written
             continue;
           }
-          if (fwrite(NewLinesIter->c_str(), NewLinesIter->length(), 1, OutFp) != 1) {
-            fprintf(stderr, "Unable to write %zu bytes[1] to tmp output file for %s\n",
+          if (fwrite(NewLinesIter->c_str(), NewLinesIter->length(), 1, OutFp) !=
+              1) {
+            fprintf(stderr,
+                    "Unable to write %zu bytes[1] to tmp output file for %s\n",
                     NewLinesIter->length(), Filename.c_str());
             exit(1);
           }
@@ -825,7 +824,8 @@ public:
 
         // Write the entry read from the existing file.
         if (fwrite(OldLine.c_str(), OldLine.length(), 1, OutFp) != 1) {
-          fprintf(stderr, "Unable to write %zu bytes[2] to tmp output file for %s\n",
+          fprintf(stderr,
+                  "Unable to write %zu bytes[2] to tmp output file for %s\n",
                   OldLine.length(), Filename.c_str());
           exit(1);
         }
@@ -839,8 +839,10 @@ public:
         if (*NewLinesIter == LastNewWritten) {
           continue;
         }
-        if (fwrite(NewLinesIter->c_str(), NewLinesIter->length(), 1, OutFp) != 1) {
-          fprintf(stderr, "Unable to write %zu bytes[3] to tmp output file for %s\n",
+        if (fwrite(NewLinesIter->c_str(), NewLinesIter->length(), 1, OutFp) !=
+            1) {
+          fprintf(stderr,
+                  "Unable to write %zu bytes[3] to tmp output file for %s\n",
                   NewLinesIter->length(), Filename.c_str());
           exit(1);
         }
@@ -851,7 +853,9 @@ public:
       // with the new one.
       fclose(OutFp);
       if (!Lock.moveTmp()) {
-        fprintf(stderr, "Unable to move tmp output file into place for %s (err %d)\n", Filename.c_str(), errno);
+        fprintf(stderr,
+                "Unable to move tmp output file into place for %s (err %d)\n",
+                Filename.c_str(), errno);
         exit(1);
       }
     }
@@ -950,7 +954,8 @@ public:
       D = F->getTemplateInstantiationPattern();
     }
 
-    return Context(D->getQualifiedNameAsString(), getMangledName(CurMangleContext, D));
+    return Context(D->getQualifiedNameAsString(),
+                   getMangledName(CurMangleContext, D));
   }
 
   Context getContext(SourceLocation Loc) {
@@ -990,7 +995,8 @@ public:
     return Context();
   }
 
-  // Searches for the closest CurDeclContext parent that is a function template instantiation
+  // Searches for the closest CurDeclContext parent that is a function template
+  // instantiation
   const FunctionDecl *getCurrentFunctionTemplateInstantiation() {
     const auto *Ctxt = CurDeclContext;
     while (Ctxt) {
@@ -1033,9 +1039,9 @@ public:
   // indexer to visit EVERY identifier, which is way too much data.
   struct AutoTemplateContext {
     AutoTemplateContext(IndexConsumer *Self)
-        : Self(Self)
-        , CurMode(Self->TemplateStack ? Self->TemplateStack->CurMode : Mode::GatherDependent)
-        , Parent(Self->TemplateStack) {
+        : Self(Self), CurMode(Self->TemplateStack ? Self->TemplateStack->CurMode
+                                                  : Mode::GatherDependent),
+          Parent(Self->TemplateStack) {
       Self->TemplateStack = this;
     }
 
@@ -1066,9 +1072,7 @@ public:
       }
     }
 
-    bool inGatherMode() {
-      return CurMode == Mode::GatherDependent;
-    }
+    bool inGatherMode() { return CurMode == Mode::GatherDependent; }
 
     // Do we need to perform the extra AnalyzeDependent passes (one per
     // instantiation)?
@@ -1119,7 +1123,8 @@ public:
 
   AutoTemplateContext *TemplateStack;
 
-  std::unordered_multimap<const FunctionDecl *, const Stmt *> ForwardingTemplates;
+  std::unordered_multimap<const FunctionDecl *, const Stmt *>
+      ForwardingTemplates;
   std::unordered_set<unsigned> ForwardedTemplateLocations;
 
   bool shouldVisitTemplateInstantiations() const {
@@ -1196,7 +1201,8 @@ public:
     // Flag to omit the identifier from being cross-referenced across files.
     // This is usually desired for local variables.
     NoCrossref = 1 << 0,
-    // Flag to indicate the token with analysis data is not an identifier. Indicates
+    // Flag to indicate the token with analysis data is not an identifier.
+    // Indicates
     // we want to skip the check that tries to ensure a sane identifier token.
     NotIdentifierToken = 1 << 1,
     // This indicates that the end of the provided SourceRange is valid and
@@ -1206,8 +1212,10 @@ public:
     LocRangeEndValid = 1 << 2
   };
 
-  void emitStructuredRecordInfo(llvm::json::OStream &J, SourceLocation Loc, const RecordDecl *decl) {
-    J.attribute("kind", TypeWithKeyword::getTagTypeKindName(decl->getTagKind()));
+  void emitStructuredRecordInfo(llvm::json::OStream &J, SourceLocation Loc,
+                                const RecordDecl *decl) {
+    J.attribute("kind",
+                TypeWithKeyword::getTagTypeKindName(decl->getTagKind()));
 
     const ASTContext &C = *AstContext;
     const ASTRecordLayout &Layout = C.getASTRecordLayout(decl);
@@ -1226,7 +1234,8 @@ public:
         //  * the size string 4/8 is shorter than true/false in the analysis
         //    file
         const QualType ptrType = C.getUIntPtrType();
-        J.attribute("ownVFPtrBytes", C.getTypeSizeInChars(ptrType).getQuantity());
+        J.attribute("ownVFPtrBytes",
+                    C.getTypeSizeInChars(ptrType).getQuantity());
       }
 
       J.attributeBegin("supers");
@@ -1310,14 +1319,17 @@ public:
     J.arrayBegin();
     uint64_t iField = 0;
     for (RecordDecl::field_iterator It = decl->field_begin(),
-          End = decl->field_end(); It != End; ++It, ++iField) {
+                                    End = decl->field_end();
+         It != End; ++It, ++iField) {
       const FieldDecl &Field = **It;
-      auto sourceRange = SM.getExpansionRange(Field.getSourceRange()).getAsRange();
+      auto sourceRange =
+          SM.getExpansionRange(Field.getSourceRange()).getAsRange();
       uint64_t localOffsetBits = Layout.getFieldOffset(iField);
       CharUnits localOffsetBytes = C.toCharUnitsFromBits(localOffsetBits);
 
       J.objectBegin();
-      J.attribute("lineRange", pathAndLineRangeToString(structFileID, sourceRange));
+      J.attribute("lineRange",
+                  pathAndLineRangeToString(structFileID, sourceRange));
       J.attribute("pretty", getQualifiedName(&Field));
       J.attribute("sym", getMangledName(CurMangleContext, &Field));
 
@@ -1346,7 +1358,8 @@ public:
         J.attributeBegin("bitPositions");
         J.objectBegin();
 
-        J.attribute("begin", unsigned(localOffsetBits - C.toBits(localOffsetBytes)));
+        J.attribute("begin",
+                    unsigned(localOffsetBits - C.toBits(localOffsetBytes)));
         J.attribute("width", Field.getBitWidthValue(C));
 
         J.objectEnd();
@@ -1381,7 +1394,8 @@ public:
     J.attribute("kind", "enumConstant");
   }
 
-  void emitStructuredFunctionInfo(llvm::json::OStream &J, const FunctionDecl *decl) {
+  void emitStructuredFunctionInfo(llvm::json::OStream &J,
+                                  const FunctionDecl *decl) {
     emitBindingAttributes(J, *decl);
 
     J.attributeBegin("args");
@@ -1431,7 +1445,8 @@ public:
         // TODO: Make sure we're doing template traversals appropriately...
         // findOverriddenMethods (now removed) liked to do:
         //   if (Decl->isTemplateInstantiation()) {
-        //     Decl = dyn_cast<CXXMethodDecl>(Decl->getTemplateInstantiationPattern());
+        //     Decl =
+        //     dyn_cast<CXXMethodDecl>(Decl->getTemplateInstantiationPattern());
         //   }
         // I think our pre-emptive dereferencing/avoidance of templates may
         // protect us from this, but it needs more investigation.
@@ -1507,7 +1522,8 @@ public:
    * Emit structured info for a variable if it is a static class member.
    */
   void emitStructuredVarInfo(llvm::json::OStream &J, const VarDecl *decl) {
-    const auto *parentDecl = dyn_cast_or_null<RecordDecl>(decl->getDeclContext());
+    const auto *parentDecl =
+        dyn_cast_or_null<RecordDecl>(decl->getDeclContext());
 
     J.attribute("kind", "field");
 
@@ -1572,8 +1588,7 @@ public:
   // called for each identifier that corresponds to a symbol.
   void visitIdentifier(const char *Kind, const char *SyntaxKind,
                        llvm::StringRef QualName, SourceRange LocRange,
-                       std::string Symbol,
-                       QualType MaybeType = QualType(),
+                       std::string Symbol, QualType MaybeType = QualType(),
                        Context TokenContext = Context(), int Flags = 0,
                        SourceRange PeekRange = SourceRange(),
                        SourceRange NestingRange = SourceRange(),
@@ -1583,7 +1598,9 @@ public:
     // Also visit the spelling site.
     SourceLocation SpellingLoc = SM.getSpellingLoc(Loc);
     if (SpellingLoc != Loc) {
-      visitIdentifier(Kind, SyntaxKind, QualName, SpellingLoc, Symbol, MaybeType, TokenContext, Flags, PeekRange, NestingRange, ArgRanges);
+      visitIdentifier(Kind, SyntaxKind, QualName, SpellingLoc, Symbol,
+                      MaybeType, TokenContext, Flags, PeekRange, NestingRange,
+                      ArgRanges);
     }
 
     SourceLocation ExpansionLoc = SM.getExpansionLoc(Loc);
@@ -1598,12 +1615,16 @@ public:
 
     // Find the file positions corresponding to the token.
     unsigned StartOffset = SM.getFileOffset(ExpansionLoc);
-    unsigned EndOffset = (Flags & LocRangeEndValid)
-        ? SM.getFileOffset(LocRange.getEnd())
-        : StartOffset + Lexer::MeasureTokenLength(ExpansionLoc, SM, CI.getLangOpts());
+    unsigned EndOffset =
+        (Flags & LocRangeEndValid)
+            ? SM.getFileOffset(LocRange.getEnd())
+            : StartOffset +
+                  Lexer::MeasureTokenLength(ExpansionLoc, SM, CI.getLangOpts());
 
-    std::string LocStr = locationToString(ExpansionLoc, EndOffset - StartOffset);
-    std::string RangeStr = locationToString(ExpansionLoc, EndOffset - StartOffset);
+    std::string LocStr =
+        locationToString(ExpansionLoc, EndOffset - StartOffset);
+    std::string RangeStr =
+        locationToString(ExpansionLoc, EndOffset - StartOffset);
     std::string PeekRangeStr;
 
     if (!(Flags & NotIdentifierToken)) {
@@ -1727,10 +1748,10 @@ public:
       J.arrayBegin();
 
       for (auto range : *ArgRanges) {
-          std::string ArgRangeStr = fullRangeToString(range);
-          if (!ArgRangeStr.empty()) {
-            J.value(ArgRangeStr);
-          }
+        std::string ArgRangeStr = fullRangeToString(range);
+        if (!ArgRangeStr.empty()) {
+          J.value(ArgRangeStr);
+        }
       }
 
       J.arrayEnd();
@@ -1745,7 +1766,8 @@ public:
         J.objectBegin();
         J.attributeBegin(macroInfo.Key);
         J.objectBegin();
-        J.attribute("", macroInfo.Expansion); // "" is the platform key, populated by the merge step
+        J.attribute("", macroInfo.Expansion); // "" is the platform key,
+                                              // populated by the merge step
         J.objectEnd();
         J.attributeEnd();
         J.objectEnd();
@@ -1757,7 +1779,8 @@ public:
           J.objectBegin();
           J.attributeBegin(macroInfo.Key);
           J.objectBegin();
-          J.attributeBegin(""); // "" is the platform key, populated by the merge step
+          J.attributeBegin(
+              ""); // "" is the platform key, populated by the merge step
           J.arrayBegin();
           J.value(it->second);
           J.arrayEnd();
@@ -1790,7 +1813,7 @@ public:
   }
 
   // If the provided statement is compound, return its range.
-  SourceRange getCompoundStmtRange(Stmt* D) {
+  SourceRange getCompoundStmtRange(Stmt *D) {
     if (!D) {
       return SourceRange();
     }
@@ -1803,7 +1826,7 @@ public:
     return SourceRange();
   }
 
-  SourceRange getFunctionPeekRange(FunctionDecl* D) {
+  SourceRange getFunctionPeekRange(FunctionDecl *D) {
     // We always start at the start of the function decl, which may include the
     // return type on a separate line.
     SourceLocation Start = D->getBeginLoc();
@@ -1814,8 +1837,9 @@ public:
     std::pair<FileID, unsigned> FuncLoc = SM.getDecomposedLoc(End);
 
     // But if there are parameters, we want to include those as well.
-    for (ParmVarDecl* Param : D->parameters()) {
-      std::pair<FileID, unsigned> ParamLoc = SM.getDecomposedLoc(Param->getLocation());
+    for (ParmVarDecl *Param : D->parameters()) {
+      std::pair<FileID, unsigned> ParamLoc =
+          SM.getDecomposedLoc(Param->getLocation());
 
       // It's possible there are macros involved or something. We don't include
       // the parameters in that case.
@@ -1828,7 +1852,7 @@ public:
     return SourceRange(Start, End);
   }
 
-  SourceRange getTagPeekRange(TagDecl* D) {
+  SourceRange getTagPeekRange(TagDecl *D) {
     SourceLocation Start = D->getBeginLoc();
 
     // By default, we end at the line containing the name.
@@ -1836,13 +1860,13 @@ public:
 
     std::pair<FileID, unsigned> FuncLoc = SM.getDecomposedLoc(End);
 
-    if (CXXRecordDecl* D2 = dyn_cast<CXXRecordDecl>(D)) {
+    if (CXXRecordDecl *D2 = dyn_cast<CXXRecordDecl>(D)) {
       // But if there are parameters, we want to include those as well.
-      for (CXXBaseSpecifier& Base : D2->bases()) {
+      for (CXXBaseSpecifier &Base : D2->bases()) {
         std::pair<FileID, unsigned> Loc = SM.getDecomposedLoc(Base.getEndLoc());
 
-        // It's possible there are macros involved or something. We don't include
-        // the parameters in that case.
+        // It's possible there are macros involved or something. We don't
+        // include the parameters in that case.
         if (Loc.first == FuncLoc.first) {
           // Assume parameters are in order, so we always take the last one.
           End = Base.getEndLoc();
@@ -1853,9 +1877,8 @@ public:
     return SourceRange(Start, End);
   }
 
-  SourceRange getCommentRange(NamedDecl* D) {
-    const RawComment* RC =
-      AstContext->getRawCommentForDeclNoCache(D);
+  SourceRange getCommentRange(NamedDecl *D) {
+    const RawComment *RC = AstContext->getRawCommentForDeclNoCache(D);
     if (!RC) {
       return SourceRange();
     }
@@ -1944,7 +1967,8 @@ public:
         D = D2->getTemplateInstantiationPattern();
       }
       // We treat pure virtual declarations as definitions.
-      Kind = (D2->isThisDeclarationADefinition() || isPure(D2)) ? "def" : "decl";
+      Kind =
+          (D2->isThisDeclarationADefinition() || isPure(D2)) ? "def" : "decl";
       PrettyKind = "function";
       PeekRange = getFunctionPeekRange(D2);
 
@@ -1998,8 +2022,9 @@ public:
       if (D2) {
         // There's no exposure of the left brace so we have to find it.
         NestingRange = SourceRange(
-          findLeftBraceFromLoc(D2->isAnonymousNamespace() ? D2->getBeginLoc() : ExpansionLoc),
-          D2->getRBraceLoc());
+            findLeftBraceFromLoc(D2->isAnonymousNamespace() ? D2->getBeginLoc()
+                                                            : ExpansionLoc),
+            D2->getRBraceLoc());
       }
     } else if (isa<FieldDecl>(D)) {
       Kind = "def";
@@ -2024,9 +2049,9 @@ public:
 
     // In the case of destructors, Loc might point to the ~ character. In that
     // case we want to skip to the name of the class. However, Loc might also
-    // point to other places that generate destructors, such as a lambda (apparently
-    // clang 8 creates a destructor declaration for at least some lambdas). In
-    // that case we'll just drop the declaration.
+    // point to other places that generate destructors, such as a lambda
+    // (apparently clang 8 creates a destructor declaration for at least some
+    // lambdas). In that case we'll just drop the declaration.
     if (isa<CXXDestructorDecl>(D)) {
       PrettyKind = "destructor";
       const char *P = SM.getCharacterData(Loc);
@@ -2046,9 +2071,9 @@ public:
       }
     }
 
-    visitIdentifier(Kind, PrettyKind, getQualifiedName(D), SourceRange(Loc), Symbol,
-                    qtype,
-                    getContext(D), Flags, PeekRange, NestingRange);
+    visitIdentifier(Kind, PrettyKind, getQualifiedName(D), SourceRange(Loc),
+                    Symbol, qtype, getContext(D), Flags, PeekRange,
+                    NestingRange);
 
     // In-progress structured info emission.
     if (RecordDecl *D2 = dyn_cast<RecordDecl>(D)) {
@@ -2058,8 +2083,7 @@ public:
           // dependent type or if we're in any kind of template context.  This
           // should be re-evaluated once this is working for normal classes and
           // we can better evaluate what is useful.
-          !D2->isDependentType() &&
-          !TemplateStack) {
+          !D2->isDependentType() && !TemplateStack) {
         if (auto *D3 = dyn_cast<CXXRecordDecl>(D2)) {
           findBindingToJavaClass(*AstContext, *D3);
           findBoundAsJavaClasses(*AstContext, *D3);
@@ -2082,10 +2106,8 @@ public:
       if ((D2->isThisDeclarationADefinition() || isPure(D2)) &&
           // a clause at the top should have generalized and set wasTemplate so
           // it shouldn't be the case that isTemplateInstantiation() is true.
-          !D2->isTemplateInstantiation() &&
-          !wasTemplate &&
-          !D2->isFunctionTemplateSpecialization() &&
-          !TemplateStack) {
+          !D2->isTemplateInstantiation() && !wasTemplate &&
+          !D2->isFunctionTemplateSpecialization() && !TemplateStack) {
         if (auto *D3 = dyn_cast<CXXMethodDecl>(D2)) {
           findBindingToJavaMember(*AstContext, *D3);
         } else {
@@ -2095,14 +2117,12 @@ public:
       }
     }
     if (FieldDecl *D2 = dyn_cast<FieldDecl>(D)) {
-      if (!D2->isTemplated() &&
-          !TemplateStack) {
+      if (!D2->isTemplated() && !TemplateStack) {
         emitStructuredInfo(ExpansionLoc, D2);
       }
     }
     if (VarDecl *D2 = dyn_cast<VarDecl>(D)) {
-      if (!D2->isTemplated() &&
-          !TemplateStack &&
+      if (!D2->isTemplated() && !TemplateStack &&
           isa<CXXRecordDecl>(D2->getDeclContext())) {
         findBindingToJavaConstant(*AstContext, *D2);
         emitStructuredInfo(ExpansionLoc, D2);
@@ -2118,11 +2138,14 @@ public:
       return true;
     }
 
-    // If we are in a template and find a Stmt that was registed in ForwardedTemplateLocations,
-    // convert the location to an actual Stmt* in ForwardingTemplates
+    // If we are in a template and find a Stmt that was registed in
+    // ForwardedTemplateLocations, convert the location to an actual Stmt* in
+    // ForwardingTemplates
     if (TemplateStack && !TemplateStack->inGatherMode()) {
-      if (ForwardedTemplateLocations.find(E->getBeginLoc().getRawEncoding()) != ForwardedTemplateLocations.end()) {
-        ForwardingTemplates.insert({getCurrentFunctionTemplateInstantiation(), E});
+      if (ForwardedTemplateLocations.find(E->getBeginLoc().getRawEncoding()) !=
+          ForwardedTemplateLocations.end()) {
+        ForwardingTemplates.insert(
+            {getCurrentFunctionTemplateInstantiation(), E});
         return true;
       }
     }
@@ -2148,8 +2171,9 @@ public:
   }
 
   bool VisitUnresolvedLookupExpr(UnresolvedLookupExpr *E) {
-    // If we are in a template and the callee is type-dependent, register it in ForwardedTemplateLocations
-    // to forward its uses to the surrounding template call site
+    // If we are in a template and the callee is type-dependent, register it in
+    // ForwardedTemplateLocations to forward its uses to the surrounding
+    // template call site
     if (TemplateStack && TemplateStack->inGatherMode()) {
       if (E->isTypeDependent()) {
         TemplateStack->visitDependent(E->getBeginLoc());
@@ -2210,9 +2234,10 @@ public:
       argRanges.push_back(argExpr->getSourceRange());
     }
 
-    visitIdentifier("use", "function", getQualifiedName(NamedCallee), Loc, Mangled,
-                    E->getCallReturnType(*AstContext), getContext(SpellingLoc), Flags,
-                    SourceRange(), SourceRange(), &argRanges);
+    visitIdentifier("use", "function", getQualifiedName(NamedCallee), Loc,
+                    Mangled, E->getCallReturnType(*AstContext),
+                    getContext(SpellingLoc), Flags, SourceRange(),
+                    SourceRange(), &argRanges);
 
     return true;
   }
@@ -2300,7 +2325,8 @@ public:
   }
 
   void VisitForwardedStatements(const Expr *E, SourceLocation Loc) {
-    // If this is a forwarding template (eg MakeUnique), visit the forwarded statements
+    // If this is a forwarding template (eg MakeUnique), visit the forwarded
+    // statements
     auto todo = std::stack{std::vector<const Stmt *>{E}};
     auto seen = std::unordered_set<const Stmt *>{};
     while (!todo.empty()) {
@@ -2326,8 +2352,10 @@ public:
         continue;
       if (!F->isTemplateInstantiation())
         continue;
-      const auto [ForwardedBegin, ForwardedEnd] = ForwardingTemplates.equal_range(F);
-      for (auto ForwardedIt = ForwardedBegin; ForwardedIt != ForwardedEnd; ++ForwardedIt)
+      const auto [ForwardedBegin, ForwardedEnd] =
+          ForwardingTemplates.equal_range(F);
+      for (auto ForwardedIt = ForwardedBegin; ForwardedIt != ForwardedEnd;
+           ++ForwardedIt)
         if (seen.find(ForwardedIt->second) == seen.end())
           todo.push(ForwardedIt->second);
     }
@@ -2339,12 +2367,16 @@ public:
       return true;
     }
 
-    // If we are in a template and find a Stmt that was registed in ForwardedTemplateLocations,
-    // convert the location to an actual Stmt* in ForwardingTemplates
+    // If we are in a template and find a Stmt that was registed in
+    // ForwardedTemplateLocations, convert the location to an actual Stmt* in
+    // ForwardingTemplates
     if (TemplateStack && !TemplateStack->inGatherMode()) {
-      const auto IsForwarded = ForwardedTemplateLocations.find(E->getBeginLoc().getRawEncoding()) != ForwardedTemplateLocations.end();
+      const auto IsForwarded =
+          ForwardedTemplateLocations.find(E->getBeginLoc().getRawEncoding()) !=
+          ForwardedTemplateLocations.end();
       if (IsForwarded) {
-        ForwardingTemplates.insert({getCurrentFunctionTemplateInstantiation(), E});
+        ForwardingTemplates.insert(
+            {getCurrentFunctionTemplateInstantiation(), E});
         return true;
       }
     }
@@ -2513,8 +2545,9 @@ public:
       return true;
     }
 
-    // If we are in a template and the new is type-dependent, register it in ForwardedTemplateLocations
-    // to forward its uses to the surrounding template call site
+    // If we are in a template and the new is type-dependent, register it in
+    // ForwardedTemplateLocations to forward its uses to the surrounding
+    // template call site
     if (TemplateStack && TemplateStack->inGatherMode()) {
       const auto *TypeInfo = N->getAllocatedTypeSourceInfo();
       const auto ConstructExprLoc = TypeInfo->getTypeLoc().getBeginLoc();
@@ -2544,7 +2577,8 @@ public:
 
       // Also record the dependent NestedNameSpecifier locations
       for (auto NestedNameLoc = E->getQualifierLoc();
-           NestedNameLoc && NestedNameLoc.getNestedNameSpecifier()->isDependent();
+           NestedNameLoc &&
+           NestedNameLoc.getNestedNameSpecifier()->isDependent();
            NestedNameLoc = NestedNameLoc.getPrefix()) {
         TemplateStack->visitDependent(NestedNameLoc.getLocalBeginLoc());
       }
@@ -2575,16 +2609,15 @@ public:
 
     std::string symbol = std::string("URL_") + mangleURL(s);
 
-    visitIdentifier("use", "file", StringRef(s), Loc, symbol,
-                    QualType(), Context(),
-                    NotIdentifierToken | LocRangeEndValid);
+    visitIdentifier("use", "file", StringRef(s), Loc, symbol, QualType(),
+                    Context(), NotIdentifierToken | LocRangeEndValid);
 
     return true;
   }
 
   void enterSourceFile(SourceLocation Loc) {
     normalizeLocation(&Loc);
-    FileInfo* newFile = getFileInfo(Loc);
+    FileInfo *newFile = getFileInfo(Loc);
     if (!newFile->Interesting) {
       return;
     }
@@ -2592,31 +2625,33 @@ public:
     std::string symbol =
         std::string("FILE_") + mangleFile(newFile->Realname, type);
 
-    // We use an explicit zero-length source range at the start of the file. If we
-    // don't set the LocRangeEndValid flag, the visitIdentifier code will use the
-    // entire first token, which could be e.g. a long multiline-comment.
-    visitIdentifier("def", "file", newFile->Realname, SourceRange(Loc),
-                    symbol, QualType(), Context(),
+    // We use an explicit zero-length source range at the start of the file. If
+    // we don't set the LocRangeEndValid flag, the visitIdentifier code will use
+    // the entire first token, which could be e.g. a long multiline-comment.
+    visitIdentifier("def", "file", newFile->Realname, SourceRange(Loc), symbol,
+                    QualType(), Context(),
                     NotIdentifierToken | LocRangeEndValid);
   }
 
-  void inclusionDirective(SourceRange FileNameRange, const FileEntry* File) {
+  void inclusionDirective(SourceRange FileNameRange, const FileEntry *File) {
     std::string includedFile(File->tryGetRealPathName());
     FileType type = relativizePath(includedFile);
     if (type == FileType::Unknown) {
       return;
     }
-    std::string symbol =
-        std::string("FILE_") + mangleFile(includedFile, type);
+    std::string symbol = std::string("FILE_") + mangleFile(includedFile, type);
 
     // Support the #include MACRO use-case
     // When parsing #include MACRO:
     // - the filename is never passed to onTokenLexed
-    // - inclusionDirective is called before endMacroExpansion (which is only called when the following token is parsed)
-    // So add the filename here and call endMacroExpansion immediately.
-    // This ensures the macro has a correct expansion and it has been added to MacroMaps so the referenced filename knows to populate inExpansionAt.
+    // - inclusionDirective is called before endMacroExpansion (which is only
+    // called when the following token is parsed) So add the filename here and
+    // call endMacroExpansion immediately. This ensures the macro has a correct
+    // expansion and it has been added to MacroMaps so the referenced filename
+    // knows to populate inExpansionAt.
     if (MacroExpansionState) {
-      MacroExpansionState->TokenLocations[FileNameRange.getBegin()] = MacroExpansionState->Expansion.length();
+      MacroExpansionState->TokenLocations[FileNameRange.getBegin()] =
+          MacroExpansionState->Expansion.length();
       MacroExpansionState->Expansion += '"';
       MacroExpansionState->Expansion += includedFile;
       MacroExpansionState->Expansion += '"';
@@ -2640,8 +2675,8 @@ public:
 
     IdentifierInfo *Ident = Tok.getIdentifierInfo();
     if (Ident) {
-      std::string Mangled =
-          std::string("M_") + mangleLocation(Loc, std::string(Ident->getName()));
+      std::string Mangled = std::string("M_") +
+                            mangleLocation(Loc, std::string(Ident->getName()));
       visitIdentifier("def", "macro", Ident->getName(), Loc, Mangled);
     }
   }
@@ -2661,13 +2696,14 @@ public:
     IdentifierInfo *Ident = Tok.getIdentifierInfo();
     if (Ident) {
       std::string Mangled =
-          std::string("M_") +
-          mangleLocation(Macro->getDefinitionLoc(), std::string(Ident->getName()));
+          std::string("M_") + mangleLocation(Macro->getDefinitionLoc(),
+                                             std::string(Ident->getName()));
       visitIdentifier("use", "macro", Ident->getName(), Loc, Mangled);
     }
   }
 
-  void beginMacroExpansion(const Token &Tok, const MacroInfo *Macro, SourceRange Range) {
+  void beginMacroExpansion(const Token &Tok, const MacroInfo *Macro,
+                           SourceRange Range) {
     if (!Macro)
       return;
 
@@ -2683,12 +2719,19 @@ public:
       return;
 
     if (MacroExpansionState) {
-      const auto InMacroArgs = MacroExpansionState->Range.fullyContains(SM.getExpansionRange(Range).getAsRange());
-      const auto InMacroBody = SM.getExpansionLoc(Tok.getLocation()) == SM.getExpansionLoc(MacroExpansionState->MacroNameToken.getLocation());
+      const auto InMacroArgs = MacroExpansionState->Range.fullyContains(
+          SM.getExpansionRange(Range).getAsRange());
+      const auto InMacroBody =
+          SM.getExpansionLoc(Tok.getLocation()) ==
+          SM.getExpansionLoc(MacroExpansionState->MacroNameToken.getLocation());
       if (InMacroArgs || InMacroBody) {
-        if (MacroExpansionState->MacroInfo->getDefinitionLoc() != Macro->getDefinitionLoc()) {
+        if (MacroExpansionState->MacroInfo->getDefinitionLoc() !=
+            Macro->getDefinitionLoc()) {
           IdentifierInfo *DependencyIdent = Tok.getIdentifierInfo();
-          std::string DependencySymbol = std::string("M_") + mangleLocation(Macro->getDefinitionLoc(), std::string(DependencyIdent->getName()));
+          std::string DependencySymbol =
+              std::string("M_") +
+              mangleLocation(Macro->getDefinitionLoc(),
+                             std::string(DependencyIdent->getName()));
 
           MacroExpansionState->Dependencies.push_back(DependencySymbol);
         }
@@ -2701,42 +2744,49 @@ public:
     }
 
     MacroExpansionState = ::MacroExpansionState{
-      .MacroNameToken = Tok,
-      .MacroInfo = Macro,
-      .Expansion = {},
-      .TokenLocations = {},
-      .Range = Range,
-      .PrevPrevTok = {},
-      .PrevTok = {},
+        .MacroNameToken = Tok,
+        .MacroInfo = Macro,
+        .Expansion = {},
+        .TokenLocations = {},
+        .Range = Range,
+        .PrevPrevTok = {},
+        .PrevTok = {},
     };
   }
 
   void endMacroExpansion() {
-    // large macros are too slow to reformat, don't reformat macros larger than those arbitrary thresholds
+    // large macros are too slow to reformat, don't reformat macros larger than
+    // those arbitrary thresholds
     static constexpr auto includedFileExpansionReformatThreshold = 20'000;
     static constexpr auto mainFileExpansionReformatThreshold = 200'000;
 
-    const auto expansionLocation = SM.getExpansionLoc(MacroExpansionState->MacroNameToken.getLocation());
+    const auto expansionLocation =
+        SM.getExpansionLoc(MacroExpansionState->MacroNameToken.getLocation());
     const auto expansionFilename = SM.getFilename(expansionLocation);
-    const auto includedExtensions = std::array{".h", ".hpp", ".hxx", ".inc", ".def"};
-    const auto isIncludedFile = std::any_of(includedExtensions.begin(), includedExtensions.end(), [&](const auto *extension) {
-      return expansionFilename.ends_with_insensitive(extension);
-    });
-    const auto expansionReformatThreshold = isIncludedFile ? includedFileExpansionReformatThreshold : mainFileExpansionReformatThreshold;
+    const auto includedExtensions =
+        std::array{".h", ".hpp", ".hxx", ".inc", ".def"};
+    const auto isIncludedFile =
+        std::any_of(includedExtensions.begin(), includedExtensions.end(),
+                    [&](const auto *extension) {
+                      return expansionFilename.ends_with_insensitive(extension);
+                    });
+    const auto expansionReformatThreshold =
+        isIncludedFile ? includedFileExpansionReformatThreshold
+                       : mainFileExpansionReformatThreshold;
 
     if (MacroExpansionState->Expansion.length() < expansionReformatThreshold) {
       // large macros are too memory-hungry to reformat with ColumnLimit != 0
       // see https://github.com/llvm/llvm-project/issues/107434
       auto style = clang::format::getMozillaStyle();
-      if (MacroExpansionState->Expansion.length() > includedFileExpansionReformatThreshold)
+      if (MacroExpansionState->Expansion.length() >
+          includedFileExpansionReformatThreshold)
         style.ColumnLimit = 0;
 
       const auto replacements = clang::format::reformat(
-        style,
-        MacroExpansionState->Expansion,
-        {tooling::Range(0, MacroExpansionState->Expansion.length())}
-      );
-      auto formatted = clang::tooling::applyAllReplacements(MacroExpansionState->Expansion, replacements);
+          style, MacroExpansionState->Expansion,
+          {tooling::Range(0, MacroExpansionState->Expansion.length())});
+      auto formatted = clang::tooling::applyAllReplacements(
+          MacroExpansionState->Expansion, replacements);
       if (formatted) {
         for (auto &[k, v] : MacroExpansionState->TokenLocations) {
           v = replacements.getShiftedCodePosition(v);
@@ -2745,15 +2795,18 @@ public:
       }
     }
 
-    IdentifierInfo *Ident = MacroExpansionState->MacroNameToken.getIdentifierInfo();
+    IdentifierInfo *Ident =
+        MacroExpansionState->MacroNameToken.getIdentifierInfo();
     std::string Symbol =
         std::string("M_") +
-        mangleLocation(MacroExpansionState->MacroInfo->getDefinitionLoc(), std::string(Ident->getName()));
+        mangleLocation(MacroExpansionState->MacroInfo->getDefinitionLoc(),
+                       std::string(Ident->getName()));
 
     const auto dependenciesBegin = MacroExpansionState->Dependencies.begin();
     const auto dependenciesEnd = MacroExpansionState->Dependencies.end();
     std::sort(dependenciesBegin, dependenciesEnd);
-    MacroExpansionState->Dependencies.erase(std::unique(dependenciesBegin, dependenciesEnd), dependenciesEnd);
+    MacroExpansionState->Dependencies.erase(
+        std::unique(dependenciesBegin, dependenciesEnd), dependenciesEnd);
 
     auto Key = Symbol;
     for (const auto &Dependency : MacroExpansionState->Dependencies) {
@@ -2762,18 +2815,19 @@ public:
     }
 
     MacroMaps.emplace(std::pair{
-      MacroExpansionState->MacroNameToken.getLocation(),
-      ExpandedMacro{
-        std::move(Symbol),
-        std::move(Key),
-        std::move(MacroExpansionState->Expansion),
-        std::move(MacroExpansionState->TokenLocations),
-      },
+        MacroExpansionState->MacroNameToken.getLocation(),
+        ExpandedMacro{
+            std::move(Symbol),
+            std::move(Key),
+            std::move(MacroExpansionState->Expansion),
+            std::move(MacroExpansionState->TokenLocations),
+        },
     });
 
     MacroExpansionState.reset();
 
-    macroUsed(MacroExpansionState->MacroNameToken, MacroExpansionState->MacroInfo);
+    macroUsed(MacroExpansionState->MacroNameToken,
+              MacroExpansionState->MacroInfo);
   }
 
   void onTokenLexed(const Token &Tok) {
@@ -2787,7 +2841,8 @@ public:
       return;
     }
 
-    if (ConcatInfo.AvoidConcat(MacroExpansionState->PrevPrevTok, MacroExpansionState->PrevTok, Tok)) {
+    if (ConcatInfo.AvoidConcat(MacroExpansionState->PrevPrevTok,
+                               MacroExpansionState->PrevTok, Tok)) {
       MacroExpansionState->Expansion += ' ';
     }
 
@@ -2799,7 +2854,8 @@ public:
     } else {
       const auto spelling = CI.getPreprocessor().getSpelling(Tok);
       if (Tok.isAnyIdentifier()) {
-        MacroExpansionState->TokenLocations[SLoc] = MacroExpansionState->Expansion.length();
+        MacroExpansionState->TokenLocations[SLoc] =
+            MacroExpansionState->Expansion.length();
       }
       MacroExpansionState->Expansion += spelling;
     }
@@ -2813,45 +2869,42 @@ void PreprocessorHook::FileChanged(SourceLocation Loc, FileChangeReason Reason,
                                    SrcMgr::CharacteristicKind FileType,
                                    FileID PrevFID = FileID()) {
   switch (Reason) {
-    case PPCallbacks::RenameFile:
-    case PPCallbacks::SystemHeaderPragma:
-      // Don't care about these, since we want the actual on-disk filenames
-      break;
-    case PPCallbacks::EnterFile:
-      Indexer->enterSourceFile(Loc);
-      break;
-    case PPCallbacks::ExitFile:
-      // Don't care about exiting files
-      break;
+  case PPCallbacks::RenameFile:
+  case PPCallbacks::SystemHeaderPragma:
+    // Don't care about these, since we want the actual on-disk filenames
+    break;
+  case PPCallbacks::EnterFile:
+    Indexer->enterSourceFile(Loc);
+    break;
+  case PPCallbacks::ExitFile:
+    // Don't care about exiting files
+    break;
   }
 }
 
-void PreprocessorHook::InclusionDirective(SourceLocation HashLoc,
-                                          const Token &IncludeTok,
-                                          StringRef FileName,
-                                          bool IsAngled,
-                                          CharSourceRange FileNameRange,
+void PreprocessorHook::InclusionDirective(
+    SourceLocation HashLoc, const Token &IncludeTok, StringRef FileName,
+    bool IsAngled, CharSourceRange FileNameRange,
 #if CLANG_VERSION_MAJOR >= 16
-                                          OptionalFileEntryRef File,
+    OptionalFileEntryRef File,
 #elif CLANG_VERSION_MAJOR >= 15
-                                          Optional<FileEntryRef> File,
+    Optional<FileEntryRef> File,
 #else
-                                          const FileEntry *File,
+    const FileEntry *File,
 #endif
-                                          StringRef SearchPath,
-                                          StringRef RelativePath,
+    StringRef SearchPath, StringRef RelativePath,
 #if CLANG_VERSION_MAJOR >= 19
-                                          const Module *SuggestedModule,
-                                          bool ModuleImported,
+    const Module *SuggestedModule, bool ModuleImported,
 #else
-                                          const Module *Imported,
+    const Module *Imported,
 #endif
-                                          SrcMgr::CharacteristicKind FileType) {
+    SrcMgr::CharacteristicKind FileType) {
 #if CLANG_VERSION_MAJOR >= 15
   if (!File) {
     return;
   }
-  Indexer->inclusionDirective(FileNameRange.getAsRange(), &File->getFileEntry());
+  Indexer->inclusionDirective(FileNameRange.getAsRange(),
+                              &File->getFileEntry());
 #else
   Indexer->inclusionDirective(FileNameRange.getAsRange(), File);
 #endif
@@ -2869,8 +2922,7 @@ void PreprocessorHook::MacroExpands(const Token &Tok, const MacroDefinition &Md,
 
 void PreprocessorHook::MacroUndefined(const Token &Tok,
                                       const MacroDefinition &Md,
-                                      const MacroDirective *Undef)
-{
+                                      const MacroDirective *Undef) {
   Indexer->macroUsed(Tok, Md.getMacroInfo());
 }
 

--- a/clang-plugin/StringOperations.cpp
+++ b/clang-plugin/StringOperations.cpp
@@ -37,6 +37,4 @@ std::string hash(const std::string &Str) {
   return std::string(HashStr);
 }
 
-std::string toString(int N) {
-  return stringFormat("%d", N);
-}
+std::string toString(int N) { return stringFormat("%d", N); }

--- a/clang-plugin/StringOperations.h
+++ b/clang-plugin/StringOperations.h
@@ -7,8 +7,8 @@
 #define StringOperations_h
 
 #include <memory>
-#include <string>
 #include <string.h>
+#include <string>
 
 std::string hash(const std::string &Str);
 

--- a/tools/src/abstract_server/lazy_crossref.rs
+++ b/tools/src/abstract_server/lazy_crossref.rs
@@ -33,7 +33,7 @@
 
 use super::{local_index::LocalIndex, server_interface::Result};
 
-use serde_json::{Value};
+use serde_json::Value;
 
 /// Perform the actual lazy cross-reference process.
 ///

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -89,7 +89,7 @@ async fn read_gzipped_ndjson_from_file(path: &str) -> Result<Vec<Value>> {
 
     raw_str
         .lines()
-        .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+        .map(|s| from_str(s).map_err(ServerError::from))
         .collect()
 }
 
@@ -247,7 +247,7 @@ impl AbstractServer for LocalIndex {
                 // to do either.  The exception is that for the root directory, ""
                 // is the right choice because our "no leading /" rule trumps our
                 // "yes trailing /" rule for path manipulation.
-                let norm_path = if norm_path == "" {
+                let norm_path = if norm_path.is_empty() {
                     "".to_string()
                 } else if norm_path.ends_with('/') {
                     norm_path.to_string()
@@ -302,7 +302,7 @@ impl AbstractServer for LocalIndex {
             symbol
         );
         if result.is_ok() && extra_processing {
-            perform_lazy_crossref(&self, result.unwrap()).await
+            perform_lazy_crossref(self, result.unwrap()).await
         } else {
             result
         }
@@ -417,7 +417,7 @@ impl AbstractServer for LocalIndex {
                     let path_kind = self
                         .file_lookup_map
                         .lookup_file_from_ustr(&path)
-                        .map_or_else(|| ustr(""), |fi| fi.path_kind.clone());
+                        .map_or_else(|| ustr(""), |fi| fi.path_kind);
                     TextMatchesByFile {
                         file: path,
                         path_kind,
@@ -490,7 +490,7 @@ pub fn make_local_server(
     config_path: &str,
     tree_name: &str,
 ) -> Result<Box<dyn AbstractServer + Send + Sync>> {
-    let mut config = load(config_path, false, Some(&tree_name), None);
+    let mut config = load(config_path, false, Some(tree_name), None);
     let tree_config = match config.trees.remove(&tree_name.to_string()) {
         Some(t) => t,
         None => {

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -135,11 +135,7 @@ impl LocalIndex {
     fn normalize_and_validate_path<'a>(&self, sf_path: &'a str) -> Result<&'a str> {
         // We normalize off any leading "/" mainly to support our test cases
         // being able to use "/" to indicate they're interested in a root dir.
-        let norm_path = if sf_path.starts_with('/') {
-            &sf_path[1..]
-        } else {
-            sf_path
-        };
+        let norm_path = sf_path.strip_prefix('/').unwrap_or(sf_path);
         // We don't want anyone trying to construct a path that escapes the
         // sub-tree.
         validate_absoluteish_path(norm_path)?;

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -22,8 +22,8 @@ use crate::file_format::config::{load, TreeConfig, TreeConfigPaths};
 use crate::file_format::crossref_lookup::CrossrefLookupMap;
 use crate::file_format::identifiers::IdentMap;
 use crate::file_format::per_file_info::FileLookupMap;
-use crate::languages::select_formatting;
 use crate::format::format_code;
+use crate::languages::select_formatting;
 
 pub mod livegrep {
     tonic::include_proto!("_");
@@ -184,8 +184,7 @@ impl AbstractServer for LocalIndex {
 
     async fn fetch_raw_analysis<'a>(&self, sf_path: &str) -> Result<BoxStream<'a, Value>> {
         let norm_path = self.normalize_and_validate_path(sf_path)?;
-        let full_path = self.translate_path(
-            SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;
+        let full_path = self.translate_path(SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;
         let values = read_gzipped_ndjson_from_file(&full_path).await?;
         Ok(Box::pin(tokio_stream::iter(values)))
     }
@@ -193,8 +192,11 @@ impl AbstractServer for LocalIndex {
     async fn fetch_raw_source(&self, sf_path: &str) -> Result<String> {
         let norm_path = self.normalize_and_validate_path(sf_path)?;
         let full_path = if norm_path.starts_with("__GENERATED__/") {
-            format!("{}/{}", self.config_paths.objdir_path,
-                    norm_path.strip_prefix("__GENERATED__/").unwrap())
+            format!(
+                "{}/{}",
+                self.config_paths.objdir_path,
+                norm_path.strip_prefix("__GENERATED__/").unwrap()
+            )
         } else {
             format!("{}/{}", self.config_paths.files_path, norm_path)
         };
@@ -208,8 +210,8 @@ impl AbstractServer for LocalIndex {
     async fn fetch_formatted_lines(&self, sf_path: &str) -> Result<(Vec<String>, String)> {
         let norm_path = self.normalize_and_validate_path(sf_path)?;
         let source = self.fetch_raw_source(sf_path).await?;
-        let analysis_path = self.translate_path(
-            SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;
+        let analysis_path =
+            self.translate_path(SearchfoxIndexRoot::CompressedAnalysis, norm_path)?;
         let analysis = read_analyses(&[analysis_path], &mut read_source);
 
         let jumpref_path = format!("{}/jumpref", self.config_paths.index_path);
@@ -223,7 +225,7 @@ impl AbstractServer for LocalIndex {
             select_formatting(sf_path),
             sf_path,
             source.as_str(),
-            &analysis
+            &analysis,
         );
 
         let lines = raw_lines.into_iter().map(|line| line.line).collect();

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -487,7 +487,7 @@ pub fn make_local_server(
     tree_name: &str,
 ) -> Result<Box<dyn AbstractServer + Send + Sync>> {
     let mut config = load(config_path, false, Some(tree_name), None);
-    let tree_config = match config.trees.remove(&tree_name.to_string()) {
+    let tree_config = match config.trees.remove(tree_name) {
         Some(t) => t,
         None => {
             return Err(ServerError::StickyProblem(ErrorDetails {

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -135,11 +135,7 @@ impl AbstractServer for RemoteServer {
             return Err(ServerError::Unsupported);
         }
         // Our tree-relative paths should not start with a slash
-        let norm_path = if sf_path.starts_with('/') {
-            &sf_path[1..]
-        } else {
-            sf_path
-        };
+        let norm_path = sf_path.strip_prefix('/').unwrap_or(sf_path);
         // We don't both caring about the presence of ".." here because we don't
         // have any security-ish things to worry about for a public web server.
 

--- a/tools/src/abstract_server/remote_server.rs
+++ b/tools/src/abstract_server/remote_server.rs
@@ -112,7 +112,7 @@ impl AbstractServer for RemoteServer {
         let raw_str = get(url).await?.text().await?;
         let values: Result<Vec<Value>> = raw_str
             .lines()
-            .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+            .map(|s| from_str(s).map_err(ServerError::from))
             .collect();
         Ok(Box::pin(tokio_stream::iter(values?)))
     }

--- a/tools/src/abstract_server/server_interface.rs
+++ b/tools/src/abstract_server/server_interface.rs
@@ -28,7 +28,7 @@ impl From<regex::Error> for ServerError {
     fn from(err: regex::Error) -> ServerError {
         ServerError::StickyProblem(ErrorDetails {
             layer: ErrorLayer::BadInput,
-            message: format!("bad regexp: {}", err.to_string()),
+            message: format!("bad regexp: {}", err),
         })
     }
 }
@@ -46,7 +46,7 @@ impl From<tokio::task::JoinError> for ServerError {
         */
         ServerError::StickyProblem(ErrorDetails {
             layer: ErrorLayer::RuntimeInvariantViolation,
-            message: format!("task panicked?: {}", err.to_string()),
+            message: format!("task panicked?: {}", err),
         })
     }
 }
@@ -55,7 +55,7 @@ impl From<liquid::Error> for ServerError {
     fn from(err: liquid::Error) -> ServerError {
         ServerError::StickyProblem(ErrorDetails {
             layer: ErrorLayer::ConfigLayer,
-            message: format!("Liquid error: {}", err.to_string()),
+            message: format!("Liquid error: {}", err),
         })
     }
 }

--- a/tools/src/bin/build-blame.rs
+++ b/tools/src/bin/build-blame.rs
@@ -460,7 +460,7 @@ fn build_blame_tree(
                 )
                 .unwrap();
                 writeln!(import_stream, "data {}", blame_bytes.len()).unwrap();
-                import_stream.write(blame_bytes).unwrap();
+                import_stream.write_all(blame_bytes).unwrap();
                 // We skip the optional trailing LF character here since in practice it
                 // wasn't particularly useful for debugging. Also the blame blobs we write
                 // here always have a trailing LF anyway.
@@ -784,9 +784,9 @@ fn main() {
 
             let mut write_role = |role: &str, sig: &git2::Signature| {
                 write!(import_stream, "{} ", role).unwrap();
-                import_stream.write(sig.name_bytes()).unwrap();
+                import_stream.write_all(sig.name_bytes()).unwrap();
                 write!(import_stream, " <").unwrap();
-                import_stream.write(sig.email_bytes()).unwrap();
+                import_stream.write_all(sig.email_bytes()).unwrap();
                 write!(import_stream, "> ").unwrap();
                 // git-fast-import can take a few different date formats, but the
                 // default "raw" format is the easiest for us to write. Refer to

--- a/tools/src/bin/build-syntax-token-tree.rs
+++ b/tools/src/bin/build-syntax-token-tree.rs
@@ -409,7 +409,7 @@ fn recursively_process_source_tree(
                     )
                     .unwrap();
                     writeln!(import_stream, "data {}", tokenized_bytes.len()).unwrap();
-                    import_stream.write(tokenized_bytes).unwrap();
+                    import_stream.write_all(tokenized_bytes).unwrap();
                     // We skip the optional trailing LF character here since in practice it
                     // wasn't particularly useful for debugging. Also the blame blobs we write
                     // here always have a trailing LF anyway.
@@ -431,7 +431,7 @@ fn recursively_process_source_tree(
                     )
                     .unwrap();
                     writeln!(import_stream, "data {}", struct_bytes.len()).unwrap();
-                    import_stream.write(struct_bytes).unwrap();
+                    import_stream.write_all(struct_bytes).unwrap();
                     // (skipping trailing LF again)
 
                     // ## Accumulate the symdex data.
@@ -612,7 +612,7 @@ fn process_symdex_tree(
 
                 writeln!(import_stream, "M 100644 inline {}", sanitize(&sym_path)).unwrap();
                 writeln!(import_stream, "data {}", symdex_bytes.len()).unwrap();
-                import_stream.write(symdex_bytes).unwrap();
+                import_stream.write_all(symdex_bytes).unwrap();
                 // (skipping trailing LF again)
             }
         }
@@ -826,9 +826,9 @@ fn main() {
 
             let mut write_role = |role: &str, sig: &git2::Signature| {
                 write!(import_stream, "{} ", role).unwrap();
-                import_stream.write(sig.name_bytes()).unwrap();
+                import_stream.write_all(sig.name_bytes()).unwrap();
                 write!(import_stream, " <").unwrap();
-                import_stream.write(sig.email_bytes()).unwrap();
+                import_stream.write_all(sig.email_bytes()).unwrap();
                 write!(import_stream, "> ").unwrap();
                 // git-fast-import can take a few different date formats, but the
                 // default "raw" format is the easiest for us to write. Refer to

--- a/tools/src/bin/build-timeline-tree.rs
+++ b/tools/src/bin/build-timeline-tree.rs
@@ -455,7 +455,7 @@ fn build_blame_tree(
                 )
                 .unwrap();
                 writeln!(import_stream, "data {}", blame_bytes.len()).unwrap();
-                import_stream.write(blame_bytes).unwrap();
+                import_stream.write_all(blame_bytes).unwrap();
                 // We skip the optional trailing LF character here since in practice it
                 // wasn't particularly useful for debugging. Also the blame blobs we write
                 // here always have a trailing LF anyway.
@@ -779,9 +779,9 @@ fn main() {
 
             let mut write_role = |role: &str, sig: &git2::Signature| {
                 write!(import_stream, "{} ", role).unwrap();
-                import_stream.write(sig.name_bytes()).unwrap();
+                import_stream.write_all(sig.name_bytes()).unwrap();
                 write!(import_stream, " <").unwrap();
-                import_stream.write(sig.email_bytes()).unwrap();
+                import_stream.write_all(sig.email_bytes()).unwrap();
                 write!(import_stream, "> ").unwrap();
                 // git-fast-import can take a few different date formats, but the
                 // default "raw" format is the easiest for us to write. Refer to

--- a/tools/src/bin/build-timeline-tree.rs
+++ b/tools/src/bin/build-timeline-tree.rs
@@ -23,7 +23,7 @@ use tools::blame::LineData;
 use tools::file_format::config::index_blame;
 
 fn get_hg_rev(helper: &mut Child, git_oid: &Oid) -> Option<String> {
-    write!(helper.stdin.as_mut().unwrap(), "{}\n", git_oid).unwrap();
+    writeln!(helper.stdin.as_mut().unwrap(), "{}", git_oid).unwrap();
     let mut reader = BufReader::new(helper.stdout.as_mut().unwrap());
     let mut result = String::new();
     reader.read_line(&mut result).unwrap();
@@ -103,9 +103,9 @@ fn read_path_oid(
     commit: &BlameRepoCommit,
     path: &Path,
 ) -> Option<String> {
-    write!(
+    writeln!(
         import_helper.stdin.as_mut().unwrap(),
-        "ls {} {}\n",
+        "ls {} {}",
         commit,
         sanitize(path)
     )
@@ -138,7 +138,7 @@ fn read_path_blob(
     path: &Path,
 ) -> Option<Vec<u8>> {
     let oid = read_path_oid(import_helper, commit, path)?;
-    write!(import_helper.stdin.as_mut().unwrap(), "cat-blob {}\n", oid).unwrap();
+    writeln!(import_helper.stdin.as_mut().unwrap(), "cat-blob {}", oid).unwrap();
     let mut reader = BufReader::new(import_helper.stdout.as_mut().unwrap());
     let mut description = String::new();
     reader.read_line(&mut description).unwrap();
@@ -278,7 +278,7 @@ fn blame_for_path(
     blame_parents: &[BlameRepoCommit],
     path: &Path,
 ) -> Result<String, git2::Error> {
-    let linecount = count_lines(&blob);
+    let linecount = count_lines(blob);
     let mut line_data = LineData {
         rev: Cow::Owned(commit.id().to_string()),
         path: LineData::path_unchanged(),
@@ -418,9 +418,9 @@ fn build_blame_tree(
                     // Item at `path` is the same in the tree for `commit` as in
                     // `parent_trees[i]`, so the blame must be the same too
                     let oid = read_path_oid(import_helper, &blame_parents[i], &path).unwrap();
-                    write!(
+                    writeln!(
                         import_helper.stdin.as_mut().unwrap(),
-                        "M {:06o} {} {}\n",
+                        "M {:06o} {} {}",
                         entry.filemode(),
                         oid,
                         sanitize(&path)
@@ -447,14 +447,14 @@ fn build_blame_tree(
                 // https://git-scm.com/docs/git-fast-import#Documentation/git-fast-import.txt-Exactbytecountformat
                 let blame_bytes = blame_text.as_bytes();
                 let import_stream = import_helper.stdin.as_mut().unwrap();
-                write!(
+                writeln!(
                     import_stream,
-                    "M {:06o} inline {}\n",
+                    "M {:06o} inline {}",
                     entry.filemode(),
                     sanitize(&path)
                 )
                 .unwrap();
-                write!(import_stream, "data {}\n", blame_bytes.len()).unwrap();
+                writeln!(import_stream, "data {}", blame_bytes.len()).unwrap();
                 import_stream.write(blame_bytes).unwrap();
                 // We skip the optional trailing LF character here since in practice it
                 // wasn't particularly useful for debugging. Also the blame blobs we write
@@ -468,9 +468,9 @@ fn build_blame_tree(
                 // For the external ref data format documentation, refer to
                 // https://git-scm.com/docs/git-fast-import#Documentation/git-fast-import.txt-Externaldataformat
                 assert_eq!(entry.filemode(), 0o160000);
-                write!(
+                writeln!(
                     import_helper.stdin.as_mut().unwrap(),
-                    "M {:06o} 4b825dc642cb6eb9a060e54bf8d69288fbee4904 {}\n",
+                    "M {:06o} 4b825dc642cb6eb9a060e54bf8d69288fbee4904 {}",
                     entry.filemode(),
                     sanitize(&path)
                 )
@@ -748,7 +748,7 @@ fn main() {
         rev_done += 1;
 
         let hg_rev = match hg_helper {
-            Some(ref mut helper) => get_hg_rev(helper, &git_oid),
+            Some(ref mut helper) => get_hg_rev(helper, git_oid),
             None => None, // we don't support mapfiles any more.
         };
 
@@ -773,8 +773,8 @@ fn main() {
             // https://git-scm.com/docs/git-fast-import#_commit
             // https://git-scm.com/docs/git-fast-import#_mark
             let mut import_stream = BufWriter::new(import_helper.stdin.as_mut().unwrap());
-            write!(import_stream, "commit {}\n", blame_ref).unwrap();
-            write!(import_stream, "mark :{}\n", rev_done).unwrap();
+            writeln!(import_stream, "commit {}", blame_ref).unwrap();
+            writeln!(import_stream, "mark :{}", rev_done).unwrap();
             blame_map.insert(*git_oid, BlameRepoCommit::Mark(rev_done));
 
             let mut write_role = |role: &str, sig: &git2::Signature| {
@@ -787,9 +787,9 @@ fn main() {
                 // default "raw" format is the easiest for us to write. Refer to
                 // https://git-scm.com/docs/git-fast-import#Documentation/git-fast-import.txt-coderawcode
                 let when = sig.when();
-                write!(
+                writeln!(
                     import_stream,
-                    "{} {}{:02}{:02}\n",
+                    "{} {}{:02}{:02}",
                     when.seconds(),
                     when.sign(),
                     when.offset_minutes().abs() / 60,
@@ -808,18 +808,18 @@ fn main() {
 
             write!(import_stream, "data {}\n{}\n", commit_msg.len(), commit_msg).unwrap();
             if let Some(first_parent) = blame_parents.first() {
-                write!(import_stream, "from {}\n", first_parent).unwrap();
+                writeln!(import_stream, "from {}", first_parent).unwrap();
             } else {
                 // This is a new root commit, so we need to use a special null
                 // parent commit identifier for git-fast-import to know that.
-                write!(
+                writeln!(
                     import_stream,
-                    "from 0000000000000000000000000000000000000000\n"
+                    "from 0000000000000000000000000000000000000000"
                 )
                 .unwrap();
             }
             for additional_parent in blame_parents.iter().skip(1) {
-                write!(import_stream, "merge {}\n", additional_parent).unwrap();
+                writeln!(import_stream, "merge {}", additional_parent).unwrap();
             }
             // For each commit, we start with a clean slate (all files deleted), and then
             // the build_blame_tree call below will add new files or link pre-existing
@@ -829,7 +829,7 @@ fn main() {
             // well for us, particularly in the case of merge commits where we might
             // need to pull some entries from one parent and other entries from the other
             // parent.
-            write!(import_stream, "deleteall\n").unwrap();
+            writeln!(import_stream, "deleteall").unwrap();
             import_stream.flush().unwrap();
         }
 
@@ -847,7 +847,7 @@ fn main() {
 
         if rev_done % 100000 == 0 {
             info!("Completed 100,000 commits, issuing checkpoint...");
-            write!(import_helper.stdin.as_mut().unwrap(), "checkpoint\n").unwrap();
+            writeln!(import_helper.stdin.as_mut().unwrap(), "checkpoint").unwrap();
         }
     }
 

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -91,7 +91,7 @@ fn process_analysis_target(
     pretty_table: &mut PrettyTable,
     id_table: &mut IdTable,
     callees_table: &mut CalleesTable,
-    lines: &Vec<(String, u32)>,
+    lines: &[(String, u32)],
 ) {
     if piece.pretty.is_empty() {
         info!("Skipping empty pretty for symbol {}", piece.sym);

--- a/tools/src/bin/css-analyze.rs
+++ b/tools/src/bin/css-analyze.rs
@@ -7,7 +7,7 @@ fn main() {
     let path = args[1].clone();
     let text = match fs::read_to_string(path.clone()) {
         Ok(text) => text,
-        _ => return
+        _ => return,
     };
     let mut callback = |s| {
         println!("{}", s);

--- a/tools/src/bin/ipdl-analyze.rs
+++ b/tools/src/bin/ipdl-analyze.rs
@@ -100,8 +100,9 @@ fn find_analysis<'a>(analysis: &'a TargetAnalysis, mangled: &str) -> Option<&'a 
             // Inline method definitions and pure virtual method declarations
             // will both be reported as definitions by the C++ indexer without a
             // declaration, so we need to accept both decls and defs.
-            if (piece.kind == AnalysisKind::Decl || piece.kind == AnalysisKind::Def) &&
-               piece.sym.contains(mangled) {
+            if (piece.kind == AnalysisKind::Decl || piece.kind == AnalysisKind::Def)
+                && piece.sym.contains(mangled)
+            {
                 best_piece = Some(piece);
             }
         }
@@ -110,7 +111,14 @@ fn find_analysis<'a>(analysis: &'a TargetAnalysis, mangled: &str) -> Option<&'a 
     return best_piece;
 }
 
-fn output_ipc_data(outputf: &mut File, locstr: &str, ipc_pretty: &str, ipc_sym: &str, send_datum: &AnalysisTarget, recv_datum: &AnalysisTarget) {
+fn output_ipc_data(
+    outputf: &mut File,
+    locstr: &str,
+    ipc_pretty: &str,
+    ipc_sym: &str,
+    send_datum: &AnalysisTarget,
+    recv_datum: &AnalysisTarget,
+) {
     write!(
         outputf,
         "{}",
@@ -218,9 +226,12 @@ fn output_send_recv(
         &format!("{}{}{}", recv_prefix, message.name.id, ctor_suffix),
     );
     let maybe_recv_datum = find_analysis(recv_analysis, &mangled_no_p)
-                           .or_else(|| find_analysis(recv_analysis, &mangled_yes_p));
+        .or_else(|| find_analysis(recv_analysis, &mangled_yes_p));
     if let None = maybe_recv_datum {
-        println!("No analysis target found for recv: {} or {}", mangled_no_p, mangled_yes_p);
+        println!(
+            "No analysis target found for recv: {} or {}",
+            mangled_no_p, mangled_yes_p
+        );
     }
 
     if let (Some(send_datum), Some(recv_datum)) = (maybe_send_datum, maybe_recv_datum) {
@@ -236,7 +247,14 @@ fn output_send_recv(
             protocol.name.id,
             message.name.id
         );
-        output_ipc_data(outputf, &locstr, &ipc_pretty, &ipc_sym, &send_datum, &recv_datum);
+        output_ipc_data(
+            outputf,
+            &locstr,
+            &ipc_pretty,
+            &ipc_sym,
+            &send_datum,
+            &recv_datum,
+        );
     }
 }
 
@@ -344,18 +362,32 @@ fn main() {
             // ### Parent Analyses
             let mut parent_ana_files = vec![];
             if let Some(parent_fname) = objdir_files_map.get(&format!("{}Parent.h", &ns.name.id)) {
-                let parent_path = analysis_path.join(parent_fname).to_string_lossy().into_owned();
+                let parent_path = analysis_path
+                    .join(parent_fname)
+                    .to_string_lossy()
+                    .into_owned();
                 println!("  Reading Parent header {:?}", &parent_path);
                 parent_ana_files.push(parent_path);
             } else {
-                println!("  Unable to find Parent header for protocol: {}", &ns.name.id);
+                println!(
+                    "  Unable to find Parent header for protocol: {}",
+                    &ns.name.id
+                );
             }
-            if let Some(parent_impl_fname) = repo_files_map.get(&format!("{}Parent.h", &ns.name.id[1..])) {
-                let parent_impl_path = analysis_path.join(parent_impl_fname).to_string_lossy().into_owned();
+            if let Some(parent_impl_fname) =
+                repo_files_map.get(&format!("{}Parent.h", &ns.name.id[1..]))
+            {
+                let parent_impl_path = analysis_path
+                    .join(parent_impl_fname)
+                    .to_string_lossy()
+                    .into_owned();
                 println!("  Reading Parent impl header {:?}", &parent_impl_path);
                 parent_ana_files.push(parent_impl_path);
             } else {
-                println!("  Unable to find Parent impl header for protocol: {}", &ns.name.id);
+                println!(
+                    "  Unable to find Parent impl header for protocol: {}",
+                    &ns.name.id
+                );
             }
 
             let parent_analysis = read_analyses(parent_ana_files.as_slice(), &mut read_target);
@@ -363,18 +395,32 @@ fn main() {
             // ### Child Analyses
             let mut child_ana_files = vec![];
             if let Some(child_fname) = objdir_files_map.get(&format!("{}Child.h", &ns.name.id)) {
-                let child_path = analysis_path.join(child_fname).to_string_lossy().into_owned();
+                let child_path = analysis_path
+                    .join(child_fname)
+                    .to_string_lossy()
+                    .into_owned();
                 println!("  Reading Child header {:?}", &child_path);
                 child_ana_files.push(child_path);
             } else {
-                println!("  Unable to find Child header for protocol: {}", &ns.name.id);
+                println!(
+                    "  Unable to find Child header for protocol: {}",
+                    &ns.name.id
+                );
             }
-            if let Some(child_impl_fname) = repo_files_map.get(&format!("{}Child.h", &ns.name.id[1..])) {
-                let child_impl_path = analysis_path.join(child_impl_fname).to_string_lossy().into_owned();
+            if let Some(child_impl_fname) =
+                repo_files_map.get(&format!("{}Child.h", &ns.name.id[1..]))
+            {
+                let child_impl_path = analysis_path
+                    .join(child_impl_fname)
+                    .to_string_lossy()
+                    .into_owned();
                 println!("  Reading Child impl header {:?}", &child_impl_path);
                 child_ana_files.push(child_impl_path);
             } else {
-                println!("  Unable to find Child impl header for protocol: {}", &ns.name.id);
+                println!(
+                    "  Unable to find Child impl header for protocol: {}",
+                    &ns.name.id
+                );
             }
             let child_analysis = read_analyses(child_ana_files.as_slice(), &mut read_target);
 

--- a/tools/src/bin/ipdl-analyze.rs
+++ b/tools/src/bin/ipdl-analyze.rs
@@ -80,7 +80,7 @@ fn mangle_nested_name(ns: &[String], protocol: &str, name: &str) -> String {
     format!(
         "_ZN{}{}{}E",
         ns.iter()
-            .map(|id| mangle_simple(&id))
+            .map(|id| mangle_simple(id))
             .collect::<Vec<_>>()
             .join(""),
         mangle_simple(protocol),
@@ -108,7 +108,7 @@ fn find_analysis<'a>(analysis: &'a TargetAnalysis, mangled: &str) -> Option<&'a 
         }
     }
 
-    return best_piece;
+    best_piece
 }
 
 fn output_ipc_data(
@@ -131,7 +131,7 @@ fn output_ipc_data(
         })
     )
     .unwrap();
-    write!(outputf, "\n").unwrap();
+    writeln!(outputf).unwrap();
     write!(
         outputf,
         "{}",
@@ -144,7 +144,7 @@ fn output_ipc_data(
         })
     )
     .unwrap();
-    write!(outputf, "\n").unwrap();
+    writeln!(outputf).unwrap();
     write!(
         outputf,
         "{}",
@@ -173,7 +173,7 @@ fn output_ipc_data(
         })
     )
     .unwrap();
-    write!(outputf, "\n").unwrap();
+    writeln!(outputf).unwrap();
 }
 
 fn output_send_recv(
@@ -206,7 +206,7 @@ fn output_send_recv(
         &format!("{}{}{}", send_prefix, message.name.id, ctor_suffix),
     );
     let maybe_send_datum = find_analysis(send_analysis, &mangled);
-    if let None = maybe_send_datum {
+    if maybe_send_datum.is_none() {
         println!("No analysis target found for send: {}", mangled);
     }
 
@@ -227,7 +227,7 @@ fn output_send_recv(
     );
     let maybe_recv_datum = find_analysis(recv_analysis, &mangled_no_p)
         .or_else(|| find_analysis(recv_analysis, &mangled_yes_p));
-    if let None = maybe_recv_datum {
+    if maybe_recv_datum.is_none() {
         println!(
             "No analysis target found for recv: {} or {}",
             mangled_no_p, mangled_yes_p
@@ -249,11 +249,11 @@ fn output_send_recv(
         );
         output_ipc_data(
             outputf,
-            &locstr,
+            locstr,
             &ipc_pretty,
             &ipc_sym,
-            &send_datum,
-            &recv_datum,
+            send_datum,
+            recv_datum,
         );
     }
 }
@@ -424,7 +424,7 @@ fn main() {
             }
             let child_analysis = read_analyses(child_ana_files.as_slice(), &mut read_target);
 
-            let is_toplevel = protocol.managers.len() == 0;
+            let is_toplevel = protocol.managers.is_empty();
 
             for message in protocol.messages {
                 let loc = &message.name.loc;

--- a/tools/src/bin/merge-analyses.rs
+++ b/tools/src/bin/merge-analyses.rs
@@ -28,7 +28,7 @@ fn main() {
 
     let args: Vec<_> = env::args().skip(1).collect();
 
-    if args.len() == 0 {
+    if args.is_empty() {
         eprintln!("Usage: merge-analyses <filename> [<filename> [...]]");
         eprintln!("  This tool will merge the analysis data from the given files");
         eprintln!("  and print it to stdout; each line will be in a normalized format.");

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -51,7 +51,7 @@ fn main() {
     let cfg = config::load(
         &base_args[1],
         true,
-        Some(&tree_name),
+        Some(tree_name),
         Some(base_args[3].to_string()),
     );
     writeln!(
@@ -107,8 +107,8 @@ fn main() {
     .unwrap();
 
     let pre_blame_prep = Instant::now();
-    let (blame_commit, head_oid) = match &tree_config.git {
-        &Some(ref git) => {
+    let (blame_commit, head_oid) = match tree_config.git {
+        Some(ref git) => {
             let head_oid = git.repo.refname_to_id("HEAD").unwrap();
             let blame_commit = if let Some(ref blame_repo) = git.blame_repo {
                 let blame_oid = blame_repo.refname_to_id("HEAD").unwrap();
@@ -118,7 +118,7 @@ fn main() {
             };
             (blame_commit, Some(head_oid))
         }
-        &None => (None, None),
+        None => (None, None),
     };
 
     let head_commit =
@@ -198,12 +198,9 @@ fn main() {
 
         let mut reader = BufReader::new(&source_file);
 
-        match format {
-            FormatAs::Binary => {
-                let _ = io::copy(&mut reader, &mut writer);
-                continue;
-            }
-            _ => {}
+        if let FormatAs::Binary = format {
+            let _ = io::copy(&mut reader, &mut writer);
+            continue;
         };
 
         let pre_analysis_load = Instant::now();
@@ -258,11 +255,11 @@ fn main() {
 
         let extension = path_wrapper
             .extension()
-            .unwrap_or(&OsStr::new(""))
+            .unwrap_or(OsStr::new(""))
             .to_str()
             .unwrap();
         let show_header = match extension_mapping.get(extension) {
-            Some(&(ref description, ref try_extensions)) => {
+            Some((description, try_extensions)) => {
                 let mut result = None;
                 for try_ext in try_extensions {
                     let try_buf = path_wrapper.with_extension(try_ext);

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -26,8 +26,8 @@ extern crate log;
 extern crate tools;
 use crate::languages::FormatAs;
 use tools::file_format::analysis::{read_analysis, read_source};
-use tools::format::{create_markdown_panel_section, format_file_data};
 use tools::file_format::crossref_lookup::CrossrefLookupMap;
+use tools::format::{create_markdown_panel_section, format_file_data};
 use tools::languages;
 use tools::url_encode_path::url_encode_path;
 
@@ -48,7 +48,12 @@ fn main() {
 
     let pre_config = Instant::now();
     let tree_name = &base_args[2];
-    let cfg = config::load(&base_args[1], true, Some(&tree_name), Some(base_args[3].to_string()));
+    let cfg = config::load(
+        &base_args[1],
+        true,
+        Some(&tree_name),
+        Some(base_args[3].to_string()),
+    );
     writeln!(
         stdout,
         "Config file read, duration: {}us",
@@ -81,7 +86,12 @@ fn main() {
     let pre_jumpref = Instant::now();
     let jumpref_lookup_map = CrossrefLookupMap::new(&jumpref_path, &jumpref_extra_path);
 
-    writeln!(stdout, "Jumpref opened, duration: {}us", pre_jumpref.elapsed().as_micros() as u64).unwrap();
+    writeln!(
+        stdout,
+        "Jumpref opened, duration: {}us",
+        pre_jumpref.elapsed().as_micros() as u64
+    )
+    .unwrap();
 
     let pre_lookup_map = Instant::now();
     let file_lookup_path = format!(
@@ -375,7 +385,10 @@ fn main() {
         if let Some(ref ccov_root) = tree_config.paths.ccov_root {
             tools_items.push(PanelItem {
                 title: "Code Coverage".to_owned(),
-                link: format!("{}#revision=latest&path={}&view=file", ccov_root, encoded_path),
+                link: format!(
+                    "{}#revision=latest&path={}&view=file",
+                    ccov_root, encoded_path
+                ),
                 update_link_lineno: "&line={}",
                 accel_key: None,
                 copyable: false,

--- a/tools/src/bin/pipeline-server.rs
+++ b/tools/src/bin/pipeline-server.rs
@@ -57,10 +57,9 @@ async fn handle_query(
     };
 
     let graph = {
-        let _log_entered = match &logged_span {
-            Some(lspan) => Some(lspan.span.clone().entered()),
-            _ => None,
-        };
+        let _log_entered = logged_span
+            .as_ref()
+            .map(|lspan| lspan.span.clone().entered());
 
         let pipeline_plan = chew_query(query)?;
 
@@ -74,7 +73,7 @@ async fn handle_query(
 
     let accept = headers
         .get("accept")
-        .map(|x| x.to_str().unwrap_or_else(|_| "text/html"));
+        .map(|x| x.to_str().unwrap_or("text/html"));
     let make_html = match accept {
         Some("application/json") => false,
         _ => true,

--- a/tools/src/bin/pipeline-server.rs
+++ b/tools/src/bin/pipeline-server.rs
@@ -7,7 +7,7 @@ use std::{
 use axum::{
     extract::{Path, Query},
     http::{HeaderMap, StatusCode},
-    response::{IntoResponse, Response, Html},
+    response::{Html, IntoResponse, Response},
     routing::get,
     Extension, Json, Router,
 };
@@ -17,8 +17,9 @@ use serde_json::Value;
 use tools::{
     abstract_server::{make_all_local_servers, AbstractServer, ServerError},
     cmd_pipeline::{builder::build_pipeline_graph, PipelineValues},
+    logging::{init_logging, LoggedSpan},
     query::chew_query::chew_query,
-    templating::builder::build_and_parse_query_results, logging::{LoggedSpan, init_logging},
+    templating::builder::build_and_parse_query_results,
 };
 use tracing::Instrument;
 
@@ -42,7 +43,11 @@ async fn handle_query(
     }
 
     let maybe_log = params.contains_key("debug");
-    let logged_span: Option<LoggedSpan> = if maybe_log { Some(LoggedSpan::new_logged_span("query")) } else { None };
+    let logged_span: Option<LoggedSpan> = if maybe_log {
+        Some(LoggedSpan::new_logged_span("query"))
+    } else {
+        None
+    };
 
     let query = match params.get("q") {
         Some(q) => q,
@@ -86,7 +91,8 @@ async fn handle_query(
                 serde_json::to_string(&grb.symbols).unwrap_or_else(|_| "{}".to_string())
             }
             PipelineValues::SymbolTreeTableList(sttl) => {
-                serde_json::to_string(&sttl.unioned_node_sets_as_jumprefs()).unwrap_or_else(|_| "{}".to_string())
+                serde_json::to_string(&sttl.unioned_node_sets_as_jumprefs())
+                    .unwrap_or_else(|_| "{}".to_string())
             }
             _ => "{}".to_string(),
         };

--- a/tools/src/bin/pipeline-server.rs
+++ b/tools/src/bin/pipeline-server.rs
@@ -74,10 +74,7 @@ async fn handle_query(
     let accept = headers
         .get("accept")
         .map(|x| x.to_str().unwrap_or("text/html"));
-    let make_html = match accept {
-        Some("application/json") => false,
-        _ => true,
-    };
+    let make_html = !matches!(accept, Some("application/json"));
 
     let logs = match logged_span {
         Some(lspan) => lspan.retrieve_serde_json().await,

--- a/tools/src/bin/rust-indexer.rs
+++ b/tools/src/bin/rust-indexer.rs
@@ -722,7 +722,7 @@ fn analyze_file(
 // combination of backslashes and forward slashes for windows platform builds
 // because the paths are normalized by a sed script that will match backslashes
 // and output front-slashes.  The sed script could be made smarter.
-fn linuxized_path(path: &PathBuf) -> PathBuf {
+fn linuxized_path(path: &Path) -> PathBuf {
     if let Some(pathstr) = path.to_str() {
         if pathstr.find('\\').is_some() {
             // Pesky backslashes, get rid of them!
@@ -740,7 +740,7 @@ fn linuxized_path(path: &PathBuf) -> PathBuf {
         }
     }
     // Already a valid path!
-    path.clone()
+    path.to_path_buf()
 }
 
 fn analyze_crate(analysis: &data::Analysis, defs: &Defs, tree_info: &TreeInfo) {

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -396,7 +396,7 @@ struct NestedSymbol {
 
 fn compile_nesting_queries(
     lang: &tree_sitter::Language,
-    nesting: &Vec<SitterNesting>,
+    nesting: &[SitterNesting],
 ) -> tree_sitter::Query {
     let query_pats: Vec<String> = nesting
         .iter()

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -25,7 +25,7 @@ async fn main() {
             "This command expects a single argument that it can parse up; quote in your shell."
         );
         println!("Example: `searchfox-tool 'cmd1 --arg | cmd2 --arg | cmd3'");
-        println!("");
+        println!();
         println!(
             "The built-in help will work, but the arg parser gets invoked once for each pipe."
         );

--- a/tools/src/bin/searchfox-tool.rs
+++ b/tools/src/bin/searchfox-tool.rs
@@ -1,13 +1,11 @@
-use std::{
-    env::args_os,
-};
+use std::env::args_os;
 
-use serde_json::{to_string_pretty, Value, to_value};
+use serde_json::{to_string_pretty, to_value, Value};
 use tools::{
     abstract_server::{ErrorDetails, ErrorLayer, ServerError},
     cmd_pipeline::{builder::build_pipeline, parser::OutputFormat, PipelineValues},
 };
-use tracing_subscriber::{EnvFilter, fmt, prelude::*};
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 #[tokio::main]
 async fn main() {

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -53,7 +53,7 @@ impl WebResponse {
         WebResponse {
             content_type: "text/html".to_owned(),
             output: body,
-            .. WebResponse::default()
+            ..WebResponse::default()
         }
     }
 
@@ -61,7 +61,7 @@ impl WebResponse {
         WebResponse {
             content_type: "application/json".to_owned(),
             output: body,
-            .. WebResponse::default()
+            ..WebResponse::default()
         }
     }
 
@@ -69,7 +69,7 @@ impl WebResponse {
         WebResponse {
             status: StatusCode::InternalServerError,
             output: body,
-            .. WebResponse::default()
+            ..WebResponse::default()
         }
     }
 
@@ -77,7 +77,7 @@ impl WebResponse {
         WebResponse {
             status: StatusCode::NotFound,
             output: "Not found".to_owned(),
-            .. WebResponse::default()
+            ..WebResponse::default()
         }
     }
 
@@ -85,7 +85,7 @@ impl WebResponse {
         WebResponse {
             status: StatusCode::MovedPermanently,
             redirect_location: Some(url),
-            .. WebResponse::default()
+            ..WebResponse::default()
         }
     }
 }
@@ -122,7 +122,7 @@ fn handle_static(path: String, content_type: Option<&str>) -> WebResponse {
     WebResponse {
         content_type: content_type.to_owned(),
         output: input,
-        .. WebResponse::default()
+        ..WebResponse::default()
     }
 }
 
@@ -180,13 +180,12 @@ fn handle(
                 .current_dir(&git_path)
                 .output();
             match output_result {
-                Ok(output) if output.status.success() => {
-                    WebResponse::redirect(format!("/{}/rev/{}/{}",
-                        tree_name,
-                        git_ops::decode_bytes(output.stdout).trim(),
-                        path[3..].join("/"))
-                    )
-                }
+                Ok(output) if output.status.success() => WebResponse::redirect(format!(
+                    "/{}/rev/{}/{}",
+                    tree_name,
+                    git_ops::decode_bytes(output.stdout).trim(),
+                    path[3..].join("/")
+                )),
                 Ok(_) => WebResponse::not_found(),
                 Err(err) => WebResponse::internal_error(format!("{:?}", err)),
             }
@@ -317,5 +316,7 @@ fn main() {
     println!("On 8001");
     // Use 4 threads instead of the 2 that would be automatically chosen on our
     // AWS boxes.
-    let _listening = hyper::Server::http("0.0.0.0:8001").unwrap().handle_threads(handler, 4);
+    let _listening = hyper::Server::http("0.0.0.0:8001")
+        .unwrap()
+        .handle_threads(handler, 4);
 }

--- a/tools/src/blame.rs
+++ b/tools/src/blame.rs
@@ -1,8 +1,8 @@
 use crate::file_format::config::Config;
 use crate::links;
 
+use serde_json::{json, to_string, Map};
 use std::borrow::Cow;
-use serde_json::{json, Map, to_string};
 
 use chrono::datetime::DateTime;
 use chrono::naive::datetime::NaiveDateTime;
@@ -21,11 +21,7 @@ pub fn commit_header(commit: &git2::Commit) -> Result<(String, String), &'static
     Ok((header, entity_replace(&remainder)))
 }
 
-pub fn get_commit_info(
-    cfg: &Config,
-    tree_name: &str,
-    revs: &str,
-) -> Result<String, &'static str> {
+pub fn get_commit_info(cfg: &Config, tree_name: &str, revs: &str) -> Result<String, &'static str> {
     let tree_config = cfg.trees.get(tree_name).ok_or("Invalid tree")?;
     let git = tree_config.get_git()?;
     let mut infos = vec![];

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -216,7 +216,7 @@ pub fn build_pipeline_graph(
                     // The args needs to include a fake binary name, then the
                     // command, then the args.
                     let full_args: Vec<String> =
-                        vec!["searchfox-tool".to_string(), segment.command.clone()]
+                        ["searchfox-tool".to_string(), segment.command.clone()]
                             .iter()
                             .chain(&segment.args.to_vec())
                             .cloned()
@@ -265,7 +265,7 @@ pub fn build_pipeline_graph(
                 })
             })?;
 
-            let full_args: Vec<String> = vec![
+            let full_args: Vec<String> = [
                 "searchfox-tool".to_string(),
                 junction_info.command.command.clone(),
             ]

--- a/tools/src/cmd_pipeline/builder.rs
+++ b/tools/src/cmd_pipeline/builder.rs
@@ -18,7 +18,13 @@ use crate::{
     cmd_pipeline::parser::{Command, OutputFormat, ToolOpts},
 };
 
-use super::{cmd_augment_results::AugmentResultsCommand, cmd_batch_render::BatchRenderCommand, cmd_format_symbols::FormatSymbolsCommand, cmd_fuse_crossrefs::FuseCrossrefsCommand, cmd_jumpref_lookup::JumprefLookupCommand, cmd_render::RenderCommand, cmd_tokenize_source::TokenizeSourceCommand, cmd_traverse::TraverseCommand, cmd_webtest::WebtestCommand};
+use super::{
+    cmd_augment_results::AugmentResultsCommand, cmd_batch_render::BatchRenderCommand,
+    cmd_format_symbols::FormatSymbolsCommand, cmd_fuse_crossrefs::FuseCrossrefsCommand,
+    cmd_jumpref_lookup::JumprefLookupCommand, cmd_render::RenderCommand,
+    cmd_tokenize_source::TokenizeSourceCommand, cmd_traverse::TraverseCommand,
+    cmd_webtest::WebtestCommand,
+};
 use super::{
     cmd_cat_html::CatHtmlCommand,
     cmd_compile_results::CompileResultsCommand,
@@ -42,7 +48,10 @@ pub enum CommandSafetyLevel {
     WebSafety,
 }
 
-pub fn fab_command_from_opts(opts: ToolOpts, safety: CommandSafetyLevel) -> Result<Box<dyn PipelineCommand + Send + Sync>> {
+pub fn fab_command_from_opts(
+    opts: ToolOpts,
+    safety: CommandSafetyLevel,
+) -> Result<Box<dyn PipelineCommand + Send + Sync>> {
     match (opts.cmd, safety) {
         (Command::AugmentResults(ar), _) => Ok(Box::new(AugmentResultsCommand { args: ar })),
 
@@ -84,12 +93,14 @@ pub fn fab_command_from_opts(opts: ToolOpts, safety: CommandSafetyLevel) -> Resu
 
         (Command::Traverse(t), _) => Ok(Box::new(TraverseCommand { args: t })),
 
-        (Command::Webtest(t), CommandSafetyLevel::DangerousToolUseAllowed) => Ok(Box::new(WebtestCommand { args: t })),
+        (Command::Webtest(t), CommandSafetyLevel::DangerousToolUseAllowed) => {
+            Ok(Box::new(WebtestCommand { args: t }))
+        }
 
         _ => Err(ServerError::StickyProblem(ErrorDetails {
             layer: ErrorLayer::BadInput,
             message: "Command not allowed in this context".to_string(),
-        }))
+        })),
     }
 }
 
@@ -160,7 +171,10 @@ pub fn build_pipeline(bin_name: &str, arg_str: &str) -> Result<(ServerPipeline, 
         // test_check_insta, and we allow them to do raw pipeline stuff that we
         // do not want to expose to the web.  The pipeline-server uses
         // `build_pipeline_graph` below.  (Also, the "query" command )
-        commands.push(fab_command_from_opts(opts, CommandSafetyLevel::DangerousToolUseAllowed)?);
+        commands.push(fab_command_from_opts(
+            opts,
+            CommandSafetyLevel::DangerousToolUseAllowed,
+        )?);
     }
 
     Ok((

--- a/tools/src/cmd_pipeline/cmd_augment_results.rs
+++ b/tools/src/cmd_pipeline/cmd_augment_results.rs
@@ -90,9 +90,7 @@ impl PipelineCommand for AugmentResultsCommand {
                 .fetch_html(HtmlFileRoot::FormattedFile, &path)
                 .await?;
 
-            let file_lines = path_line_contents
-                .entry(path.clone())
-                .or_insert_with(|| HashMap::new());
+            let file_lines = path_line_contents.entry(path).or_default();
 
             // ### HTML Extraction: What We Want
             //

--- a/tools/src/cmd_pipeline/cmd_augment_results.rs
+++ b/tools/src/cmd_pipeline/cmd_augment_results.rs
@@ -55,7 +55,7 @@ pub struct AugmentResultsCommand {
 impl PipelineCommand for AugmentResultsCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let mut results = match input {

--- a/tools/src/cmd_pipeline/cmd_batch_render.rs
+++ b/tools/src/cmd_pipeline/cmd_batch_render.rs
@@ -32,7 +32,7 @@ pub struct BatchRenderCommand {
 impl PipelineCommand for BatchRenderCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let batch_groups = match input {

--- a/tools/src/cmd_pipeline/cmd_batch_render.rs
+++ b/tools/src/cmd_pipeline/cmd_batch_render.rs
@@ -6,7 +6,8 @@ use crate::{
     abstract_server::{
         AbstractServer, ErrorDetails, ErrorLayer, Result, SearchfoxIndexRoot, ServerError,
     },
-    templating::builder::build_and_parse_dir_listing, file_utils::write_file_ensuring_parent_dir,
+    file_utils::write_file_ensuring_parent_dir,
+    templating::builder::build_and_parse_dir_listing,
 };
 
 #[derive(Debug, Args)]

--- a/tools/src/cmd_pipeline/cmd_cat_html.rs
+++ b/tools/src/cmd_pipeline/cmd_cat_html.rs
@@ -105,7 +105,7 @@ fn extract_html_snippet(html_str: String, selector: &str) -> String {
                 }
                 // Flush if this was apparently a transition from accumulating
                 // into our buffer.
-                if buf.len() > 0 {
+                if !buf.is_empty() {
                     excerpts.push(String::from_utf8_lossy(&buf).to_string());
                     buf.clear();
                 }

--- a/tools/src/cmd_pipeline/cmd_cat_html.rs
+++ b/tools/src/cmd_pipeline/cmd_cat_html.rs
@@ -126,7 +126,7 @@ fn extract_html_snippet(html_str: String, selector: &str) -> String {
 impl PipelineCommand for CatHtmlCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let root = if self.args.dir {

--- a/tools/src/cmd_pipeline/cmd_compile_results.rs
+++ b/tools/src/cmd_pipeline/cmd_compile_results.rs
@@ -1,20 +1,20 @@
 use std::collections::{BTreeMap, HashSet};
 
 use async_trait::async_trait;
-use serde_json::{from_value, Value};
 use clap::Args;
-use ustr::{UstrMap, Ustr, ustr};
+use serde_json::{from_value, Value};
+use ustr::{ustr, Ustr, UstrMap};
 
 use super::interface::{
     FlattenedKindGroupResults, FlattenedLineSpan, FlattenedPathKindGroupResults,
-    FlattenedResultsBundle, FlattenedResultsByFile, PipelineJunctionCommand,
-    PipelineValues, PresentationKind, ResultFacetGroup, ResultFacetKind, ResultFacetRoot,
-    SymbolCrossrefInfo, SymbolQuality, SymbolRelation,
+    FlattenedResultsBundle, FlattenedResultsByFile, PipelineJunctionCommand, PipelineValues,
+    PresentationKind, ResultFacetGroup, ResultFacetKind, ResultFacetRoot, SymbolCrossrefInfo,
+    SymbolQuality, SymbolRelation,
 };
 
 use crate::{
     abstract_server::{
-        AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError, TextMatchesByFile, FileMatch,
+        AbstractServer, ErrorDetails, ErrorLayer, FileMatch, Result, ServerError, TextMatchesByFile,
     },
     file_format::analysis::PathSearchResult,
 };
@@ -348,15 +348,17 @@ impl SearchResults {
                     line_spans: vec![],
                 });
             for text_match in file_match.matches {
-                if self.path_line_suppressions
-                    .insert(format!("{}:{}", path, text_match.line_num)) {
-                        file_results.line_spans.push(FlattenedLineSpan {
-                            key_line: text_match.line_num,
-                            line_range: (text_match.line_num, text_match.line_num),
-                            contents: text_match.line_str,
-                            context: ustr(""),
-                            contextsym: ustr(""),
-                        });
+                if self
+                    .path_line_suppressions
+                    .insert(format!("{}:{}", path, text_match.line_num))
+                {
+                    file_results.line_spans.push(FlattenedLineSpan {
+                        key_line: text_match.line_num,
+                        line_range: (text_match.line_num, text_match.line_num),
+                        contents: text_match.line_str,
+                        context: ustr(""),
+                        contextsym: ustr(""),
+                    });
                 }
             }
             // The suppressions could mean we don't actually need this path hit,
@@ -541,8 +543,11 @@ impl MaybeFacetGroup {
             );
         } else if self.nested_groups.len() == 1 {
             let (sole_name, sole_group) = self.nested_groups.into_iter().next().unwrap();
-            let (mut sole_compiled, breadth) =
-                sole_group.compile(prefix.clone() + sole_name.as_str(), clump_thresh, other.clone());
+            let (mut sole_compiled, breadth) = sole_group.compile(
+                prefix.clone() + sole_name.as_str(),
+                clump_thresh,
+                other.clone(),
+            );
 
             if self.values.len() == 0 {
                 // Collapse us into the nested group
@@ -621,8 +626,11 @@ impl MaybeFacetGroup {
 
                 for (name, group) in self.nested_groups {
                     if group.count >= clump_thresh {
-                        let (sub_compiled, sub_breadth) =
-                            group.compile(prefix.clone() + name.as_str(), clump_thresh, other.clone());
+                        let (sub_compiled, sub_breadth) = group.compile(
+                            prefix.clone() + name.as_str(),
+                            clump_thresh,
+                            other.clone(),
+                        );
                         nested_groups.push(sub_compiled);
                         if sub_breadth > breadth {
                             breadth = sub_breadth;

--- a/tools/src/cmd_pipeline/cmd_compile_results.rs
+++ b/tools/src/cmd_pipeline/cmd_compile_results.rs
@@ -674,7 +674,7 @@ pub struct CompileResultsCommand {
 impl PipelineJunctionCommand for CompileResultsCommand {
     async fn execute(
         &self,
-        _server: &Box<dyn AbstractServer + Send + Sync>,
+        _server: &(dyn AbstractServer + Send + Sync),
         input: Vec<(String, PipelineValues)>,
     ) -> Result<PipelineValues> {
         let mut results = SearchResults::default();

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -110,9 +110,9 @@ impl PipelineCommand for CrossrefExpandCommand {
         let mut considered = HashSet::new();
 
         for info in source_crossrefs.symbol_crossref_infos {
-            considered.insert(info.symbol.clone());
+            considered.insert(info.symbol);
             to_traverse.push_back((
-                info.symbol.clone(),
+                info.symbol,
                 info.relation.clone(),
                 info.quality.clone(),
                 Some(info),
@@ -141,7 +141,7 @@ impl PipelineCommand for CrossrefExpandCommand {
                 None => {
                     let fresh_info = server.crossref_lookup(&symbol, false).await?;
                     SymbolCrossrefInfo {
-                        symbol: symbol.clone(),
+                        symbol,
                         crossref_info: fresh_info,
                         relation: relation.clone(),
                         quality,
@@ -197,9 +197,9 @@ impl PipelineCommand for CrossrefExpandCommand {
                         for wrapped in arr.iter() {
                             if let Value::String(sym) = xfunc(wrapped) {
                                 let usym = ustr(sym);
-                                if considered.insert(usym.clone()) {
+                                if considered.insert(usym) {
                                     to_traverse.push_back((
-                                        usym.clone(),
+                                        usym,
                                         use_relation.clone(),
                                         info.quality.clone(),
                                         None,
@@ -230,26 +230,26 @@ impl PipelineCommand for CrossrefExpandCommand {
                 SymbolRelation::Queried => {
                     proc_ptr(
                         "/meta/overridenBy",
-                        &|x| &x,
-                        SymbolRelation::OverrideOf(symbol.clone(), 1),
+                        &|x| x,
+                        SymbolRelation::OverrideOf(symbol, 1),
                         Some(&mut override_limits),
                     );
                     proc_ptr(
                         "/meta/overrides",
                         &|x| &x["sym"],
-                        SymbolRelation::OverriddenBy(symbol.clone(), 1),
+                        SymbolRelation::OverriddenBy(symbol, 1),
                         None,
                     );
                     proc_ptr(
                         "/meta/subclasses",
-                        &|x| &x,
-                        SymbolRelation::SubclassOf(symbol.clone(), 1),
+                        &|x| x,
+                        SymbolRelation::SubclassOf(symbol, 1),
                         Some(&mut subclass_limits),
                     );
                     proc_ptr(
                         "/meta/supers",
                         &|x| &x["sym"],
-                        SymbolRelation::SuperclassOf(symbol.clone(), 1),
+                        SymbolRelation::SuperclassOf(symbol, 1),
                         None,
                     );
                 }
@@ -257,37 +257,37 @@ impl PipelineCommand for CrossrefExpandCommand {
                     proc_ptr(
                         "/meta/overrides",
                         &|x| &x["sym"],
-                        SymbolRelation::OverriddenBy(root_sym.clone(), dist + 1),
+                        SymbolRelation::OverriddenBy(*root_sym, dist + 1),
                         None,
                     );
                     proc_ptr(
                         "/meta/overridenBy",
-                        &|x| &x,
-                        SymbolRelation::CousinOverrideOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::CousinOverrideOf(*root_sym, dist + 1),
                         Some(&mut override_limits),
                     );
                 }
                 SymbolRelation::OverrideOf(root_sym, dist) => {
                     proc_ptr(
                         "/meta/overridenBy",
-                        &|x| &x,
-                        SymbolRelation::OverrideOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::OverrideOf(*root_sym, dist + 1),
                         Some(&mut override_limits),
                     );
                 }
                 SymbolRelation::CousinOverrideOf(root_sym, dist) => {
                     proc_ptr(
                         "/meta/overridenBy",
-                        &|x| &x,
-                        SymbolRelation::CousinOverrideOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::CousinOverrideOf(*root_sym, dist + 1),
                         Some(&mut override_limits),
                     );
                 }
                 SymbolRelation::SubclassOf(root_sym, dist) => {
                     proc_ptr(
                         "/meta/subclasses",
-                        &|x| &x,
-                        SymbolRelation::SubclassOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::SubclassOf(*root_sym, dist + 1),
                         Some(&mut subclass_limits),
                     );
                 }
@@ -295,21 +295,21 @@ impl PipelineCommand for CrossrefExpandCommand {
                     proc_ptr(
                         "/meta/supers",
                         &|x| &x["sym"],
-                        SymbolRelation::SuperclassOf(root_sym.clone(), dist + 1),
+                        SymbolRelation::SuperclassOf(*root_sym, dist + 1),
                         None,
                     );
                     proc_ptr(
                         "/meta/subclasses",
-                        &|x| &x,
-                        SymbolRelation::CousinClassOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::CousinClassOf(*root_sym, dist + 1),
                         Some(&mut subclass_limits),
                     );
                 }
                 SymbolRelation::CousinClassOf(root_sym, dist) => {
                     proc_ptr(
                         "/meta/subclasses",
-                        &|x| &x,
-                        SymbolRelation::CousinClassOf(root_sym.clone(), dist + 1),
+                        &|x| x,
+                        SymbolRelation::CousinClassOf(*root_sym, dist + 1),
                         Some(&mut subclass_limits),
                     );
                 }

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -80,7 +80,7 @@ struct LimitGroup {
 impl PipelineCommand for CrossrefExpandCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let source_crossrefs = match input {

--- a/tools/src/cmd_pipeline/cmd_crossref_expand.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_expand.rs
@@ -1,13 +1,14 @@
 use std::collections::{HashSet, VecDeque};
 
 use async_trait::async_trait;
-use serde_json::Value;
 use clap::Args;
-use tracing::{trace};
+use serde_json::Value;
+use tracing::trace;
 use ustr::ustr;
 
 use super::interface::{
-    OverloadInfo, OverloadKind, PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolMetaFlags, SymbolRelation
+    OverloadInfo, OverloadKind, PipelineCommand, PipelineValues, SymbolCrossrefInfo,
+    SymbolCrossrefInfoList, SymbolMetaFlags, SymbolRelation,
 };
 
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
@@ -192,7 +193,7 @@ impl PipelineCommand for CrossrefExpandCommand {
                             }
                             limits.global_count += arr.len() as u32;
                         }
-                        trace!(edge=ptr, count=arr.len(), "considering");
+                        trace!(edge = ptr, count = arr.len(), "considering");
                         for wrapped in arr.iter() {
                             if let Value::String(sym) = xfunc(wrapped) {
                                 let usym = ustr(sym);

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -3,7 +3,8 @@ use clap::Args;
 use ustr::{ustr, Ustr};
 
 use super::interface::{
-    PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolMetaFlags, SymbolQuality, SymbolRelation
+    PipelineCommand, PipelineValues, SymbolCrossrefInfo, SymbolCrossrefInfoList, SymbolMetaFlags,
+    SymbolQuality, SymbolRelation,
 };
 
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};

--- a/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_crossref_lookup.rs
@@ -39,7 +39,7 @@ pub struct CrossrefLookupCommand {
 impl PipelineCommand for CrossrefLookupCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         // Because this pipeline stage can receive symbols from unfiltered user

--- a/tools/src/cmd_pipeline/cmd_filter_analysis.rs
+++ b/tools/src/cmd_pipeline/cmd_filter_analysis.rs
@@ -40,7 +40,7 @@ pub struct FilterAnalysisCommand {
 impl PipelineCommand for FilterAnalysisCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let mut filtered = server.fetch_raw_analysis(&self.args.file).await?;

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -158,13 +158,13 @@ impl Field {
                 match range.split_once("-") {
                     Some((start, end)) => (
                         def_path,
-                        u64::from_str_radix(start, 10).unwrap_or(identifier_lineno),
-                        u64::from_str_radix(end, 10).unwrap_or(identifier_lineno),
+                        start.parse().unwrap_or(identifier_lineno),
+                        end.parse().unwrap_or(identifier_lineno),
                     ),
                     None => (
                         def_path,
-                        u64::from_str_radix(range, 10).unwrap_or(identifier_lineno),
-                        u64::from_str_radix(range, 10).unwrap_or(identifier_lineno),
+                        range.parse().unwrap_or(identifier_lineno),
+                        range.parse().unwrap_or(identifier_lineno),
                     ),
                 }
             }

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -967,9 +967,7 @@ impl ClassMap {
     }
 
     fn get_struct_structured(sym_info: &DerivedSymbolInfo) -> Option<AnalysisStructured> {
-        let Some(structured) = sym_info.get_structured() else {
-            return None;
-        };
+        let structured = sym_info.get_structured()?;
 
         // See clang TagTypeKind.
         // https://clang.llvm.org/doxygen/namespaceclang.html#a9237bdb3cf715b9bff8bcb3172635548

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -476,7 +476,7 @@ impl PlatformMap {
     }
 }
 
-fn platform_name_to_order(name: &String) -> u32 {
+fn platform_name_to_order(name: &str) -> u32 {
     if name.starts_with("win") {
         return 0;
     }
@@ -582,14 +582,11 @@ impl FieldsPerPlatform {
             .collect()
     }
 
-    fn get_fields_for_platforms<'a>(
-        &'a self,
-        platform_ids: &Vec<PlatformId>,
-    ) -> Option<&'a Vec<Field>> {
+    fn get_fields_for_platforms<'a>(&'a self, platform_ids: &[PlatformId]) -> Option<&'a [Field]> {
         let platform_id = &platform_ids[0];
         self.fields_per_platform
             .get(platform_id)
-            .map(|fields| &fields.fields)
+            .map(|fields| fields.fields.as_slice())
     }
 }
 
@@ -715,7 +712,7 @@ impl ClassMap {
     async fn populate(
         &mut self,
         nom_sym_info: SymbolCrossrefInfo,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
     ) -> Result<()> {
         let root_sym_id = self.populate_platform_map(nom_sym_info, server).await?;
 
@@ -940,7 +937,7 @@ impl ClassMap {
     async fn populate_file_lines(
         &mut self,
         path: &String,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
     ) -> Result<()> {
         if path.is_empty() {
             return Ok(());
@@ -991,7 +988,7 @@ impl ClassMap {
     async fn populate_platform_map(
         &mut self,
         nom_sym_info: SymbolCrossrefInfo,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
     ) -> Result<SymbolGraphNodeId> {
         let (root_sym_id, _) = self.stt.node_set.add_symbol(DerivedSymbolInfo::new(
             nom_sym_info.symbol,
@@ -1252,7 +1249,7 @@ impl ClassMap {
 impl PipelineCommand for FormatSymbolsCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let cil = match input {

--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -1108,16 +1108,12 @@ impl ClassMap {
                 let mut field_name = "".to_string();
                 let mut field_symbols = "".to_string();
 
-                for maybe_field in field_variants {
-                    if let Some(field) = maybe_field {
-                        let pretty = field.pretty.clone();
-                        field_name = pretty.replace(&field_prefix, "");
+                if let Some(field) = field_variants.iter().flatten().next() {
+                    let pretty = field.pretty.clone();
+                    field_name = pretty.replace(&field_prefix, "");
 
-                        if let Some(field_id) = &field.field_id {
-                            field_symbols =
-                                self.stt.node_set.get(field_id).symbol.to_string();
-                        }
-                        break;
+                    if let Some(field_id) = &field.field_id {
+                        field_symbols = self.stt.node_set.get(field_id).symbol.to_string();
                     }
                 }
 

--- a/tools/src/cmd_pipeline/cmd_fuse_crossrefs.rs
+++ b/tools/src/cmd_pipeline/cmd_fuse_crossrefs.rs
@@ -29,7 +29,7 @@ pub struct FuseCrossrefsCommand {
 impl PipelineJunctionCommand for FuseCrossrefsCommand {
     async fn execute(
         &self,
-        _server: &Box<dyn AbstractServer + Send + Sync>,
+        _server: &(dyn AbstractServer + Send + Sync),
         input: Vec<(String, PipelineValues)>,
     ) -> Result<PipelineValues> {
         let mut fused_crossref = vec![];

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -242,7 +242,7 @@ fn transform_svg(svg: &str) -> String {
 impl PipelineCommand for GraphCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let mut graphs = match input {

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -6,7 +6,7 @@ use clap::{Args, ValueEnum};
 use dot_generator::*;
 use dot_structures::*;
 use regex::{Captures, Regex};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 use graphviz_rust::cmd::{CommandArg, Format, Layout};
 use graphviz_rust::exec;

--- a/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
@@ -26,7 +26,7 @@ pub struct JumprefLookupCommand {
 impl PipelineCommand for JumprefLookupCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         // Because this pipeline stage can receive symbols from unfiltered user

--- a/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
@@ -42,7 +42,7 @@ impl PipelineCommand for JumprefLookupCommand {
             // Right now we're assuming that we're the first command in the
             // pipeline so that we would have no inputs if someone wants to use
             // arguments...
-            PipelineValues::Void => self.args.symbols.iter().map(|sym| sym.clone()).collect(),
+            PipelineValues::Void => self.args.symbols.to_vec(),
             _ => {
                 return Err(ServerError::StickyProblem(ErrorDetails {
                     layer: ErrorLayer::ConfigLayer,

--- a/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
+++ b/tools/src/cmd_pipeline/cmd_jumpref_lookup.rs
@@ -1,9 +1,7 @@
 use async_trait::async_trait;
 use clap::Args;
 
-use super::interface::{
-    PipelineCommand, PipelineValues, JsonValueList, JsonValue,
-};
+use super::interface::{JsonValue, JsonValueList, PipelineCommand, PipelineValues};
 
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
 
@@ -44,12 +42,7 @@ impl PipelineCommand for JumprefLookupCommand {
             // Right now we're assuming that we're the first command in the
             // pipeline so that we would have no inputs if someone wants to use
             // arguments...
-            PipelineValues::Void => self
-                .args
-                .symbols
-                .iter()
-                .map(|sym| sym.clone())
-                .collect(),
+            PipelineValues::Void => self.args.symbols.iter().map(|sym| sym.clone()).collect(),
             _ => {
                 return Err(ServerError::StickyProblem(ErrorDetails {
                     layer: ErrorLayer::ConfigLayer,
@@ -64,10 +57,8 @@ impl PipelineCommand for JumprefLookupCommand {
             jumpref_values.push(JsonValue { value: info });
         }
 
-        Ok(PipelineValues::JsonValueList(
-            JsonValueList {
-                values: jumpref_values,
-            },
-        ))
+        Ok(PipelineValues::JsonValueList(JsonValueList {
+            values: jumpref_values,
+        }))
     }
 }

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -1,10 +1,8 @@
 use async_trait::async_trait;
-use serde_json::{from_str, Value};
 use clap::Args;
+use serde_json::{from_str, Value};
 
-use super::interface::{
-    JsonRecords, PipelineCommand, PipelineValues,
-};
+use super::interface::{JsonRecords, PipelineCommand, PipelineValues};
 use crate::{
     abstract_server::{AbstractServer, Result, ServerError},
     cmd_pipeline::interface::JsonRecordsByFile,
@@ -43,7 +41,12 @@ impl PipelineCommand for MergeAnalysesCommand {
             .args
             .files
             .iter()
-            .map(|f| server.translate_path(crate::abstract_server::SearchfoxIndexRoot::CompressedAnalysis, f))
+            .map(|f| {
+                server.translate_path(
+                    crate::abstract_server::SearchfoxIndexRoot::CompressedAnalysis,
+                    f,
+                )
+            })
             .collect();
 
         let mut merged_output = Vec::new();

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -34,7 +34,7 @@ impl PipelineCommand for MergeAnalysesCommand {
     ///
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let abs_paths: Result<Vec<String>> = self

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -30,8 +30,6 @@ pub struct MergeAnalysesCommand {
 
 #[async_trait]
 impl PipelineCommand for MergeAnalysesCommand {
-    ///
-    ///
     async fn execute(
         &self,
         server: &(dyn AbstractServer + Send + Sync),

--- a/tools/src/cmd_pipeline/cmd_merge_analyses.rs
+++ b/tools/src/cmd_pipeline/cmd_merge_analyses.rs
@@ -55,12 +55,12 @@ impl PipelineCommand for MergeAnalysesCommand {
         let values: Result<Vec<Value>> = std::str::from_utf8(merged_output.as_slice())
             .unwrap()
             .lines()
-            .map(|s| from_str(s).map_err(|e| ServerError::from(e)))
+            .map(|s| from_str(s).map_err(ServerError::from))
             .collect();
 
         Ok(PipelineValues::JsonRecords(JsonRecords {
             by_file: vec![JsonRecordsByFile {
-                file: self.args.files.iter().next().unwrap().clone(),
+                file: self.args.files.first().unwrap().clone(),
                 records: values?,
             }],
         }))

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -1,11 +1,9 @@
 use async_trait::async_trait;
+use clap::Args;
 use lazy_static::lazy_static;
-use lol_html::{
-    element, rewrite_str, RewriteStrSettings,
-};
+use lol_html::{element, rewrite_str, RewriteStrSettings};
 use regex::Regex;
 use serde_json::Value;
-use clap::Args;
 
 use super::interface::{
     JsonRecords, JsonRecordsByFile, JsonValue, PipelineCommand, PipelineValues,
@@ -51,13 +49,10 @@ fn norm_json_value(mut val: Value) -> Value {
 /// - Replacing data-i values with "NORM".
 fn norm_html_value(s: String) -> String {
     let element_content_handlers = vec![
-        element!(
-            r#"div.cov-strip, div.blame-strip"#,
-            |el| {
-                el.remove();
-                Ok(())
-            }
-        ),
+        element!(r#"div.cov-strip, div.blame-strip"#, |el| {
+            el.remove();
+            Ok(())
+        }),
         // As a transient thing, remove data-i entirely since this will allow us
         // to update the production checks before landing.  This rule can be
         // removed after we've transitioned as "data-i" should no longer exist.

--- a/tools/src/cmd_pipeline/cmd_prod_filter.rs
+++ b/tools/src/cmd_pipeline/cmd_prod_filter.rs
@@ -84,7 +84,7 @@ fn norm_html_value(s: String) -> String {
 impl PipelineCommand for ProductionFilterCommand {
     async fn execute(
         &self,
-        _server: &Box<dyn AbstractServer + Send + Sync>,
+        _server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         Ok(match input {

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -34,7 +34,7 @@ pub struct QueryCommand {
 impl PipelineCommand for QueryCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let pipeline_plan = chew_query(&self.args.query)?;

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -1,10 +1,14 @@
 use async_trait::async_trait;
-use serde_json::{to_value};
 use clap::Args;
+use serde_json::to_value;
 
-use super::{interface::{JsonValue, PipelineCommand, PipelineValues}, builder::build_pipeline_graph};
+use super::{
+    builder::build_pipeline_graph,
+    interface::{JsonValue, PipelineCommand, PipelineValues},
+};
 use crate::{
-    abstract_server::{AbstractServer, Result}, query::chew_query::chew_query,
+    abstract_server::{AbstractServer, Result},
+    query::chew_query::chew_query,
 };
 
 /// Run a new-style `query-parser` `term:value` query parse against the local
@@ -26,7 +30,6 @@ pub struct QueryCommand {
     pub args: Query,
 }
 
-
 #[async_trait]
 impl PipelineCommand for QueryCommand {
     async fn execute(
@@ -37,7 +40,9 @@ impl PipelineCommand for QueryCommand {
         let pipeline_plan = chew_query(&self.args.query)?;
 
         if self.args.dump_pipeline {
-            return Ok(PipelineValues::JsonValue(JsonValue { value: to_value(pipeline_plan)? }));
+            return Ok(PipelineValues::JsonValue(JsonValue {
+                value: to_value(pipeline_plan)?,
+            }));
         }
 
         let graph = build_pipeline_graph(server.clonify(), pipeline_plan)?;

--- a/tools/src/cmd_pipeline/cmd_query.rs
+++ b/tools/src/cmd_pipeline/cmd_query.rs
@@ -47,7 +47,6 @@ impl PipelineCommand for QueryCommand {
 
         let graph = build_pipeline_graph(server.clonify(), pipeline_plan)?;
 
-        let result = graph.run(true).await;
-        result
+        graph.run(true).await
     }
 }

--- a/tools/src/cmd_pipeline/cmd_render.rs
+++ b/tools/src/cmd_pipeline/cmd_render.rs
@@ -35,7 +35,7 @@ pub struct RenderCommand {
 impl PipelineCommand for RenderCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let tree_info = server.tree_info()?;

--- a/tools/src/cmd_pipeline/cmd_render.rs
+++ b/tools/src/cmd_pipeline/cmd_render.rs
@@ -6,7 +6,10 @@ use crate::{
     abstract_server::{
         AbstractServer, ErrorDetails, ErrorLayer, Result, SearchfoxIndexRoot, ServerError,
     },
-    templating::builder::{build_and_parse_search_template, build_and_parse_help_index, build_and_parse_settings}, file_utils::write_file_ensuring_parent_dir,
+    file_utils::write_file_ensuring_parent_dir,
+    templating::builder::{
+        build_and_parse_help_index, build_and_parse_search_template, build_and_parse_settings,
+    },
 };
 
 /// Render a single template, potentially processing pipeline input.
@@ -55,20 +58,16 @@ impl PipelineCommand for RenderCommand {
                         }));
                     }
                 };
-                let output_path = server.translate_path(
-                    SearchfoxIndexRoot::IndexTemplates,
-                    "search.html",
-                )?;
+                let output_path =
+                    server.translate_path(SearchfoxIndexRoot::IndexTemplates, "search.html")?;
                 write_file_ensuring_parent_dir(&output_path, &rendered)?;
                 Ok(PipelineValues::Void)
             }
             "help" => {
                 let template = build_and_parse_help_index();
 
-                let content_path = server.translate_path(
-                    SearchfoxIndexRoot::ConfigRepo,
-                    "help.html"
-                )?;
+                let content_path =
+                    server.translate_path(SearchfoxIndexRoot::ConfigRepo, "help.html")?;
                 let content = std::fs::read_to_string(content_path)?;
 
                 let liquid_globals = liquid::object!({
@@ -86,13 +85,10 @@ impl PipelineCommand for RenderCommand {
                         }));
                     }
                 };
-                let output_path = server.translate_path(
-                    SearchfoxIndexRoot::IndexTemplates,
-                    "help.html",
-                )?;
+                let output_path =
+                    server.translate_path(SearchfoxIndexRoot::IndexTemplates, "help.html")?;
                 write_file_ensuring_parent_dir(&output_path, &rendered)?;
                 Ok(PipelineValues::Void)
-
             }
             "settings" => {
                 let template = build_and_parse_settings();
@@ -111,13 +107,10 @@ impl PipelineCommand for RenderCommand {
                         }));
                     }
                 };
-                let output_path = server.translate_path(
-                    SearchfoxIndexRoot::IndexPages,
-                    "settings.html",
-                )?;
+                let output_path =
+                    server.translate_path(SearchfoxIndexRoot::IndexPages, "settings.html")?;
                 write_file_ensuring_parent_dir(&output_path, &rendered)?;
                 Ok(PipelineValues::Void)
-
             }
             unknown => Err(ServerError::StickyProblem(ErrorDetails {
                 layer: ErrorLayer::ConfigLayer,

--- a/tools/src/cmd_pipeline/cmd_search.rs
+++ b/tools/src/cmd_pipeline/cmd_search.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
+use clap::Args;
 use json_structural_diff::JsonDiff;
 use serde_json::{json, Map, Value};
-use clap::Args;
 
 use super::interface::{JsonValue, PipelineCommand, PipelineValues};
 use crate::abstract_server::{AbstractServer, Result};

--- a/tools/src/cmd_pipeline/cmd_search.rs
+++ b/tools/src/cmd_pipeline/cmd_search.rs
@@ -91,14 +91,14 @@ fn dictify(val: &mut Value) -> Option<Value> {
         _ => {}
     };
 
-    return None;
+    None
 }
 
 fn dictify_root(mut val: Value) -> Value {
     if let Some(replacement) = dictify(&mut val) {
         return replacement;
     }
-    return val;
+    val
 }
 
 #[async_trait]

--- a/tools/src/cmd_pipeline/cmd_search.rs
+++ b/tools/src/cmd_pipeline/cmd_search.rs
@@ -105,7 +105,7 @@ fn dictify_root(mut val: Value) -> Value {
 impl PipelineCommand for SearchCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let mut value = server.perform_query(&self.args.query).await?;

--- a/tools/src/cmd_pipeline/cmd_search_files.rs
+++ b/tools/src/cmd_pipeline/cmd_search_files.rs
@@ -47,7 +47,7 @@ const FILE_MATCH_LIMIT: usize = 2_000_000;
 impl PipelineCommand for SearchFilesCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let pathre_pattern = if let Some(pathre) = &self.args.pathre {

--- a/tools/src/cmd_pipeline/cmd_search_identifiers.rs
+++ b/tools/src/cmd_pipeline/cmd_search_identifiers.rs
@@ -48,7 +48,7 @@ pub struct SearchIdentifiersCommand {
 impl PipelineCommand for SearchIdentifiersCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let identifier_list: Vec<String> = match input {

--- a/tools/src/cmd_pipeline/cmd_search_text.rs
+++ b/tools/src/cmd_pipeline/cmd_search_text.rs
@@ -46,7 +46,7 @@ pub struct SearchTextCommand {
 impl PipelineCommand for SearchTextCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let re_pattern = if let Some(re) = &self.args.re {

--- a/tools/src/cmd_pipeline/cmd_search_text.rs
+++ b/tools/src/cmd_pipeline/cmd_search_text.rs
@@ -1,7 +1,10 @@
 use async_trait::async_trait;
 use clap::Args;
 
-use super::{interface::{PipelineCommand, PipelineValues}, transforms::path_glob_transform};
+use super::{
+    interface::{PipelineCommand, PipelineValues},
+    transforms::path_glob_transform,
+};
 
 use crate::abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError};
 

--- a/tools/src/cmd_pipeline/cmd_show_html.rs
+++ b/tools/src/cmd_pipeline/cmd_show_html.rs
@@ -33,7 +33,7 @@ pub struct ShowHtmlCommand {
 impl PipelineCommand for ShowHtmlCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let jr = match input {

--- a/tools/src/cmd_pipeline/cmd_tokenize_source.rs
+++ b/tools/src/cmd_pipeline/cmd_tokenize_source.rs
@@ -35,7 +35,7 @@ pub struct TokenizeSourceCommand {
 impl PipelineCommand for TokenizeSourceCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let source_str = server.fetch_raw_source(&self.args.file).await?;

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -152,7 +152,7 @@ bitflags! {
 impl PipelineCommand for TraverseCommand {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues> {
         let max_depth = match (self.args.max_depth, self.args.paths_between) {

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -537,14 +537,22 @@ impl PipelineCommand for TraverseCommand {
                             EdgeKind::IPC,
                         ),
                         // For uses, draw an inbound IPC edge from the "send" slot via the IDL symbol
-                        (_, BindingSlotKind::Recv) => {
-                            (self.args.edge == "uses", true, Some("send"), false, EdgeKind::IPC)
-                        }
+                        (_, BindingSlotKind::Recv) => (
+                            self.args.edge == "uses",
+                            true,
+                            Some("send"),
+                            false,
+                            EdgeKind::IPC,
+                        ),
                         // For IDL bindings, we want an upward (inbound) edge from the IDL symbol
-                        (BindingOwnerLang::Idl, _) => (true, false, None, false, EdgeKind::Implementation),
+                        (BindingOwnerLang::Idl, _) => {
+                            (true, false, None, false, EdgeKind::Implementation)
+                        }
                         // Cross-language binding class relationships are weird because
                         // the bindings inside are bidirectional, so let's ignore them.
-                        (_, BindingSlotKind::Class) => (false, false, None, false, EdgeKind::Default),
+                        (_, BindingSlotKind::Class) => {
+                            (false, false, None, false, EdgeKind::Default)
+                        }
                         // This leaves us with cross-language bindings where the slot owner is always the
                         // implementation symbol so slotOwner is always aligned with "callees"; the "uses"
                         // edges hammen when processing bindingSlots.
@@ -662,7 +670,12 @@ impl PipelineCommand for TraverseCommand {
                             // For cross-language wrappers the implementing language is the slotOwner
                             // so the binding slots are edges to the binding.  That is, the slotOwner
                             // constitutes a "uses" edge and the slots constitute a "callees" edge.
-                            (_, _) => (self.args.edge == "uses", true, false, EdgeKind::CrossLanguage),
+                            (_, _) => (
+                                self.args.edge == "uses",
+                                true,
+                                false,
+                                EdgeKind::CrossLanguage,
+                            ),
                         };
                     if should_traverse {
                         // Skipping is conditional on the decision to traverse.
@@ -688,7 +701,6 @@ impl PipelineCommand for TraverseCommand {
                                 vec![],
                                 &mut graph,
                             );
-
                         }
                         if next_depth < max_depth && considered.insert(slot.sym.clone()) {
                             trace!(sym = slot.sym.as_str(), "scheduling bind slot sym");

--- a/tools/src/cmd_pipeline/cmd_webtest.rs
+++ b/tools/src/cmd_pipeline/cmd_webtest.rs
@@ -41,11 +41,8 @@ fn print_log(ty: &str, msg: String) {
     };
     spec.set_fg(Some(color));
 
-    match ty {
-        "DEBUG" => {
-            spec.set_dimmed(true);
-        }
-        _ => {}
+    if ty == "DEBUG" {
+        spec.set_dimmed(true);
     }
 
     stderr.set_color(&spec).unwrap();
@@ -198,7 +195,7 @@ impl WebtestCommand {
         }
 
         let elapsed_time = entire_start.elapsed();
-        eprintln!("");
+        eprintln!();
         println_color(Color::Yellow, "Overall Summary");
         println_color(Color::Yellow, "===============");
         eprintln!(
@@ -209,7 +206,7 @@ impl WebtestCommand {
         );
         eprintln!("Passed: {} tests", test_count - failed_tests.len());
         eprintln!("Failed: {} tests", failed_tests.len());
-        eprintln!("");
+        eprintln!();
 
         let passed = failed_tests.is_empty();
 

--- a/tools/src/cmd_pipeline/cmd_webtest.rs
+++ b/tools/src/cmd_pipeline/cmd_webtest.rs
@@ -233,7 +233,7 @@ impl WebtestCommand {
 impl PipelineCommand for WebtestCommand {
     async fn execute(
         &self,
-        _server: &Box<dyn AbstractServer + Send + Sync>,
+        _server: &(dyn AbstractServer + Send + Sync),
         _input: PipelineValues,
     ) -> Result<PipelineValues> {
         let passed = self.setup_webdriver_and_run_tests().await.map_err(|e| {

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -859,7 +859,7 @@ pub struct TextFile {
 pub trait PipelineCommand: Debug {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: PipelineValues,
     ) -> Result<PipelineValues>;
 }
@@ -870,7 +870,7 @@ pub trait PipelineCommand: Debug {
 pub trait PipelineJunctionCommand: Debug {
     async fn execute(
         &self,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
         input: Vec<(String, PipelineValues)>,
     ) -> Result<PipelineValues>;
 }
@@ -904,7 +904,7 @@ impl NamedPipeline {
             let span = trace_span!("run_named_pipeline_step", cmd = ?cmd);
 
             match cmd
-                .execute(&server, cur_values)
+                .execute(server.as_ref(), cur_values)
                 .instrument(span.clone())
                 .await
             {
@@ -949,7 +949,7 @@ impl JunctionInvocation {
 
         let result = match self
             .command
-            .execute(&server, input_values)
+            .execute(server.as_ref(), input_values)
             .instrument(span.clone())
             .await
         {
@@ -992,7 +992,7 @@ impl ServerPipeline {
             let span = trace_span!("run_pipeline_step", cmd = ?cmd);
 
             match cmd
-                .execute(&self.server, cur_values)
+                .execute(self.server.as_ref(), cur_values)
                 .instrument(span.clone())
                 .await
             {

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -379,9 +379,7 @@ impl SymbolQuality {
 
 impl PartialOrd for SymbolQuality {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        let self_rank = self.numeric_rank();
-        let other_rank = other.numeric_rank();
-        self_rank.partial_cmp(&other_rank)
+        Some(self.cmp(other))
     }
 }
 

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -393,7 +393,6 @@ impl Ord for SymbolQuality {
     }
 }
 
-///
 #[derive(Clone, Serialize)]
 pub enum OverloadKind {
     /// There's just too many overrides!  This would happen for

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -1,10 +1,7 @@
 use async_trait::async_trait;
 use bitflags::bitflags;
 use clap::{Args, ValueEnum};
-use serde::{
-    ser::SerializeStruct,
-    Serialize, Serializer,
-};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 use serde_json::{json, to_string_pretty, Value};
 use std::{
     cmp::Ordering,
@@ -94,10 +91,7 @@ impl SymbolTreeTableList {
                 );
             }
             for (sym, info) in &table.extra_syms {
-                jumprefs.insert(
-                    ustr(sym.as_str()),
-                    info.clone(),
-                );
+                jumprefs.insert(ustr(sym.as_str()), info.clone());
             }
         }
 
@@ -193,7 +187,7 @@ pub struct SymbolTreeTableField {
     pub types: Vec<SymbolTreeTableFieldType>,
     pub lines: Vec<String>,
     #[serde(rename = "offsetAndSize")]
-    pub offset_and_size: Vec<Option<SymbolTreeTableFieldOffsetAndSize>>
+    pub offset_and_size: Vec<Option<SymbolTreeTableFieldOffsetAndSize>>,
 }
 
 impl SymbolTreeTableField {

--- a/tools/src/cmd_pipeline/mod.rs
+++ b/tools/src/cmd_pipeline/mod.rs
@@ -7,8 +7,8 @@ pub mod symbol_graph;
 pub mod transforms;
 
 mod cmd_augment_results;
-mod cmd_cat_html;
 mod cmd_batch_render;
+mod cmd_cat_html;
 mod cmd_compile_results;
 mod cmd_crossref_expand;
 mod cmd_crossref_lookup;
@@ -30,5 +30,5 @@ mod cmd_tokenize_source;
 mod cmd_traverse;
 mod cmd_webtest;
 
-pub use builder::{build_pipeline};
+pub use builder::build_pipeline;
 pub use interface::{PipelineCommand, PipelineValues};

--- a/tools/src/cmd_pipeline/parser.rs
+++ b/tools/src/cmd_pipeline/parser.rs
@@ -53,13 +53,7 @@ pub struct ToolOpts {
     )]
     pub tree: String,
 
-    #[clap(
-        long,
-        short,
-        value_parser,
-        value_enum,
-        default_value = "concise"
-    )]
+    #[clap(long, short, value_parser, value_enum, default_value = "concise")]
     pub output_format: OutputFormat,
 
     #[clap(subcommand)]

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -736,7 +736,7 @@ impl SymbolGraphCollection {
 
         graph
             .root
-            .compile(policies, 0, 0, false, &self.node_set, &mut state);
+            .compile(policies, 0, false, &self.node_set, &mut state);
 
         let mut dot_graph = Graph::DiGraph {
             id: id!("g"),
@@ -1300,7 +1300,6 @@ impl HierarchicalNode {
         &mut self,
         policies: &HierarchyPolicies,
         depth: usize,
-        collapsed_ancestors: u32,
         has_class_ancestor: bool,
         node_set: &SymbolGraphNodeSet,
         state: &mut HierarchicalRenderState,
@@ -1344,14 +1343,7 @@ impl HierarchicalNode {
                         format!("{}{}{}", self.display_name, delim, sole_kid.display_name);
                     self.display_name = "".to_string();
                 }
-                sole_kid.compile(
-                    policies,
-                    depth + 1,
-                    collapsed_ancestors + 1,
-                    be_class,
-                    node_set,
-                    state,
-                );
+                sole_kid.compile(policies, depth + 1, be_class, node_set, state);
                 return;
             }
         }
@@ -1361,14 +1353,7 @@ impl HierarchicalNode {
         if is_root {
             self.action = Some(HierarchicalLayoutAction::Flatten);
             for kid in self.children.values_mut() {
-                kid.compile(
-                    policies,
-                    depth + 1,
-                    collapsed_ancestors,
-                    be_class,
-                    node_set,
-                    state,
-                );
+                kid.compile(policies, depth + 1, be_class, node_set, state);
             }
         } else if !self.edges.is_empty() && !self.children.is_empty() {
             // If there are edges at this level, it does not make sense to be a
@@ -1457,7 +1442,7 @@ impl HierarchicalNode {
             );
 
             for kid in self.children.values_mut() {
-                kid.compile(policies, depth + 1, 0, be_class, node_set, state);
+                kid.compile(policies, depth + 1, be_class, node_set, state);
             }
         }
     }

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -427,7 +427,7 @@ impl SymbolGraphCollection {
         &mut self,
         policies: &HierarchyPolicies,
         graph_idx: usize,
-        server: &Box<dyn AbstractServer + Send + Sync>,
+        server: &(dyn AbstractServer + Send + Sync),
     ) -> Result<()> {
         trace!("derive_hierarchical_graph");
         let graph = match self.graphs.get(graph_idx) {
@@ -1918,7 +1918,7 @@ impl HierarchicalRenderState {
 
     /// Return a node identifier for the set of nodes.  We just pick the first
     /// one.
-    pub fn id_for_nodes(&self, nodes: &Vec<SymbolGraphNodeId>) -> String {
+    pub fn id_for_nodes(&self, nodes: &[SymbolGraphNodeId]) -> String {
         // XXX there are cases where nodes is empty and the code assumed it
         // would not be.
         if nodes.is_empty() {
@@ -1937,7 +1937,7 @@ impl HierarchicalRenderState {
         from_id: &SymbolGraphNodeId,
         to_id: &SymbolGraphNodeId,
         edge_id: &SymbolGraphEdgeId,
-        edge_data: &Vec<EdgeDetail>,
+        edge_data: &[EdgeDetail],
     ) {
         let from_eid = self.id_for_node(from_id);
         let to_eid = self.id_for_node(to_id);
@@ -2272,7 +2272,7 @@ impl SymbolGraphNodeSet {
     pub async fn ensure_symbol<'a>(
         &'a mut self,
         sym: &'a Ustr,
-        server: &'a Box<dyn AbstractServer + Send + Sync>,
+        server: &'a (dyn AbstractServer + Send + Sync),
         depth: u32,
     ) -> Result<(SymbolGraphNodeId, &'a mut DerivedSymbolInfo)> {
         if let Some(index) = self.symbol_to_index_map.get(sym) {

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -1961,7 +1961,7 @@ impl HierarchicalRenderState {
                     } else {
                         match jump_detail.rsplit_once('#') {
                             Some((_, lines)) => format!("{},{}", jump, lines),
-                            None => jump
+                            None => jump,
                         }
                     }
                 }

--- a/tools/src/cmd_pipeline/transforms.rs
+++ b/tools/src/cmd_pipeline/transforms.rs
@@ -1,38 +1,44 @@
-use regex::{Regex, Captures};
+use regex::{Captures, Regex};
 
 /// Apply the searchfox path glob transformation ported from `router.py`.
 pub fn path_glob_transform(s: &str) -> String {
-  lazy_static! {
-    static ref RE_TO_ESCAPE: Regex = Regex::new("[()|.]").unwrap();
-    static ref RE_STARS: Regex = Regex::new(r"\*\*?").unwrap();
-    static ref RE_BRACES: Regex = Regex::new(r"\{([^}]*)\}").unwrap();
-  }
-  let backslashed = RE_TO_ESCAPE.replace_all(s, r"\$0");
-  let starred = RE_STARS.replace_all(&backslashed, |caps: &Captures| {
-    if caps.get(0).unwrap().as_str().len() == 1 {
-      "[^/]*"
-    } else {
-      ".*"
+    lazy_static! {
+        static ref RE_TO_ESCAPE: Regex = Regex::new("[()|.]").unwrap();
+        static ref RE_STARS: Regex = Regex::new(r"\*\*?").unwrap();
+        static ref RE_BRACES: Regex = Regex::new(r"\{([^}]*)\}").unwrap();
     }
-  });
-  let questioned = str::replace(&starred, "?", ".");
-  let braced = RE_BRACES.replace_all(&questioned, |caps: &Captures| {
-    let inside_braces = caps.get(1).unwrap().as_str();
-    format!("({})", str::replace(inside_braces, ",", "|"))
-  });
-  braced.to_string()
+    let backslashed = RE_TO_ESCAPE.replace_all(s, r"\$0");
+    let starred = RE_STARS.replace_all(&backslashed, |caps: &Captures| {
+        if caps.get(0).unwrap().as_str().len() == 1 {
+            "[^/]*"
+        } else {
+            ".*"
+        }
+    });
+    let questioned = str::replace(&starred, "?", ".");
+    let braced = RE_BRACES.replace_all(&questioned, |caps: &Captures| {
+        let inside_braces = caps.get(1).unwrap().as_str();
+        format!("({})", str::replace(inside_braces, ",", "|"))
+    });
+    braced.to_string()
 }
 
 #[test]
 fn test_path_glob_transform() {
-  // Test coverage for the cases we documented on the help page.
-  assert_eq!(path_glob_transform("test"), "test");
-  assert_eq!(path_glob_transform("^js/src"), "^js/src");
+    // Test coverage for the cases we documented on the help page.
+    assert_eq!(path_glob_transform("test"), "test");
+    assert_eq!(path_glob_transform("^js/src"), "^js/src");
 
-  assert_eq!(path_glob_transform("*.cpp"), "[^/]*\\.cpp");
-  assert_eq!(path_glob_transform("*.cpp$"), "[^/]*\\.cpp$");
+    assert_eq!(path_glob_transform("*.cpp"), "[^/]*\\.cpp");
+    assert_eq!(path_glob_transform("*.cpp$"), "[^/]*\\.cpp$");
 
-  assert_eq!(path_glob_transform("^js/src/*.cpp$"), "^js/src/[^/]*\\.cpp$");
-  assert_eq!(path_glob_transform("^js/src/**.cpp$"), "^js/src/.*\\.cpp$");
-  assert_eq!(path_glob_transform("^js/src/**.{cpp,h}$"), "^js/src/.*\\.(cpp|h)$");
+    assert_eq!(
+        path_glob_transform("^js/src/*.cpp$"),
+        "^js/src/[^/]*\\.cpp$"
+    );
+    assert_eq!(path_glob_transform("^js/src/**.cpp$"), "^js/src/.*\\.cpp$");
+    assert_eq!(
+        path_glob_transform("^js/src/**.{cpp,h}$"),
+        "^js/src/.*\\.(cpp|h)$"
+    );
 }

--- a/tools/src/css_analyzer.rs
+++ b/tools/src/css_analyzer.rs
@@ -16,7 +16,7 @@ fn mangle_name(name: &str) -> String {
                 s.push(c as char);
             }
             _ => {
-                s.push_str(format!("@{:02X}", c as u8).as_str());
+                s.push_str(format!("@{:02X}", { c }).as_str());
             }
         }
     }
@@ -32,11 +32,11 @@ fn to_loc(
     // cssparser::SourceLocation uses 0-origin line and 1-origin column.
     // analysis::Location uses 1-origin line and 0-origin column.
     // first_line is 1-origin.
-    return Location {
+    Location {
         lineno: first_line + start.line,
         col_start: start.column - 1,
         col_end: end.column - 1,
-    };
+    }
 }
 
 fn to_source(
@@ -48,8 +48,8 @@ fn to_source(
     WithLocation {
         data: AnalysisSource {
             source: SourceTag::Source,
-            syntax: syntax,
-            pretty: pretty,
+            syntax,
+            pretty,
             sym: vec![sym],
             no_crossref: false,
             nesting_range: SourceRange::default(),
@@ -58,7 +58,7 @@ fn to_source(
             arg_ranges: vec![],
             expansion_info: None,
         },
-        loc: loc.clone(),
+        loc,
     }
 }
 
@@ -71,9 +71,9 @@ fn to_target(
     WithLocation {
         data: AnalysisTarget {
             target: TargetTag::Target,
-            kind: kind,
-            pretty: pretty,
-            sym: sym,
+            kind,
+            pretty,
+            sym,
             context: "".to_string(),
             contextsym: "".to_string(),
             peek_range: LineRange {
@@ -82,7 +82,7 @@ fn to_target(
             },
             arg_ranges: vec![],
         },
-        loc: loc,
+        loc,
     }
 }
 
@@ -129,7 +129,7 @@ fn analyze_css_block<F>(
                         )
                     };
 
-                    let source = to_source(loc.clone(), syntax, source_pretty, sym.clone());
+                    let source = to_source(loc, syntax, source_pretty, sym.clone());
                     callback(serde_json::to_string(&source).unwrap());
                     let target = to_target(loc, kind, target_pretty, sym);
                     callback(serde_json::to_string(&target).unwrap());
@@ -159,7 +159,7 @@ fn analyze_css_block<F>(
                     let syntax = vec!["use".to_string(), "file".to_string()];
                     let kind = AnalysisKind::Use;
 
-                    let source = to_source(loc.clone(), syntax, source_pretty, sym.clone());
+                    let source = to_source(loc, syntax, source_pretty, sym.clone());
                     callback(serde_json::to_string(&source).unwrap());
                     let target = to_target(loc, kind, target_pretty, sym);
                     callback(serde_json::to_string(&target).unwrap());

--- a/tools/src/css_analyzer.rs
+++ b/tools/src/css_analyzer.rs
@@ -1,8 +1,8 @@
 use cssparser;
 
 use crate::file_format::analysis::{
-    AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location,
-    SourceRange, SourceTag, TargetTag, WithLocation
+    AnalysisKind, AnalysisSource, AnalysisTarget, LineRange, Location, SourceRange, SourceTag,
+    TargetTag, WithLocation,
 };
 
 // NOTE: This does the same as analysis_manglings::mangle_file without regex
@@ -24,9 +24,11 @@ fn mangle_name(name: &str) -> String {
     s
 }
 
-fn to_loc(first_line: u32,
-          start: &cssparser::SourceLocation,
-          end: &cssparser::SourceLocation) -> Location {
+fn to_loc(
+    first_line: u32,
+    start: &cssparser::SourceLocation,
+    end: &cssparser::SourceLocation,
+) -> Location {
     // cssparser::SourceLocation uses 0-origin line and 1-origin column.
     // analysis::Location uses 1-origin line and 0-origin column.
     // first_line is 1-origin.
@@ -34,10 +36,15 @@ fn to_loc(first_line: u32,
         lineno: first_line + start.line,
         col_start: start.column - 1,
         col_end: end.column - 1,
-    }
+    };
 }
 
-fn to_source(loc: Location, syntax: Vec<String>, pretty: String, sym: String) -> WithLocation<AnalysisSource::<String>> {
+fn to_source(
+    loc: Location,
+    syntax: Vec<String>,
+    pretty: String,
+    sym: String,
+) -> WithLocation<AnalysisSource<String>> {
     WithLocation {
         data: AnalysisSource {
             source: SourceTag::Source,
@@ -55,7 +62,12 @@ fn to_source(loc: Location, syntax: Vec<String>, pretty: String, sym: String) ->
     }
 }
 
-fn to_target(loc: Location, kind: AnalysisKind, pretty: String, sym: String) -> WithLocation<AnalysisTarget::<String>> {
+fn to_target(
+    loc: Location,
+    kind: AnalysisKind,
+    pretty: String,
+    sym: String,
+) -> WithLocation<AnalysisTarget<String>> {
     WithLocation {
         data: AnalysisTarget {
             target: TargetTag::Target,
@@ -74,10 +86,14 @@ fn to_target(loc: Location, kind: AnalysisKind, pretty: String, sym: String) -> 
     }
 }
 
-fn analyze_css_block<F>(input: &mut cssparser::Parser, first_line: u32,
-                        is_curly_children: bool, is_inside_lhs: bool, callback: &mut F)
-where
-    F: FnMut(String)
+fn analyze_css_block<F>(
+    input: &mut cssparser::Parser,
+    first_line: u32,
+    is_curly_children: bool,
+    is_inside_lhs: bool,
+    callback: &mut F,
+) where
+    F: FnMut(String),
 {
     use cssparser::Token::*;
     let mut start = input.current_source_location();
@@ -97,11 +113,20 @@ where
 
                     let (syntax, kind) = if after_at_property {
                         after_at_property = false;
-                        (vec!["decl".to_string(), "cssprop".to_string()], AnalysisKind::Decl)
+                        (
+                            vec!["decl".to_string(), "cssprop".to_string()],
+                            AnalysisKind::Decl,
+                        )
                     } else if is_lhs {
-                        (vec!["def".to_string(), "cssprop".to_string()], AnalysisKind::Def)
+                        (
+                            vec!["def".to_string(), "cssprop".to_string()],
+                            AnalysisKind::Def,
+                        )
                     } else {
-                        (vec!["use".to_string(), "cssprop".to_string()], AnalysisKind::Use)
+                        (
+                            vec!["use".to_string(), "cssprop".to_string()],
+                            AnalysisKind::Use,
+                        )
                     };
 
                     let source = to_source(loc.clone(), syntax, source_pretty, sym.clone());
@@ -165,10 +190,9 @@ where
     }
 }
 
-pub fn analyze_css<F>(path: String, first_line: u32,
-                  text: String, callback: &mut F)
+pub fn analyze_css<F>(path: String, first_line: u32, text: String, callback: &mut F)
 where
-    F: FnMut(String)
+    F: FnMut(String),
 {
     let mut input = cssparser::ParserInput::new(text.as_str());
     let mut input = cssparser::Parser::new(&mut input);

--- a/tools/src/describe.rs
+++ b/tools/src/describe.rs
@@ -21,7 +21,7 @@ pub fn describe_file(contents: &str, path: &Path, format: &FormatAs) -> Option<S
     match format {
         FormatAs::CSS => describe_from_c_comment(substr),
         FormatAs::FormatTagLike(_) => describe_html(substr),
-        FormatAs::FormatCLike(ref spec) => {
+        FormatAs::FormatCLike(spec) => {
             if spec.rust_tweaks {
                 describe_from_rust_comment(substr).or_else(|| describe_from_c_comment(substr))
             } else if spec.c_style_comments {
@@ -73,8 +73,7 @@ fn describe_py(contents: &str) -> Option<String> {
 fn describe_readme(contents: &str) -> Option<String> {
     contents
         .lines()
-        .filter(|s| !s.trim().is_empty())
-        .next()
+        .find(|s| !s.trim().is_empty())
         .map(str::to_string)
 }
 
@@ -91,7 +90,7 @@ fn describe_from_rust_comment(contents: &str) -> Option<String> {
         }
         in_comment = true;
         if !description.is_empty() {
-            description.push_str("\n");
+            description.push('\n');
         }
         description.push_str(line.trim_start_matches("//!"));
     }

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -671,7 +671,7 @@ impl<StrT> SerializeVecString<StrT>
 where
     StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
-    pub fn serialize<S>(arr: &Vec<StrT>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(arr: &[StrT], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
@@ -687,7 +687,7 @@ where
         Ok(s.split(',').map(|s| FromStr::from(s)).collect())
     }
 
-    pub fn join(arr: &Vec<StrT>) -> String {
+    pub fn join(arr: &[StrT]) -> String {
         arr.iter()
             .map(|x| x.as_ref())
             .collect::<Vec<&str>>()

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -19,9 +19,9 @@ use itertools::Itertools;
 #[cfg(not(target_arch = "wasm32"))]
 use flate2::read::GzDecoder;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::{from_value, Map, Value};
 #[cfg(not(target_arch = "wasm32"))]
 use serde_json::from_str;
+use serde_json::{from_value, Map, Value};
 use serde_repr::*;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -57,8 +57,8 @@ pub struct LineRange {
 
 impl LineRange {
     pub fn is_empty(&self) -> bool {
-        (self.start_lineno == 0 && self.end_lineno == 0) ||
-        (self.start_lineno == u32::MAX && self.end_lineno == u32::MAX)
+        (self.start_lineno == 0 && self.end_lineno == 0)
+            || (self.start_lineno == u32::MAX && self.end_lineno == u32::MAX)
     }
 }
 
@@ -181,7 +181,7 @@ impl FromStr for String {
 
 fn string_or_ustr_is_empty<StrT>(s: &StrT) -> bool
 where
-    StrT: Deref<Target = str>
+    StrT: Deref<Target = str>,
 {
     s.is_empty()
 }
@@ -189,7 +189,7 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AnalysisTarget<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub target: TargetTag,
     pub kind: AnalysisKind,
@@ -221,7 +221,7 @@ pub enum StructuredTag {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredSuperInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     #[serde(default)]
     pub sym: StrT,
@@ -234,7 +234,7 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredArgInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub name: StrT,
     #[serde(rename = "type", default)]
@@ -246,7 +246,7 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredMethodInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     #[serde(default)]
     pub pretty: StrT,
@@ -275,7 +275,7 @@ pub struct StructuredOverrideInfo<StrT = Ustr> {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StructuredFieldInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     /// The field definition's location in "PATH#line-line" or "PATH#line" format.
     ///
@@ -313,7 +313,7 @@ where
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct StructuredPointerInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub kind: OntologyPointerKind,
     pub sym: StrT,
@@ -415,7 +415,7 @@ pub struct BindingSlotProps {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct StructuredBindingSlotInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     #[serde(flatten)]
     pub props: BindingSlotProps,
@@ -492,7 +492,7 @@ pub enum OntologySlotKind {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OntologySlotInfo<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     #[serde(rename = "slotKind")]
     pub slot_kind: OntologySlotKind,
@@ -512,7 +512,7 @@ where
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AnalysisStructured<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub structured: StructuredTag,
     #[serde(default)]
@@ -574,7 +574,11 @@ where
     // as being symbol only.
     #[serde(rename = "subclasses", default, skip_serializing_if = "Vec::is_empty")]
     pub subclass_syms: Vec<StrT>,
-    #[serde(rename = "overriddenBy", default, skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        rename = "overriddenBy",
+        default,
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub overridden_by_syms: Vec<StrT>,
 
     #[serde(default)]
@@ -586,14 +590,22 @@ where
 
 impl<StrT> AnalysisStructured<StrT>
 where
-    StrT: Clone + Debug + serde::de::DeserializeOwned + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone
+        + Debug
+        + serde::de::DeserializeOwned
+        + Default
+        + Deref<Target = str>
+        + FromStr
+        + Hash
+        + Ord
+        + PartialEq,
 {
     // Retrieve the platforms from "extra" if present; this could arguably just
     // be serialized in the first place.
     pub fn platforms(&self) -> Vec<String> {
         match self.extra.get("platforms") {
             Some(val) => from_value(val.clone()).unwrap_or_default(),
-            _ => vec![]
+            _ => vec![],
         }
     }
 
@@ -650,14 +662,14 @@ mod bool_as_int {
 
 struct SerializeVecString<StrT>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     phantom: PhantomData<StrT>,
 }
 
 impl<StrT> SerializeVecString<StrT>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub fn serialize<S>(arr: &Vec<StrT>, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -676,8 +688,7 @@ where
     }
 
     pub fn join(arr: &Vec<StrT>) -> String {
-        arr
-            .iter()
+        arr.iter()
             .map(|x| x.as_ref())
             .collect::<Vec<&str>>()
             .join(",")
@@ -707,13 +718,19 @@ pub enum ExpansionInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AnalysisSource<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     pub source: SourceTag,
-    #[serde(serialize_with = "SerializeVecString::<StrT>::serialize", deserialize_with = "SerializeVecString::<StrT>::deserialize")]
+    #[serde(
+        serialize_with = "SerializeVecString::<StrT>::serialize",
+        deserialize_with = "SerializeVecString::<StrT>::deserialize"
+    )]
     pub syntax: Vec<StrT>,
     pub pretty: StrT,
-    #[serde(serialize_with = "SerializeVecString::<StrT>::serialize", deserialize_with = "SerializeVecString::<StrT>::deserialize")]
+    #[serde(
+        serialize_with = "SerializeVecString::<StrT>::serialize",
+        deserialize_with = "SerializeVecString::<StrT>::deserialize"
+    )]
     pub sym: Vec<StrT>,
     #[serde(default, with = "bool_as_int", skip_serializing_if = "bool_is_false")]
     pub no_crossref: bool,
@@ -741,7 +758,7 @@ where
 
 impl<StrT> AnalysisSource<StrT>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
     /// Merges the `syntax`, `sym`, `no_crossref`, and `nesting_range` fields from `other`
     /// into `self`. The `no_crossref` field can be different sometimes
@@ -794,9 +811,7 @@ where
             }
             (&mut Some(ExpandsTo(ref mut a)), &mut Some(ExpandsTo(ref mut b))) => {
                 for (k, mut v) in core::mem::take(b) {
-                    a.entry(k)
-                        .and_modify(|a_v| a_v.append(&mut v))
-                        .or_insert(v);
+                    a.entry(k).and_modify(|a_v| a_v.append(&mut v)).or_insert(v);
                 }
             }
             (&mut Some(InExpansionAt(ref mut a)), &mut Some(InExpansionAt(ref mut b))) => {
@@ -838,11 +853,11 @@ where
 #[serde(untagged)]
 pub enum AnalysisUnion<StrT = Ustr>
 where
-    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq
+    StrT: Clone + Debug + Default + Deref<Target = str> + FromStr + Hash + Ord + PartialEq,
 {
-    Target(AnalysisTarget::<StrT>),
-    Source(AnalysisSource::<StrT>),
-    Structured(AnalysisStructured::<StrT>),
+    Target(AnalysisTarget<StrT>),
+    Source(AnalysisSource<StrT>),
+    Structured(AnalysisStructured<StrT>),
 }
 
 pub fn parse_location(loc: &str) -> Location {
@@ -1072,7 +1087,7 @@ pub fn read_analyses<T>(
     result2
 }
 
-pub fn read_target(obj: Value, _loc: &Location, _i_size: usize) -> Option<AnalysisTarget::<Ustr>> {
+pub fn read_target(obj: Value, _loc: &Location, _i_size: usize) -> Option<AnalysisTarget<Ustr>> {
     // XXX this shouldn't be necessary thanks to our tag, so this should be removable
     if obj.get("target").is_none() {
         return None;
@@ -1081,7 +1096,11 @@ pub fn read_target(obj: Value, _loc: &Location, _i_size: usize) -> Option<Analys
     from_value(obj).ok()
 }
 
-pub fn read_structured(obj: Value, _loc: &Location, _i_size: usize) -> Option<AnalysisStructured::<Ustr>> {
+pub fn read_structured(
+    obj: Value,
+    _loc: &Location,
+    _i_size: usize,
+) -> Option<AnalysisStructured<Ustr>> {
     // XXX this shouldn't be necessary thanks to our tag, so this should be removable
     if obj.get("structured").is_none() {
         return None;
@@ -1090,7 +1109,7 @@ pub fn read_structured(obj: Value, _loc: &Location, _i_size: usize) -> Option<An
     from_value(obj).ok()
 }
 
-pub fn read_source(obj: Value, _loc: &Location, _i_size: usize) -> Option<AnalysisSource::<Ustr>> {
+pub fn read_source(obj: Value, _loc: &Location, _i_size: usize) -> Option<AnalysisSource<Ustr>> {
     // XXX this shouldn't be necessary thanks to our tag, so this should be removable
     if obj.get("source").is_none() {
         return None;

--- a/tools/src/file_format/analysis_manglings.rs
+++ b/tools/src/file_format/analysis_manglings.rs
@@ -77,7 +77,10 @@ pub fn split_pretty(pretty: &str, sym: &str) -> (Vec<String>, &'static str) {
     // make the diagram more legible since it will be immediately clear what
     // we're dealing with.)
     if sym.starts_with("FILE_") {
-        return (pretty.split_inclusive("/").map(|s| s.to_string()).collect(), "");
+        return (
+            pretty.split_inclusive("/").map(|s| s.to_string()).collect(),
+            "",
+        );
     }
 
     let mut pieces = vec![];
@@ -93,8 +96,7 @@ pub fn split_pretty(pretty: &str, sym: &str) -> (Vec<String>, &'static str) {
                 if state != SplitState::NotInArg {
                     info!(
                         "In arg state with depth {} when ran out of chars on {}.",
-                        arg_depth,
-                        pretty,
+                        arg_depth, pretty,
                     );
                 }
                 if !token.is_empty() {

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -1,5 +1,5 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
-use std::fs::{File, self};
+use std::fs::{self, File};
 use std::io::BufReader;
 use std::io::Read;
 use std::str;
@@ -172,7 +172,10 @@ impl Config {
     /// Synchronously read the contents of a file in the given tree's config
     /// directory, falling back to `MOZSEARCH/config_defaults/FILENAME` if
     /// available.
-    pub fn read_tree_config_file_with_default(&self, filename: &str) -> Result<String, &'static str> {
+    pub fn read_tree_config_file_with_default(
+        &self,
+        filename: &str,
+    ) -> Result<String, &'static str> {
         let repo_specific_path = format!("{}/{}", self.config_repo_path, filename);
         if let Ok(data_str) = std::fs::read_to_string(repo_specific_path) {
             return Ok(data_str);
@@ -187,7 +190,12 @@ impl Config {
     /// Synchronously attempt to locate and read the contents of the given file
     /// at the given root using the given tree as context.  Documentation on the
     /// roots can be found on `SourceDescriptor`.
-    pub fn maybe_read_file_from_given_root(&self, tree: &str, root: &str, file: &str) -> Result<Option<String>, &'static str> {
+    pub fn maybe_read_file_from_given_root(
+        &self,
+        tree: &str,
+        root: &str,
+        file: &str,
+    ) -> Result<Option<String>, &'static str> {
         let tree = self.trees.get(tree).unwrap();
 
         let path_root = match root {
@@ -209,7 +217,7 @@ impl Config {
                 // dynamic strings, but for these static strings, let's have fun
                 // with how useless this is!
                 _ => Err("some kind of read error I guess"),
-            }
+            },
             _ => Ok(None),
         }
     }
@@ -247,8 +255,12 @@ pub fn index_blame(
     (blame_map, hg_map)
 }
 
-pub fn load(config_path: &str, need_indexes: bool, only_tree: Option<&str>,
-            url_map_path: Option<String>) -> Config {
+pub fn load(
+    config_path: &str,
+    need_indexes: bool,
+    only_tree: Option<&str>,
+    url_map_path: Option<String>,
+) -> Config {
     let config_file = File::open(config_path).unwrap();
     let mut reader = BufReader::new(&config_file);
     let mut input = String::new();

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -150,7 +150,7 @@ impl TreeConfig {
         format!("{}/{}", &self.paths.files_path, path)
     }
 
-    pub fn should_ignore_missing_file(&self, path: &String) -> bool {
+    pub fn should_ignore_missing_file(&self, path: &str) -> bool {
         for prefix in &self.paths.ignore_missing_path_prefixes {
             if path.starts_with(prefix) {
                 return true;

--- a/tools/src/file_format/coverage.rs
+++ b/tools/src/file_format/coverage.rs
@@ -69,8 +69,7 @@ pub fn interpolate_coverage(mut raw: Vec<i64>) -> Vec<i64> {
         // configure for that base-case.
         have_interp_val = true;
         interp_val = -1;
-        for j in (i + 1)..raw.len() {
-            let next_val = raw[j];
+        for &next_val in raw.iter().skip(i + 1) {
             if next_val == -1 {
                 continue;
             }

--- a/tools/src/file_format/crossref_converter.rs
+++ b/tools/src/file_format/crossref_converter.rs
@@ -131,7 +131,9 @@ pub fn determine_desired_extra_syms_from_jumpref(
                     // thoroughly) and the binding slot will reference the pure virtual decl that
                     // we upgrade to a def.  That's not useful, so we also want to traverse its
                     // overridenBy edges so we can provide go to the actual impl definition.
-                    (BindingSlotKind::Method, BindingSlotLang::Cpp) => JumprefTraversals::OverriddenBy,
+                    (BindingSlotKind::Method, BindingSlotLang::Cpp) => {
+                        JumprefTraversals::OverriddenBy
+                    }
                     _ => JumprefTraversals::empty(),
                 };
                 extra_syms.push((slot_info.sym.to_string(), next_step));

--- a/tools/src/file_format/crossref_converter.rs
+++ b/tools/src/file_format/crossref_converter.rs
@@ -75,7 +75,7 @@ pub fn convert_crossref_value_to_sym_info_rep(
             // TODO: Need to handle the IDL search permutations issue that currently allows
             // the language indexer to define multiple symbol groupings.
 
-            if jumps.len() > 0 {
+            if !jumps.is_empty() {
                 rep.insert("jumps".to_string(), json!(jumps));
             }
 

--- a/tools/src/file_format/crossref_lookup.rs
+++ b/tools/src/file_format/crossref_lookup.rs
@@ -21,7 +21,6 @@ pub struct CrossrefLookupMap {
     extra_mm: Arc<Mmap>,
 }
 
-
 const SPACE: u8 = ' ' as u8;
 const NEWLINE: u8 = '\n' as u8;
 const ID_START: u8 = '!' as u8;
@@ -43,18 +42,14 @@ impl CrossrefLookupMap {
         let inline_file = File::open(inline_path).unwrap();
         let inline_mm = unsafe {
             match Mmap::map(&inline_file) {
-                Ok(mmap) => {
-                    Arc::new(mmap)
-                }
+                Ok(mmap) => Arc::new(mmap),
                 Err(_) => return None,
             }
         };
         let extra_file = File::open(extra_path).unwrap();
         let extra_mm = unsafe {
             match Mmap::map(&extra_file) {
-                Ok(mmap) => {
-                    Arc::new(mmap)
-                }
+                Ok(mmap) => Arc::new(mmap),
                 Err(_) => return None,
             }
         };

--- a/tools/src/file_format/crossref_lookup.rs
+++ b/tools/src/file_format/crossref_lookup.rs
@@ -21,11 +21,11 @@ pub struct CrossrefLookupMap {
     extra_mm: Arc<Mmap>,
 }
 
-const SPACE: u8 = ' ' as u8;
-const NEWLINE: u8 = '\n' as u8;
-const ID_START: u8 = '!' as u8;
-const INLINE_STORED: u8 = ':' as u8;
-const EXTERNALLY_STORED: u8 = '@' as u8;
+const SPACE: u8 = b' ';
+const NEWLINE: u8 = b'\n';
+const ID_START: u8 = b'!';
+const INLINE_STORED: u8 = b':';
+const EXTERNALLY_STORED: u8 = b'@';
 
 fn make_crossref_data_error(sym: &str) -> ServerError {
     ServerError::StickyProblem(ErrorDetails {
@@ -230,8 +230,8 @@ impl CrossrefLookupMap {
         };
 
         let extra_bytes: &[u8] = self.extra_mm.as_ref();
-        return Ok(from_slice(
+        Ok(from_slice(
             &extra_bytes[brace_offset..brace_offset + length_with_newline - 1],
-        )?);
+        )?)
     }
 }

--- a/tools/src/file_format/globbing_file_list.rs
+++ b/tools/src/file_format/globbing_file_list.rs
@@ -72,17 +72,16 @@ impl GlobbingFileList {
                 line.to_string()
             };
 
-            info!("  glob: '{}' normalized to '{}' negated: {}", line, &use_line, negated);
-            if let Ok(glob) = GlobBuilder::new(&use_line)
-                .literal_separator(true)
-                .build() {
+            info!(
+                "  glob: '{}' normalized to '{}' negated: {}",
+                line, &use_line, negated
+            );
+            if let Ok(glob) = GlobBuilder::new(&use_line).literal_separator(true).build() {
                 globs.push((negated, glob.compile_matcher()));
             }
         }
 
-        GlobbingFileList {
-            globs
-        }
+        GlobbingFileList { globs }
     }
 
     pub fn is_match(&self, path: &str) -> bool {

--- a/tools/src/file_format/globbing_file_list.rs
+++ b/tools/src/file_format/globbing_file_list.rs
@@ -90,11 +90,7 @@ impl GlobbingFileList {
         for (negated, matcher) in &self.globs {
             if matcher.is_match(path) {
                 // (I feel this reads better than assigning `!*negated`.)
-                if *negated {
-                    matches = false;
-                } else {
-                    matches = true;
-                }
+                matches = !(*negated);
             }
         }
 

--- a/tools/src/file_format/history/io_helpers.rs
+++ b/tools/src/file_format/history/io_helpers.rs
@@ -21,10 +21,7 @@ pub fn read_record_file_contents<
     Some((header, records))
 }
 
-pub fn record_file_contents_to_string<
-    Header: Serialize,
-    Record: Serialize,
->(
+pub fn record_file_contents_to_string<Header: Serialize, Record: Serialize>(
     header: &Header,
     records: &Vec<Record>,
 ) -> String {

--- a/tools/src/file_format/history/io_helpers.rs
+++ b/tools/src/file_format/history/io_helpers.rs
@@ -23,7 +23,7 @@ pub fn read_record_file_contents<
 
 pub fn record_file_contents_to_string<Header: Serialize, Record: Serialize>(
     header: &Header,
-    records: &Vec<Record>,
+    records: &[Record],
 ) -> String {
     let header_iter = std::iter::once(to_string(&header).unwrap());
     let records_iter = records.iter().map(|rec| to_string(rec).unwrap());

--- a/tools/src/file_format/history/syntax_symdex.rs
+++ b/tools/src/file_format/history/syntax_symdex.rs
@@ -33,9 +33,7 @@ use super::syntax_files_struct::FileStructureRow;
 // than if we eventually want to handle overload / "stop symbol" semantics for
 // some reason.
 #[derive(Debug, Serialize, Deserialize)]
-pub struct SymdexHeader {
-
-}
+pub struct SymdexHeader {}
 
 /// The contents of a FileStructuredRow with a path added.
 #[derive(Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]

--- a/tools/src/file_format/history/timeline_common.rs
+++ b/tools/src/file_format/history/timeline_common.rs
@@ -1,4 +1,3 @@
-
 use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
@@ -38,7 +37,6 @@ pub struct SummaryRecordRef {
     /// Summary records should never overlap, so sorting
     pub iso_week_range: (u16, u8, u8),
 }
-
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct TokenDeltaDetails {

--- a/tools/src/file_format/history/timeline_files_delta.rs
+++ b/tools/src/file_format/history/timeline_files_delta.rs
@@ -3,12 +3,10 @@
 
 use serde::{Deserialize, Serialize};
 
-use super::timeline_common::{SummaryRecordRef, DetailRecordRef, SymbolSyntaxDeltaGroup};
+use super::timeline_common::{DetailRecordRef, SummaryRecordRef, SymbolSyntaxDeltaGroup};
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct FileDeltaHeader {
-
-}
+pub struct FileDeltaHeader {}
 
 /// Details changes from a specific revision for the source file containing this
 /// record.  We do not currently

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -15,15 +15,7 @@ use serde_json::to_string;
 use super::config::Config;
 
 fn uppercase(s: &[u8]) -> Vec<u8> {
-    let mut result = vec![];
-    for i in 0..s.len() {
-        result.push(if s[i] >= b'a' && s[i] <= b'z' {
-            s[i] - b'a' + b'A'
-        } else {
-            s[i]
-        });
-    }
-    result
+    s.iter().map(u8::to_ascii_uppercase).collect()
 }
 
 #[derive(Clone, Debug)]

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -65,7 +65,7 @@ fn demangle_name(name: &str) -> String {
 impl IdentMap {
     pub fn new(filename: &str) -> Option<IdentMap> {
         let file = match File::open(filename) {
-            Ok(file) => { file }
+            Ok(file) => file,
             Err(e) => {
                 warn!("Failed to open {}: {:?}", filename, e);
                 return None;
@@ -73,14 +73,12 @@ impl IdentMap {
         };
         unsafe {
             match Mmap::map(&file) {
-                Ok(mmap) => {
-                    Some(IdentMap {
-                        mmap: Arc::new(mmap)
-                    })
-                }
+                Ok(mmap) => Some(IdentMap {
+                    mmap: Arc::new(mmap),
+                }),
                 Err(e) => {
                     warn!("Failed to mmap {}: {:?}", filename, e);
-                    return None
+                    return None;
                 }
             }
         }
@@ -172,8 +170,7 @@ impl IdentMap {
             // shorter than the identifier.
             if needle.len() < id.len() {
                 let suffix = &id[needle.len()..];
-                if exact_match || suffix.contains(':') || suffix.contains('.')
-                {
+                if exact_match || suffix.contains(':') || suffix.contains('.') {
                     continue;
                 }
             }

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -17,8 +17,8 @@ use super::config::Config;
 fn uppercase(s: &[u8]) -> Vec<u8> {
     let mut result = vec![];
     for i in 0..s.len() {
-        result.push(if s[i] >= 'a' as u8 && s[i] <= 'z' as u8 {
-            s[i] - ('a' as u8) + ('A' as u8)
+        result.push(if s[i] >= b'a' && s[i] <= b'z' {
+            s[i] - b'a' + b'A'
         } else {
             s[i]
         });
@@ -78,7 +78,7 @@ impl IdentMap {
                 }),
                 Err(e) => {
                     warn!("Failed to mmap {}: {:?}", filename, e);
-                    return None;
+                    None
                 }
             }
         }
@@ -99,19 +99,19 @@ impl IdentMap {
     fn get_line(&self, pos: usize) -> &[u8] {
         let mut pos = pos;
         let bytes = self.mmap.as_ref();
-        if bytes[pos] == '\n' as u8 {
+        if bytes[pos] == b'\n' {
             pos -= 1;
         }
 
         let mut start = pos;
         let mut end = pos;
 
-        while start > 0 && bytes[start - 1] != '\n' as u8 {
+        while start > 0 && bytes[start - 1] != b'\n' {
             start -= 1;
         }
 
         let size = bytes.len();
-        while end < size && bytes[end] != '\n' as u8 {
+        while end < size && bytes[end] != b'\n' {
             end += 1;
         }
 
@@ -121,7 +121,7 @@ impl IdentMap {
     fn bisect(&self, needle: &[u8], upper_bound: bool) -> usize {
         let mut needle = uppercase(needle);
         if upper_bound {
-            needle.push('~' as u8);
+            needle.push(b'~');
         }
 
         let mut first = 0;

--- a/tools/src/file_format/merger.rs
+++ b/tools/src/file_format/merger.rs
@@ -32,11 +32,7 @@ pub struct HashedStructured {
 /// The logic could almost certainly be further unified into the `cmd_pipeline`
 /// data model, with callers potentially altered to use searchfox-tool and
 /// eliminate the standalone merge-analyses.rs binary.  But there's no urgency.
-pub fn merge_files<W: std::io::Write>(
-    filenames: &[String],
-    platforms: &Vec<String>,
-    mut writer: W,
-) {
+pub fn merge_files<W: std::io::Write>(filenames: &[String], platforms: &[String], mut writer: W) {
     let mut unique_targets = HashSet::new();
     // Maps from symbol name to a HashMap<u64 hash, HashedStructured>
     let mut structured_syms = BTreeMap::new();

--- a/tools/src/file_format/merger.rs
+++ b/tools/src/file_format/merger.rs
@@ -32,198 +32,212 @@ pub struct HashedStructured {
 /// The logic could almost certainly be further unified into the `cmd_pipeline`
 /// data model, with callers potentially altered to use searchfox-tool and
 /// eliminate the standalone merge-analyses.rs binary.  But there's no urgency.
-pub fn merge_files<W: std::io::Write>(filenames: &[String],  platforms: &Vec<String>, mut writer: W) {
-  let mut unique_targets = HashSet::new();
-  // Maps from symbol name to a HashMap<u64 hash, HashedStructured>
-  let mut structured_syms = BTreeMap::new();
+pub fn merge_files<W: std::io::Write>(
+    filenames: &[String],
+    platforms: &Vec<String>,
+    mut writer: W,
+) {
+    let mut unique_targets = HashSet::new();
+    // Maps from symbol name to a HashMap<u64 hash, HashedStructured>
+    let mut structured_syms = BTreeMap::new();
 
-  let src_data = read_analyses(filenames, &mut |obj: Value, loc: &Location, i_file: usize| {
-      if let Ok(unified) = from_value::<AnalysisUnion<Ustr>>(obj) {
-          match unified {
-              AnalysisUnion::Source(mut src) => {
-                  // return source objects so that they come out of `read_analyses` for
-                  // additional processing below.
+    let src_data = read_analyses(
+        filenames,
+        &mut |obj: Value, loc: &Location, i_file: usize| {
+            if let Ok(unified) = from_value::<AnalysisUnion<Ustr>>(obj) {
+                match unified {
+                    AnalysisUnion::Source(mut src) => {
+                        // return source objects so that they come out of `read_analyses` for
+                        // additional processing below.
 
-                  // populate the platform key of expansions and expanded symbols
-                  use ExpansionInfo::*;
-                  match src.expansion_info {
-                      Some(ExpandsTo(ref mut expansions)) => {
-                          for (_, expansions) in expansions {
-                              if let Some(unnamed_expansions) = expansions.remove("") {
-                                  expansions
-                                      .insert(platforms[i_file].clone(), unnamed_expansions);
-                              }
-                          }
-                      }
-                      Some(InExpansionAt(ref mut offsets)) => {
-                          for (_, offsets) in offsets {
-                              if let Some(unnamed_offsets) = offsets.remove("") {
-                                  offsets.insert(platforms[i_file].clone(), unnamed_offsets);
-                              }
-                          }
-                      }
-                      None => {}
-                  }
+                        // populate the platform key of expansions and expanded symbols
+                        use ExpansionInfo::*;
+                        match src.expansion_info {
+                            Some(ExpandsTo(ref mut expansions)) => {
+                                for (_, expansions) in expansions {
+                                    if let Some(unnamed_expansions) = expansions.remove("") {
+                                        expansions
+                                            .insert(platforms[i_file].clone(), unnamed_expansions);
+                                    }
+                                }
+                            }
+                            Some(InExpansionAt(ref mut offsets)) => {
+                                for (_, offsets) in offsets {
+                                    if let Some(unnamed_offsets) = offsets.remove("") {
+                                        offsets.insert(platforms[i_file].clone(), unnamed_offsets);
+                                    }
+                                }
+                            }
+                            None => {}
+                        }
 
-                  return Some(src);
-              }
-              AnalysisUnion::Target(tgt) => {
-                  // for target objects, just print them back out, but use the `unique_targets`
-                  // hashset to deduplicate them.
-                  let target_str = to_string(&WithLocation {
-                      data: tgt,
-                      loc: loc.clone(),
-                  })
-                  .unwrap();
-                  if !unique_targets.contains(&target_str) {
-                      writeln!(writer, "{}", target_str).unwrap();
-                      unique_targets.insert(target_str);
-                  }
-              }
-              AnalysisUnion::Structured(structured) => {
-                  // Structured objects may have different data for different platforms.  We
-                  // detect this by building a map for each symbol from the hash of the string
-                  // representation of their JSON encoding to the AnalysisStructured
-                  // representation.  If, after processing the files we find there was a single
-                  // hash, then we emit that record as we originally found it.  However, if there
-                  // were multiple hashes, we pick the last.
-                  //
-                  // We used to have AnalysisStructured be hashable, but the `extra` Map was
-                  // not currently hashable due to https://github.com/serde-rs/json/issues/747
-                  // and in reality we just want to hash the JSON string, but it's already
-                  // been parsed into a Value, which is why we're not using the string.
-                  let variants = structured_syms
-                      .entry(structured.sym.clone())
-                      .or_insert(HashMap::new());
-                  let json_str = to_string(&structured).unwrap();
-                  let mut hasher = DefaultHasher::new();
-                  json_str.hash(&mut hasher);
-                  let hash_key = hasher.finish();
-                  let hs = variants.entry(hash_key).or_insert(HashedStructured {
-                      platforms: vec![],
-                      loc: loc.clone(),
-                      data: structured,
-                  });
-                  hs.platforms.push(i_file);
-              }
-          }
-      }
-      None
-  });
+                        return Some(src);
+                    }
+                    AnalysisUnion::Target(tgt) => {
+                        // for target objects, just print them back out, but use the `unique_targets`
+                        // hashset to deduplicate them.
+                        let target_str = to_string(&WithLocation {
+                            data: tgt,
+                            loc: loc.clone(),
+                        })
+                        .unwrap();
+                        if !unique_targets.contains(&target_str) {
+                            writeln!(writer, "{}", target_str).unwrap();
+                            unique_targets.insert(target_str);
+                        }
+                    }
+                    AnalysisUnion::Structured(structured) => {
+                        // Structured objects may have different data for different platforms.  We
+                        // detect this by building a map for each symbol from the hash of the string
+                        // representation of their JSON encoding to the AnalysisStructured
+                        // representation.  If, after processing the files we find there was a single
+                        // hash, then we emit that record as we originally found it.  However, if there
+                        // were multiple hashes, we pick the last.
+                        //
+                        // We used to have AnalysisStructured be hashable, but the `extra` Map was
+                        // not currently hashable due to https://github.com/serde-rs/json/issues/747
+                        // and in reality we just want to hash the JSON string, but it's already
+                        // been parsed into a Value, which is why we're not using the string.
+                        let variants = structured_syms
+                            .entry(structured.sym.clone())
+                            .or_insert(HashMap::new());
+                        let json_str = to_string(&structured).unwrap();
+                        let mut hasher = DefaultHasher::new();
+                        json_str.hash(&mut hasher);
+                        let hash_key = hasher.finish();
+                        let hs = variants.entry(hash_key).or_insert(HashedStructured {
+                            platforms: vec![],
+                            loc: loc.clone(),
+                            data: structured,
+                        });
+                        hs.platforms.push(i_file);
+                    }
+                }
+            }
+            None
+        },
+    );
 
-  // For each bucket of source data at a given location, sort the source data by
-  // the `pretty` field. This allows us to walk through the bucket and operate
-  // with the assumption that entries with the same (location, pretty) tuple are
-  // adjacent. If we do run into such entries we merge them to union the tokens
-  // in the `syntax` and `sym` fields.
-  for mut loc_data in src_data {
-      loc_data.data.sort_by(|s1, s2| s1.pretty.cmp(&s2.pretty));
-      let mut last_entry: Option<AnalysisSource> = None;
-      for analysis_entry in std::mem::replace(&mut loc_data.data, Vec::new()) {
-          match last_entry {
-              Some(mut e) => {
-                  if e.pretty == analysis_entry.pretty {
-                      // the (loc, pretty) tuple on `analysis_entry` matches that
-                      // on `last_entry` so we merge them
-                      e.merge(analysis_entry);
-                      last_entry = Some(e);
-                  } else {
-                      loc_data.data.push(e);
-                      last_entry = Some(analysis_entry);
-                  }
-              }
-              None => {
-                  last_entry = Some(analysis_entry);
-              }
-          }
-      }
-      if let Some(e) = last_entry {
-          loc_data.data.push(e);
-      }
-      // We can't convert WithLocation<Vec<T>> directly to JSON; we need to
-      // spread the loc to each individual piece of data.
-      let loc = loc_data.loc;
-      for datum in loc_data.data {
-        writeln!(writer, "{}", to_string(&WithLocation { loc, data: datum }).unwrap()).unwrap();
-      }
-  }
+    // For each bucket of source data at a given location, sort the source data by
+    // the `pretty` field. This allows us to walk through the bucket and operate
+    // with the assumption that entries with the same (location, pretty) tuple are
+    // adjacent. If we do run into such entries we merge them to union the tokens
+    // in the `syntax` and `sym` fields.
+    for mut loc_data in src_data {
+        loc_data.data.sort_by(|s1, s2| s1.pretty.cmp(&s2.pretty));
+        let mut last_entry: Option<AnalysisSource> = None;
+        for analysis_entry in std::mem::replace(&mut loc_data.data, Vec::new()) {
+            match last_entry {
+                Some(mut e) => {
+                    if e.pretty == analysis_entry.pretty {
+                        // the (loc, pretty) tuple on `analysis_entry` matches that
+                        // on `last_entry` so we merge them
+                        e.merge(analysis_entry);
+                        last_entry = Some(e);
+                    } else {
+                        loc_data.data.push(e);
+                        last_entry = Some(analysis_entry);
+                    }
+                }
+                None => {
+                    last_entry = Some(analysis_entry);
+                }
+            }
+        }
+        if let Some(e) = last_entry {
+            loc_data.data.push(e);
+        }
+        // We can't convert WithLocation<Vec<T>> directly to JSON; we need to
+        // spread the loc to each individual piece of data.
+        let loc = loc_data.loc;
+        for datum in loc_data.data {
+            writeln!(
+                writer,
+                "{}",
+                to_string(&WithLocation { loc, data: datum }).unwrap()
+            )
+            .unwrap();
+        }
+    }
 
-  for (_id, mut hmap) in structured_syms {
-      if hmap.len() == 1 {
-          // There was only one variant of the structured info, so we can just use it as-is.
-          let (_hash, hs) = hmap.drain().next().unwrap();
-          writeln!(
-              writer,
-              "{}",
-              to_string(&WithLocation {
-                  loc: hs.loc,
-                  data: hs.data
-              })
-              .unwrap()
-          ).unwrap();
-      } else {
-          // There are multiple variants, so we want to:
-          // 1. Pick one of the variants as the canonical variant.  For now our heuristic is to
-          //    pick the highest platform index.  This is because the platform list is currently
-          //    accomplished via wildcard that puts "android-armv7" first and that's a 32-bit
-          //    platform, and we'd rather our defaults be 64-bit.
-          // 2. Using the `extras` field, populate a `platforms` value in
-          //    the canonical variant as well a `variants` field.  This should
-          //    allow round-tripping while also avoiding us actually doing
-          //    anything with this surplus-ish info which we expect to only be
-          //    consumed by front-end JS UI at this time for the purposes of
-          //    showing differing memory layouts across platforms.
-          //
-          // Prior to the conversion to serde_json, the `extras` field was a
-          // JSON-string `payload` field and we just did a lot of sketchy
-          // gluing together of raw JSON string fragments.
+    for (_id, mut hmap) in structured_syms {
+        if hmap.len() == 1 {
+            // There was only one variant of the structured info, so we can just use it as-is.
+            let (_hash, hs) = hmap.drain().next().unwrap();
+            writeln!(
+                writer,
+                "{}",
+                to_string(&WithLocation {
+                    loc: hs.loc,
+                    data: hs.data
+                })
+                .unwrap()
+            )
+            .unwrap();
+        } else {
+            // There are multiple variants, so we want to:
+            // 1. Pick one of the variants as the canonical variant.  For now our heuristic is to
+            //    pick the highest platform index.  This is because the platform list is currently
+            //    accomplished via wildcard that puts "android-armv7" first and that's a 32-bit
+            //    platform, and we'd rather our defaults be 64-bit.
+            // 2. Using the `extras` field, populate a `platforms` value in
+            //    the canonical variant as well a `variants` field.  This should
+            //    allow round-tripping while also avoiding us actually doing
+            //    anything with this surplus-ish info which we expect to only be
+            //    consumed by front-end JS UI at this time for the purposes of
+            //    showing differing memory layouts across platforms.
+            //
+            // Prior to the conversion to serde_json, the `extras` field was a
+            // JSON-string `payload` field and we just did a lot of sketchy
+            // gluing together of raw JSON string fragments.
 
-          // Do a pass to pick the best hash.
-          let mut best_hash = 0;
-          let mut best_plat = 0;
-          for (hash, hs) in hmap.iter() {
-              let local_plat = hs.platforms.iter().max().unwrap();
-              if local_plat >= &best_plat {
-                  best_plat = *local_plat;
-                  best_hash = *hash;
-              }
-          }
+            // Do a pass to pick the best hash.
+            let mut best_hash = 0;
+            let mut best_plat = 0;
+            for (hash, hs) in hmap.iter() {
+                let local_plat = hs.platforms.iter().max().unwrap();
+                if local_plat >= &best_plat {
+                    best_plat = *local_plat;
+                    best_hash = *hash;
+                }
+            }
 
-          let mut hs = hmap.remove(&best_hash).unwrap();
-          hs.data.extra.insert(
-              "platforms".to_string(),
-              json!(hs
-                  .platforms
-                  .iter()
-                  .map(|x| platforms[*x].clone())
-                  .collect::<Vec<String>>()),
-          );
-          hs.data.extra.insert(
-              "variants".to_string(),
-              hmap.into_values()
-                  .map(|mut variant| {
-                      variant.data.extra.insert(
-                          "platforms".to_string(),
-                          json!(variant
-                              .platforms
-                              .iter()
-                              .map(|x| platforms[*x].clone())
-                              .collect::<Vec<String>>()),
-                      );
-                      to_value(&variant.data).unwrap()
-                  })
-                  .collect(),
-          );
+            let mut hs = hmap.remove(&best_hash).unwrap();
+            hs.data.extra.insert(
+                "platforms".to_string(),
+                json!(hs
+                    .platforms
+                    .iter()
+                    .map(|x| platforms[*x].clone())
+                    .collect::<Vec<String>>()),
+            );
+            hs.data.extra.insert(
+                "variants".to_string(),
+                hmap.into_values()
+                    .map(|mut variant| {
+                        variant.data.extra.insert(
+                            "platforms".to_string(),
+                            json!(variant
+                                .platforms
+                                .iter()
+                                .map(|x| platforms[*x].clone())
+                                .collect::<Vec<String>>()),
+                        );
+                        to_value(&variant.data).unwrap()
+                    })
+                    .collect(),
+            );
 
-          writeln!(
-              writer,
-              "{}",
-              to_string(&WithLocation {
-                  loc: hs.loc,
-                  data: hs.data
-              })
-              .unwrap()
-          ).unwrap();
-      }
-  }
+            writeln!(
+                writer,
+                "{}",
+                to_string(&WithLocation {
+                    loc: hs.loc,
+                    data: hs.data
+                })
+                .unwrap()
+            )
+            .unwrap();
+        }
+    }
 }

--- a/tools/src/file_format/ontology_mapping.rs
+++ b/tools/src/file_format/ontology_mapping.rs
@@ -478,9 +478,7 @@ impl OntologyMappingConfig {
                             // would have already processed tha type at its ">".
                             false
                         }
-                        Some(OntologyType::Variant) => {
-                            true
-                        }
+                        Some(OntologyType::Variant) => true,
                         Some(OntologyType::Nothing) => {
                             cur_type.is_nothing = true;
                             false
@@ -514,15 +512,11 @@ impl OntologyMappingConfig {
                                 continue;
                             }
                             if arg_type.is_pointer {
-                                results.push((
-                                    OntologyPointerKind::Raw,
-                                    ustr(&arg_type.identifier),
-                                ));
+                                results
+                                    .push((OntologyPointerKind::Raw, ustr(&arg_type.identifier)));
                             } else if arg_type.is_ref {
-                                results.push((
-                                    OntologyPointerKind::Ref,
-                                    ustr(&arg_type.identifier),
-                                ));
+                                results
+                                    .push((OntologyPointerKind::Ref, ustr(&arg_type.identifier)));
                             } else if arg_type.is_tag {
                                 if let Some(OntologyType::Value) =
                                     self.types.get(&ustr(&arg_type.identifier))
@@ -712,12 +706,18 @@ kind = "contains"
 
     assert_eq!(
         c.maybe_parse_type_as_pointer("nsTArray<RefPtr<class SyntheticExample> >"),
-        (vec![(OntologyPointerKind::Strong, ustr("SyntheticExample"))], vec![])
+        (
+            vec![(OntologyPointerKind::Strong, ustr("SyntheticExample"))],
+            vec![]
+        )
     );
 
     assert_eq!(
         c.maybe_parse_type_as_pointer("nsTArray<class SyntheticExample *>"),
-        (vec![(OntologyPointerKind::Raw, ustr("SyntheticExample"))], vec![])
+        (
+            vec![(OntologyPointerKind::Raw, ustr("SyntheticExample"))],
+            vec![]
+        )
     );
 
     assert_eq!(
@@ -753,11 +753,14 @@ kind = "contains"
 
     assert_eq!(
         c.maybe_parse_type_as_pointer("class mozilla::Atomic<class mozilla::dom::WorkerPrivate *>"),
-        (vec![
-            (OntologyPointerKind::Raw, ustr("mozilla::dom::WorkerPrivate"))
-        ], vec![ustr("atomic")])
+        (
+            vec![(
+                OntologyPointerKind::Raw,
+                ustr("mozilla::dom::WorkerPrivate")
+            )],
+            vec![ustr("atomic")]
+        )
     );
-
 
     assert_eq!(
         c.maybe_parse_type_as_pointer("class mozilla::Maybe<class nsTString<char16_t> >"),

--- a/tools/src/file_format/per_file_info.rs
+++ b/tools/src/file_format/per_file_info.rs
@@ -51,7 +51,7 @@ impl FileLookupMap {
     /// The general concern is to avoid interning a bunch of incorrect query
     /// strings.
     pub fn lookup_file_from_ustr(&self, path_ustr: &Ustr) -> Option<&ConcisePerFileInfo<Ustr>> {
-        self.concise_per_file.get(&path_ustr)
+        self.concise_per_file.get(path_ustr)
     }
 
     /// File lookup when we don't have a Ustr already available; this is
@@ -84,7 +84,7 @@ impl FileLookupMap {
                 }
             })
             .map(|v| FileMatch {
-                path: v.0.clone(),
+                path: *v.0,
                 concise: v.1.clone(),
             })
             .take(limit)

--- a/tools/src/file_format/repo_data_ingestion.rs
+++ b/tools/src/file_format/repo_data_ingestion.rs
@@ -593,10 +593,8 @@ impl RepoIngestion {
                     let maybe_description = describe_file(&contents, path_wrapper, &format);
                     if let Some(ref description) = maybe_description {
                         // We currently want to output
-                        let description_fname = format!(
-                            "{}/description/{}",
-                            tree_config.paths.index_path, file_path
-                        );
+                        let description_fname =
+                            format!("{}/description/{}", tree_config.paths.index_path, file_path);
                         let description_file = match File::create(&description_fname) {
                             Ok(df) => df,
                             Err(e) => {

--- a/tools/src/file_format/repo_data_ingestion.rs
+++ b/tools/src/file_format/repo_data_ingestion.rs
@@ -362,7 +362,7 @@ impl JsonEvalNodeIngestion {
                     Value::Object(obj) => json!(obj.len()),
                     _ => Value::Null,
                 },
-                __ => traversed,
+                _ => traversed,
             };
             if probing {
                 trace!(val = ?traversed, "length");

--- a/tools/src/file_format/url_map.rs
+++ b/tools/src/file_format/url_map.rs
@@ -16,7 +16,7 @@ pub struct URLMap {
 
 impl URLMap {
     fn new(data: HashMap<String, Vec<URLMapItem>>) -> Self {
-        Self { data: data }
+        Self { data }
     }
 
     pub fn new_empty() -> Self {

--- a/tools/src/file_format/url_map.rs
+++ b/tools/src/file_format/url_map.rs
@@ -1,7 +1,7 @@
+use serde::Deserialize;
+use serde_json::from_reader;
 use std::collections::HashMap;
 use std::fs::File;
-use serde_json::from_reader;
-use serde::Deserialize;
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct URLMapItem {
@@ -16,9 +16,7 @@ pub struct URLMap {
 
 impl URLMap {
     fn new(data: HashMap<String, Vec<URLMapItem>>) -> Self {
-        Self {
-            data: data,
-        }
+        Self { data: data }
     }
 
     pub fn new_empty() -> Self {
@@ -32,9 +30,7 @@ impl URLMap {
     }
 }
 
-pub fn read_url_map(
-    filename: &String,
-) -> URLMap {
+pub fn read_url_map(filename: &String) -> URLMap {
     let file = match File::open(filename) {
         Ok(f) => f,
         Err(_) => {

--- a/tools/src/file_utils.rs
+++ b/tools/src/file_utils.rs
@@ -1,8 +1,4 @@
-use crate::{
-    abstract_server::{
-        ErrorDetails, ErrorLayer, Result, ServerError,
-    },
-};
+use crate::abstract_server::{ErrorDetails, ErrorLayer, Result, ServerError};
 
 pub fn write_file_ensuring_parent_dir(file_path: &str, contents: &str) -> Result<()> {
     let as_path = std::path::Path::new(file_path);

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -761,16 +761,13 @@ pub fn format_file_data(
             last_color = color;
             let class = if color { 1 } else { 2 };
             let data = format!(
-                r#" class="blame-strip c{}" data-blame="{}#{}#{}" role="button" aria-label="{}" aria-expanded="false""#,
+                r#" class="blame-strip c{}" data-blame="{}#{}#{}" role="button" aria-label="{} hash {}" aria-expanded="false""#,
                 class,
                 revs,
                 filespecs,
                 blame_linenos,
-                format!(
-                    "{} hash {}",
-                    if same_rev_as_last { "same" } else { "new" },
-                    human_id
-                )
+                if same_rev_as_last { "same" } else { "new" },
+                human_id,
             );
             data
         } else {

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -304,8 +304,7 @@ pub fn format_code(
         let get_symbols =
             |token: &tokenize::Token, datum: &mut dyn Iterator<Item = &AnalysisSource>| {
                 match &token.kind {
-                    &tokenize::TokenKind::Identifier(_)
-                    | &tokenize::TokenKind::StringLiteral => {
+                    &tokenize::TokenKind::Identifier(_) | &tokenize::TokenKind::StringLiteral => {
                         // Build the list of symbols for the highlighter.  We do this for all source
                         // records, even ones marked "no_crossref" because we still want to highlight
                         // locals.  These will be emitted into a `data-symbols` attribute below.
@@ -375,10 +374,22 @@ pub fn format_code(
 
         // Only get the symbols and style of the symbols that appear directly in the source code, not in expansions
         let datum_outside_expansions = datum.iter().flat_map(|d| d.iter());
-        let has_expansion = |data: &AnalysisSource| matches!(data.expansion_info, Some(ExpansionInfo::ExpandsTo(_)));
+        let has_expansion = |data: &AnalysisSource| {
+            matches!(data.expansion_info, Some(ExpansionInfo::ExpandsTo(_)))
+        };
         let (symbols, style) = if datum_outside_expansions.clone().any(has_expansion) {
-            let symbols = get_symbols(&token, &mut datum_outside_expansions.clone().filter(|&a| has_expansion(a)));
-            let style = get_style(&token, &mut datum_outside_expansions.clone().filter(|&a| has_expansion(a)));
+            let symbols = get_symbols(
+                &token,
+                &mut datum_outside_expansions
+                    .clone()
+                    .filter(|&a| has_expansion(a)),
+            );
+            let style = get_style(
+                &token,
+                &mut datum_outside_expansions
+                    .clone()
+                    .filter(|&a| has_expansion(a)),
+            );
             (symbols, style)
         } else {
             let symbols = get_symbols(&token, &mut datum_outside_expansions.clone());
@@ -470,10 +481,7 @@ pub fn format_code(
                 .flat_map(|e| {
                     e.into_iter().flat_map(|(key, expansions)| {
                         expansions.into_iter().map(move |(platform, expansion)| {
-                            (
-                                key.to_owned(),
-                                (platform.to_owned(), expansion.to_owned()),
-                            )
+                            (key.to_owned(), (platform.to_owned(), expansion.to_owned()))
                         })
                     })
                 })
@@ -481,12 +489,10 @@ pub fn format_code(
             expansions.sort_unstable_by(|a, b| Ord::cmp(&(&a.0, &a.1 .1), &(&b.0, &b.1 .1)));
 
             // Format expansions into html
-            let expansions = expansions
-                .into_iter()
-                .map(|(key, (platform, expansion))| {
-                    let html = expansion_to_html(&key, &platform, &expansion);
-                    (key, (platform, html))
-                });
+            let expansions = expansions.into_iter().map(|(key, (platform, expansion))| {
+                let html = expansion_to_html(&key, &platform, &expansion);
+                (key, (platform, html))
+            });
 
             // Group by key again
             let expansions = expansions.group_by(|(key, _)| key.clone());
@@ -614,7 +620,14 @@ pub fn format_file_data(
 
     let slug = format_to_slug_attribute(&format);
     let pre_format_code = Instant::now();
-    let (output_lines, sym_json) = format_code(Some(cfg), crossref_lookup_map, format, path, &data, &analysis);
+    let (output_lines, sym_json) = format_code(
+        Some(cfg),
+        crossref_lookup_map,
+        format,
+        path,
+        &data,
+        &analysis,
+    );
     format_perf.format_code_duration_us = pre_format_code.elapsed().as_micros() as u64;
 
     let pre_blame_lines = Instant::now();

--- a/tools/src/git_ops.rs
+++ b/tools/src/git_ops.rs
@@ -1,5 +1,5 @@
-use std::path::Path;
 use git2::{Commit, Repository, TreeEntry};
+use std::path::Path;
 
 use crate::file_format::config::GitData;
 

--- a/tools/src/git_ops.rs
+++ b/tools/src/git_ops.rs
@@ -35,7 +35,7 @@ pub fn get_blame_lines(
                 blame_repo: Some(ref blame_repo),
                 ..
             }),
-            &Some(ref blame_commit),
+            Some(blame_commit),
         ) => {
             let blame_tree = blame_commit.tree().ok()?;
 

--- a/tools/src/glob_helper.rs
+++ b/tools/src/glob_helper.rs
@@ -45,7 +45,10 @@ pub fn block_in_place_glob_tree(root: &str, glob: &str) -> Vec<(String, String)>
                 let rel_path = entry.path().strip_prefix(root_path).unwrap();
                 paths.push((
                     // We want a trailing slash for simplified string formatting.
-                    format!("{}/", rel_path.parent().unwrap().to_str().unwrap().to_string()),
+                    format!(
+                        "{}/",
+                        rel_path.parent().unwrap().to_str().unwrap().to_string()
+                    ),
                     rel_path.file_name().unwrap().to_str().unwrap().to_string(),
                 ));
             }

--- a/tools/src/glob_helper.rs
+++ b/tools/src/glob_helper.rs
@@ -45,10 +45,7 @@ pub fn block_in_place_glob_tree(root: &str, glob: &str) -> Vec<(String, String)>
                 let rel_path = entry.path().strip_prefix(root_path).unwrap();
                 paths.push((
                     // We want a trailing slash for simplified string formatting.
-                    format!(
-                        "{}/",
-                        rel_path.parent().unwrap().to_str().unwrap().to_string()
-                    ),
+                    format!("{}/", rel_path.parent().unwrap().to_str().unwrap()),
                     rel_path.file_name().unwrap().to_str().unwrap().to_string(),
                 ));
             }

--- a/tools/src/languages.rs
+++ b/tools/src/languages.rs
@@ -18,7 +18,7 @@ pub struct LanguageSpec {
     pub markdown_slug: &'static str,
 }
 
-pub const SYN_RESERVED_CLASS: &'static str = "class=\"syn_reserved\" ";
+pub const SYN_RESERVED_CLASS: &str = "class=\"syn_reserved\" ";
 
 fn make_reserved(v: &[&str]) -> HashMap<String, String> {
     let mut reserved_words = HashMap::new();
@@ -28,7 +28,7 @@ fn make_reserved(v: &[&str]) -> HashMap<String, String> {
     reserved_words
 }
 
-static RESERVED_WORDS_JS: &'static [&'static str] = &[
+static RESERVED_WORDS_JS: &[&str] = &[
     "abstract",
     "else",
     "instanceof",
@@ -93,7 +93,7 @@ static RESERVED_WORDS_JS: &'static [&'static str] = &[
     "set",
 ];
 
-static RESERVED_WORDS_CPP: &'static [&'static str] = &[
+static RESERVED_WORDS_CPP: &[&str] = &[
     "alignas",
     "alignof",
     "and",
@@ -201,7 +201,7 @@ static RESERVED_WORDS_CPP: &'static [&'static str] = &[
     "defined",
 ];
 
-static RESERVED_WORDS_AIDL: &'static [&'static str] = &[
+static RESERVED_WORDS_AIDL: &[&str] = &[
     "parcelable",
     "import",
     "package",
@@ -219,7 +219,7 @@ static RESERVED_WORDS_AIDL: &'static [&'static str] = &[
 ];
 
 // From 'reserved' in ipc/ipdl/ipdl/parser.py
-static RESERVED_WORDS_IPDL: &'static [&'static str] = &[
+static RESERVED_WORDS_IPDL: &[&str] = &[
     "async",
     "both",
     "child",
@@ -250,7 +250,7 @@ static RESERVED_WORDS_IPDL: &'static [&'static str] = &[
     "verify",
 ];
 
-static RESERVED_WORDS_IDL: &'static [&'static str] = &[
+static RESERVED_WORDS_IDL: &[&str] = &[
     "cenum",
     "const",
     "interface",
@@ -306,7 +306,7 @@ static RESERVED_WORDS_IDL: &'static [&'static str] = &[
     "can_run_script",
 ];
 
-static RESERVED_WORDS_WEBIDL: &'static [&'static str] = &[
+static RESERVED_WORDS_WEBIDL: &[&str] = &[
     "module",
     "interface",
     "partial",
@@ -412,7 +412,7 @@ static RESERVED_WORDS_WEBIDL: &'static [&'static str] = &[
     "Unscopable",
 ];
 
-static RESERVED_WORDS_PYTHON: &'static [&'static str] = &[
+static RESERVED_WORDS_PYTHON: &[&str] = &[
     "and", "del", "from", "not", "while", "as", "elif", "global", "or", "with", "assert", "else",
     "if", "pass", "yield", "break", "except", "import", "print", "class", "exec", "in", "raise",
     "continue", "finally", "is", "return", "def", "for", "lambda", "try",
@@ -420,7 +420,7 @@ static RESERVED_WORDS_PYTHON: &'static [&'static str] = &[
 
 // List of Rust reserved words pulled from
 // https://github.com/rust-lang/rust/blob/master/src/libsyntax/symbol.rs
-static RESERVED_WORDS_RUST: &'static [&'static str] = &[
+static RESERVED_WORDS_RUST: &[&str] = &[
     "as", "box", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
     "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",
     "return", "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
@@ -429,7 +429,7 @@ static RESERVED_WORDS_RUST: &'static [&'static str] = &[
     "default", "union",
 ];
 
-static RESERVED_WORDS_JAVA: &'static [&'static str] = &[
+static RESERVED_WORDS_JAVA: &[&str] = &[
     "abstract",
     "continue",
     "for",
@@ -486,7 +486,7 @@ static RESERVED_WORDS_JAVA: &'static [&'static str] = &[
 ];
 
 // http://kotlinlang.org/docs/reference/keyword-reference.html
-static RESERVED_WORDS_KOTLIN: &'static [&'static str] = &[
+static RESERVED_WORDS_KOTLIN: &[&str] = &[
     "as",
     "as?",
     "break",
@@ -569,7 +569,7 @@ static RESERVED_WORDS_KOTLIN: &'static [&'static str] = &[
 
 lazy_static! {
     static ref JS_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_JS),
+        reserved_words: make_reserved(RESERVED_WORDS_JS),
         hash_identifier: true,
         c_style_comments: true,
         backtick_strings: true,
@@ -584,7 +584,7 @@ lazy_static! {
     };
 
     static ref CPP_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_CPP),
+        reserved_words: make_reserved(RESERVED_WORDS_CPP),
         c_style_comments: true,
         c_preprocessor: true,
         cxx14_digit_separators: true,
@@ -593,31 +593,31 @@ lazy_static! {
     };
 
     static ref AIDL_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_AIDL),
+        reserved_words: make_reserved(RESERVED_WORDS_AIDL),
         c_style_comments: true,
         .. LanguageSpec::default()
     };
 
     static ref IPDL_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_IPDL),
+        reserved_words: make_reserved(RESERVED_WORDS_IPDL),
         c_style_comments: true,
         .. LanguageSpec::default()
     };
 
     static ref IDL_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_IDL),
+        reserved_words: make_reserved(RESERVED_WORDS_IDL),
         c_style_comments: true,
         .. LanguageSpec::default()
     };
 
     static ref WEBIDL_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_WEBIDL),
+        reserved_words: make_reserved(RESERVED_WORDS_WEBIDL),
         c_style_comments: true,
         .. LanguageSpec::default()
     };
 
     static ref PYTHON_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_PYTHON),
+        reserved_words: make_reserved(RESERVED_WORDS_PYTHON),
         hash_comment: true,
         triple_quote_literals: true,
         markdown_slug: "py",
@@ -625,7 +625,7 @@ lazy_static! {
     };
 
     static ref RUST_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_RUST),
+        reserved_words: make_reserved(RESERVED_WORDS_RUST),
         hash_comment: true, // for now, for attributes
         c_style_comments: true,
         rust_tweaks: true,
@@ -634,14 +634,14 @@ lazy_static! {
     };
 
     static ref JAVA_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_JAVA),
+        reserved_words: make_reserved(RESERVED_WORDS_JAVA),
         c_style_comments: true,
         markdown_slug: "java",
         .. LanguageSpec::default()
     };
 
     static ref KOTLIN_SPEC : LanguageSpec = LanguageSpec {
-        reserved_words: make_reserved(&*RESERVED_WORDS_KOTLIN),
+        reserved_words: make_reserved(RESERVED_WORDS_KOTLIN),
         c_style_comments: true,
         .. LanguageSpec::default()
     };
@@ -664,19 +664,19 @@ pub fn select_formatting(filename: &str) -> FormatAs {
     };
     match ext {
         "c" | "cc" | "cpp" | "cxx" | "h" | "hh" | "hxx" | "hpp" | "inc" | "mm" | "m" => {
-            FormatAs::FormatCLike(&*CPP_SPEC)
+            FormatAs::FormatCLike(&CPP_SPEC)
         }
-        "aidl" => FormatAs::FormatCLike(&*AIDL_SPEC),
-        "ipdl" | "ipdlh" => FormatAs::FormatCLike(&*IPDL_SPEC),
-        "idl" => FormatAs::FormatCLike(&*IDL_SPEC),
-        "webidl" => FormatAs::FormatCLike(&*WEBIDL_SPEC),
-        "js" | "jsm" | "json" | "mjs" | "sjs" => FormatAs::FormatCLike(&*JS_SPEC),
-        "py" | "build" | "configure" => FormatAs::FormatCLike(&*PYTHON_SPEC),
-        "rs" => FormatAs::FormatCLike(&*RUST_SPEC),
-        "java" => FormatAs::FormatCLike(&*JAVA_SPEC),
-        "kt" => FormatAs::FormatCLike(&*KOTLIN_SPEC),
+        "aidl" => FormatAs::FormatCLike(&AIDL_SPEC),
+        "ipdl" | "ipdlh" => FormatAs::FormatCLike(&IPDL_SPEC),
+        "idl" => FormatAs::FormatCLike(&IDL_SPEC),
+        "webidl" => FormatAs::FormatCLike(&WEBIDL_SPEC),
+        "js" | "jsm" | "json" | "mjs" | "sjs" => FormatAs::FormatCLike(&JS_SPEC),
+        "py" | "build" | "configure" => FormatAs::FormatCLike(&PYTHON_SPEC),
+        "rs" => FormatAs::FormatCLike(&RUST_SPEC),
+        "java" => FormatAs::FormatCLike(&JAVA_SPEC),
+        "kt" => FormatAs::FormatCLike(&KOTLIN_SPEC),
 
-        "html" | "htm" | "xhtml" | "xht" | "xml" | "xul" => FormatAs::FormatTagLike(&*HTML_SPEC),
+        "html" | "htm" | "xhtml" | "xht" | "xml" | "xul" => FormatAs::FormatTagLike(&HTML_SPEC),
 
         "css" => FormatAs::CSS,
 

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -2,11 +2,9 @@ extern crate serde;
 extern crate serde_json;
 
 #[cfg(not(target_arch = "wasm32"))]
-extern crate log;
+extern crate chrono;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate clap;
-#[cfg(not(target_arch = "wasm32"))]
-extern crate chrono;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate git2;
 #[cfg(not(target_arch = "wasm32"))]
@@ -14,18 +12,20 @@ extern crate include_dir;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate itertools;
 #[cfg(not(target_arch = "wasm32"))]
+extern crate log;
+#[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 extern crate lazy_static;
 #[cfg(not(target_arch = "wasm32"))]
-extern crate linkify;
-#[cfg(not(target_arch = "wasm32"))]
-extern crate regex;
-#[cfg(not(target_arch = "wasm32"))]
 extern crate lexical_sort;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate linkify;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate liquid;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate query_parser;
+#[cfg(not(target_arch = "wasm32"))]
+extern crate regex;
 #[cfg(not(target_arch = "wasm32"))]
 #[macro_use]
 extern crate tracing;
@@ -34,8 +34,8 @@ extern crate tracing_subscriber;
 #[cfg(not(target_arch = "wasm32"))]
 extern crate uuid;
 
-pub mod file_format;
 pub mod css_analyzer;
+pub mod file_format;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub mod abstract_server;
@@ -69,10 +69,10 @@ pub mod logging;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod output;
 #[cfg(not(target_arch = "wasm32"))]
+mod symbol_graph_edge_kind;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod tokenize;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod url_encode_path;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod url_map_handler;
-#[cfg(not(target_arch = "wasm32"))]
-mod symbol_graph_edge_kind;

--- a/tools/src/links.rs
+++ b/tools/src/links.rs
@@ -1,7 +1,7 @@
+use itertools::Itertools;
 use linkify::{LinkFinder, LinkKind};
 use regex::Regex;
 use std::borrow::Cow;
-use itertools::Itertools;
 
 use crate::file_format::config::Config;
 use crate::url_map_handler::get_file_paths_for_url;

--- a/tools/src/links.rs
+++ b/tools/src/links.rs
@@ -84,7 +84,7 @@ pub fn linkify_commit_header(s: &str) -> String {
         let s = linkify_bug_numbers(s);
         WPT_SYNC_REGEX
             .replace_all(
-                &*s,
+                &s,
                 r#"[<a href="https://github.com/web-platform-tests/wpt/pull/$prno">wpt PR $prno</a>]"#,
             )
             .into_owned()

--- a/tools/src/logging.rs
+++ b/tools/src/logging.rs
@@ -64,7 +64,7 @@ impl LoggedSpan {
 
         {
             let mut span_map = SPAN_MAP.lock().unwrap();
-            span_map.insert(id.clone(), tx);
+            span_map.insert(id, tx);
         }
 
         LoggedSpan { span, rx }
@@ -73,8 +73,8 @@ impl LoggedSpan {
     pub async fn retrieve(self) -> Tree {
         info!("logged_span_end");
         drop(self.span);
-        let tree = self.rx.await.unwrap();
-        tree
+
+        self.rx.await.unwrap()
     }
 
     pub async fn retrieve_serde_json(self) -> Value {

--- a/tools/src/logging.rs
+++ b/tools/src/logging.rs
@@ -170,7 +170,6 @@ pub fn init_logging() {
             }),
     );
 
-
     {
         let mut global_opt = LOG_GLOBAL.lock().unwrap();
         *global_opt = Some(LogGlobal { handle });

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -428,11 +428,8 @@ pub fn generate_panel(
             F::Indent(vec![
                 F::T(format!(
                     r#"<span class="navpanel-icon icon-down-dir{}" aria-hidden="false"></span>"#,
-                    if collapsed {
-                        ""
-                    } else {
-                        " expanded"
-                    })),
+                    if collapsed { "" } else { " expanded" }
+                )),
                 F::S("Navigation"),
                 F::T(format!(
                     r#"<a id="show-settings" title="Go to settings page" href="/{}/pages/settings.html"><span class="navpanel-icon icon-cog expanded" aria-hidden="false"></span></a>"#,
@@ -442,21 +439,14 @@ pub fn generate_panel(
             F::S("</button>"),
             F::T(format!(
                 r#"<section id="panel-content" aria-expanded="{}" aria-hidden="{}"{}>"#,
-                if collapsed {
-                    "false"
-                } else {
-                    "true"
-                },
-                if collapsed {
-                    "true"
-                } else {
-                    "false"
-                },
+                if collapsed { "false" } else { "true" },
+                if collapsed { "true" } else { "false" },
                 if collapsed {
                     r#" style="display: none""#
                 } else {
                     ""
-                })),
+                }
+            )),
             F::S(
                 r#"<label class="panel-accel"><input type="checkbox" id="panel-accel-enable" checked="checked">Enable keyboard shortcuts</label>"#,
             ),

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -75,12 +75,8 @@ pub fn generate_breadcrumbs(
         ));
     }
 
-    write!(
-        *writer,
-        "<div class=\"breadcrumbs\">{}</div>\n",
-        breadcrumbs
-    )
-    .map_err(|_| "Write err")?;
+    writeln!(*writer, "<div class=\"breadcrumbs\">{}</div>", breadcrumbs)
+        .map_err(|_| "Write err")?;
 
     Ok(())
 }
@@ -112,13 +108,13 @@ pub fn generate_formatted(
     match *formatted {
         F::Indent(ref seq) => {
             for f in seq {
-                generate_formatted(writer, &f, indent + 1)?;
+                generate_formatted(writer, f, indent + 1)?;
             }
             Ok(())
         }
         F::Seq(ref seq) => {
             for f in seq {
-                generate_formatted(writer, &f, indent)?;
+                generate_formatted(writer, f, indent)?;
             }
             Ok(())
         }
@@ -126,14 +122,14 @@ pub fn generate_formatted(
             for _ in 0..indent {
                 write!(writer, "  ").map_err(|_| "Write err")?;
             }
-            write!(writer, "{}\n", text).map_err(|_| "Write err")?;
+            writeln!(writer, "{}", text).map_err(|_| "Write err")?;
             Ok(())
         }
         F::S(text) => {
             for _ in 0..indent {
                 write!(writer, "  ").map_err(|_| "Write err")?;
             }
-            write!(writer, "{}\n", text).map_err(|_| "Write err")?;
+            writeln!(writer, "{}", text).map_err(|_| "Write err")?;
             Ok(())
         }
     }

--- a/tools/src/query/chew_query.rs
+++ b/tools/src/query/chew_query.rs
@@ -260,7 +260,7 @@ impl PipelineArgs {
                 if oth_pri > ptr.1 {
                     *ptr = (oth_val, oth_pri);
                 }
-        } else {
+            } else {
                 self.named_args.insert(key, (oth_val, oth_pri));
             }
         }

--- a/tools/src/query/chew_query.rs
+++ b/tools/src/query/chew_query.rs
@@ -122,7 +122,7 @@ pub struct QueryPipelineGroupBuilder {
     pub phases: Vec<PipelinePhase>,
 }
 
-fn apply_transforms(user_val: String, transforms: &Vec<String>) -> String {
+fn apply_transforms(user_val: String, transforms: &[String]) -> String {
     let mut val = user_val;
     for transform in transforms.iter() {
         val = match transform.as_str() {

--- a/tools/src/templating/builder.rs
+++ b/tools/src/templating/builder.rs
@@ -3,7 +3,10 @@ use std::borrow;
 use include_dir::{include_dir, Dir};
 use liquid::Template;
 
-use super::liquid_exts::{CompactPathlikeFilterParser, FileExtFilterParser, JsonFilterParser, StripPrefixOrEmptyFilterParser, EnsureBugUrlFilterParser};
+use super::liquid_exts::{
+    CompactPathlikeFilterParser, EnsureBugUrlFilterParser, FileExtFilterParser, JsonFilterParser,
+    StripPrefixOrEmptyFilterParser,
+};
 
 static TEMPLATE_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/templates");
 

--- a/tools/src/templating/builder.rs
+++ b/tools/src/templating/builder.rs
@@ -24,7 +24,7 @@ impl liquid::partials::PartialSource for StaticTemplateSource {
 
     fn try_get<'a>(&'a self, name: &str) -> Option<borrow::Cow<'a, str>> {
         match TEMPLATE_DIR.get_file(name) {
-            Some(file) => file.contents_utf8().map(|s| borrow::Cow::from(s)),
+            Some(file) => file.contents_utf8().map(borrow::Cow::from),
             _ => None,
         }
     }

--- a/tools/src/templating/liquid_exts.rs
+++ b/tools/src/templating/liquid_exts.rs
@@ -95,12 +95,14 @@ struct EnsureBugUrlFilter;
 
 impl Filter for EnsureBugUrlFilter {
     fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
-
         let s = input.to_kstr();
         if s.starts_with(&"http") {
             Ok(Value::scalar(s.to_string()))
         } else {
-            Ok(Value::scalar(format!("https://bugzilla.mozilla.org/show_bug.cgi?id={}", s)))
+            Ok(Value::scalar(format!(
+                "https://bugzilla.mozilla.org/show_bug.cgi?id={}",
+                s
+            )))
         }
     }
 }

--- a/tools/src/templating/liquid_exts.rs
+++ b/tools/src/templating/liquid_exts.rs
@@ -96,7 +96,7 @@ struct EnsureBugUrlFilter;
 impl Filter for EnsureBugUrlFilter {
     fn evaluate(&self, input: &dyn ValueView, _runtime: &dyn Runtime) -> Result<Value> {
         let s = input.to_kstr();
-        if s.starts_with(&"http") {
+        if s.starts_with("http") {
             Ok(Value::scalar(s.to_string()))
         } else {
             Ok(Value::scalar(format!(

--- a/tools/src/templating/mod.rs
+++ b/tools/src/templating/mod.rs
@@ -1,3 +1,2 @@
 pub mod builder;
 pub mod liquid_exts;
-

--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -923,8 +923,8 @@ pub fn tokenize_tag_like(string: &str, script_spec: &LanguageSpec) -> Vec<Token>
 
         match tag_state {
             TagState::TagNone(plain_start) => {
-                let skip = (in_script_tag && !peek_ahead("/script")) ||
-                    (in_style_tag && !peek_ahead("/style"));
+                let skip = (in_script_tag && !peek_ahead("/script"))
+                    || (in_style_tag && !peek_ahead("/style"));
                 if ch == '<' && !skip {
                     if plain_start < start {
                         tokens.push(Token {
@@ -1660,9 +1660,7 @@ mod tests {
 
         check(
             "/foo/",
-            &vec![
-                ("/foo/", TokenKind::RegularExpressionLiteral),
-            ],
+            &vec![("/foo/", TokenKind::RegularExpressionLiteral)],
         );
         check(
             "v = /foo/;",
@@ -1868,7 +1866,10 @@ mod tests {
                 ("=", TokenKind::Punctuation),
                 (">", TokenKind::Punctuation),
                 ("{", TokenKind::Punctuation),
-                ("return", TokenKind::Identifier(Some("class=\"syn_reserved\" ".to_string()))),
+                (
+                    "return",
+                    TokenKind::Identifier(Some("class=\"syn_reserved\" ".to_string())),
+                ),
                 ("/foo/", TokenKind::RegularExpressionLiteral),
                 (";", TokenKind::Punctuation),
                 ("}", TokenKind::Punctuation),

--- a/tools/src/tokenize.rs
+++ b/tools/src/tokenize.rs
@@ -883,7 +883,7 @@ pub fn tokenize_tag_like(string: &str, script_spec: &LanguageSpec) -> Vec<Token>
         }
         let sub = &chars[p..p + s.len()];
         let sub = sub.iter().map(|&(_, ch)| ch).collect::<String>();
-        &sub == s
+        sub == s
     };
 
     let peek_pos = || {

--- a/tools/src/tree_sitter_support/cst_tokenizer.rs
+++ b/tools/src/tree_sitter_support/cst_tokenizer.rs
@@ -13,10 +13,10 @@ fn load_language_queries(
 ) -> Result<tree_sitter::Query, String> {
     match QUERIES_DIR.get_file(format!("{}.scm", lang_str)) {
         Some(file) => {
-            let maybe_contents = file.contents_utf8().map(|s| borrow::Cow::from(s));
+            let maybe_contents = file.contents_utf8().map(borrow::Cow::from);
             match maybe_contents {
                 Some(contents) => {
-                    tree_sitter::Query::new(&ts_lang, &contents).map_err(|ts_err| ts_err.message)
+                    tree_sitter::Query::new(ts_lang, &contents).map_err(|ts_err| ts_err.message)
                 }
                 _ => Err(format!("No queries for lang: {}", lang_str)),
             }
@@ -291,9 +291,9 @@ pub fn hypertokenize_source_file(
         }
     }
 
-    return Ok(HyperTokenized {
+    Ok(HyperTokenized {
         lang: lang.to_string(),
         tokenized,
         structure,
-    });
+    })
 }

--- a/tools/src/url_encode_path.rs
+++ b/tools/src/url_encode_path.rs
@@ -1,9 +1,8 @@
-use urlencoding;
 use std::borrow::Cow;
+use urlencoding;
 
 pub fn url_encode_path(path: &str) -> String {
-    path
-        .split('/')
+    path.split('/')
         .map(|p| urlencoding::encode(p))
         .collect::<Vec<Cow<'_, str>>>()
         .join("/")
@@ -12,6 +11,6 @@ pub fn url_encode_path(path: &str) -> String {
 pub fn url_decode_path(path: &str) -> String {
     match urlencoding::decode(path) {
         Ok(s) => s.to_string(),
-        Err(_) => path.to_string()
+        Err(_) => path.to_string(),
     }
 }

--- a/tools/src/url_map_handler.rs
+++ b/tools/src/url_map_handler.rs
@@ -1,23 +1,23 @@
-use std::sync::OnceLock;
-use crate::file_format::config::Config;
-use crate::file_format::url_map::{ URLMap, URLMapItem, read_url_map };
 use crate::file_format::analysis_manglings::mangle_file;
+use crate::file_format::config::Config;
+use crate::file_format::url_map::{read_url_map, URLMap, URLMapItem};
+use std::sync::OnceLock;
 
 pub fn get_file_paths_for_url(cfg: Option<&Config>, url: &str) -> Option<Vec<URLMapItem>> {
     static URL_MAP: OnceLock<URLMap> = OnceLock::new();
 
     if URL_MAP.get().is_none() {
-        URL_MAP.set(match cfg {
-            Some(cfg) => {
-                match &cfg.url_map_path {
+        URL_MAP
+            .set(match cfg {
+                Some(cfg) => match &cfg.url_map_path {
                     Some(url_map_path) => read_url_map(url_map_path),
-                    None => URLMap::new_empty()
-                }
-            },
-            None => URLMap::new_empty(),
-        }).unwrap();
+                    None => URLMap::new_empty(),
+                },
+                None => URLMap::new_empty(),
+            })
+            .unwrap();
     }
 
     let url_map_key = format!("URL_{}", mangle_file(url));
-    return URL_MAP.get().unwrap().get(&url_map_key)
+    return URL_MAP.get().unwrap().get(&url_map_key);
 }

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -1,6 +1,4 @@
-use std::{
-    str,
-};
+use std::str;
 
 use serde_json::{json, to_value};
 use tokio::fs::{create_dir_all, read_to_string, write};
@@ -8,7 +6,8 @@ use tools::{
     abstract_server::ServerError,
     cmd_pipeline::{build_pipeline, PipelineValues},
     glob_helper::block_in_place_glob_tree,
-    templating::builder::build_and_parse_pipeline_explainer, logging::{init_logging, LoggedSpan},
+    logging::{init_logging, LoggedSpan},
+    templating::builder::build_and_parse_pipeline_explainer,
 };
 use tracing::Instrument;
 
@@ -49,7 +48,7 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
 
         for (rel_path, filename) in input_names {
             if filename.ends_with("~") {
-                continue
+                continue;
             }
 
             let input_path = format!("{}/inputs/{}{}", check_root, rel_path, filename);
@@ -153,7 +152,8 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                         }
                     }
                 })
-                .instrument(logged_span.span.clone()).await;
+                .instrument(logged_span.span.clone())
+                .await;
 
             let log_values = logged_span.retrieve_serde_json().await;
 

--- a/tools/tests/test_check_insta.rs
+++ b/tools/tests/test_check_insta.rs
@@ -66,7 +66,7 @@ async fn test_check_glob() -> Result<(), std::io::Error> {
                 .bind_async(async {
                     let command = read_to_string(input_path).await.unwrap();
 
-                    let pipeline = match build_pipeline(&"searchfox-tool", &command) {
+                    let pipeline = match build_pipeline("searchfox-tool", &command) {
                         Ok((pipeline, _)) => pipeline,
                         Err(err) => {
                             insta::assert_snapshot!(format!("Pipeline Build Error: {:?}", err));


### PR DESCRIPTION
I like using reformat on save in Kate so I don't have to worry about styling, but had to disable it every time I switched from other projects to mozsearch. Some formatting was very off, like merge_files in merger.rs which used 2+4n spaces for indent.

This applies rustfmt in tools, clang-format 19 (with LLVM style) in clang-plugin and also fixes a couple of Clippy lints to make the rust-analyzer output less noisy.

I know this won't hold long without CI enforcement though.