### PR TITLE
Bug 1833555 - Mark OverloadExpr locations to be visited in instantiations.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2526,6 +2526,12 @@ public:
     for (auto *Candidate : E->decls()) {
       visitHeuristicResult(Loc, Candidate);
     }
+
+    // Also record this location so that if we have instantiations, we can
+    // gather more accurate results from them.
+    if (TemplateStack) {
+      TemplateStack->visitDependent(Loc);
+    }
     return true;
   }
 

--- a/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/WithOverloads_Overloaded
+++ b/tests/tests/checks/inputs/analysis/cpp/bug1781178.cpp/WithOverloads_Overloaded
@@ -1,0 +1,1 @@
+filter-analysis bug1781178.cpp -i WithOverloads::Overloaded

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@WithOverloads_Overloaded.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@WithOverloads_Overloaded.snap
@@ -1,0 +1,129 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+snapshot_kind: text
+---
+[
+  {
+    "loc": "00076:14-24",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (int)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEi"
+  },
+  {
+    "loc": "00076:14-24",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEi",
+    "context": "WithOverloads",
+    "contextsym": "T_WithOverloads",
+    "peekRange": "76-76"
+  },
+  {
+    "loc": "00077:14-24",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (float)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEf"
+  },
+  {
+    "loc": "00077:14-24",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEf",
+    "context": "WithOverloads",
+    "contextsym": "T_WithOverloads",
+    "peekRange": "77-77"
+  },
+  {
+    "loc": "00078:14-24",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (_Bool)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb"
+  },
+  {
+    "loc": "00078:14-24",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb",
+    "context": "WithOverloads",
+    "contextsym": "T_WithOverloads",
+    "peekRange": "78-78"
+  },
+  {
+    "loc": "00082:4-14",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (_Bool)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb",
+    "confidence": [
+      "cppTemplateHeuristic"
+    ]
+  },
+  {
+    "loc": "00082:4-14",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (float)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEf",
+    "confidence": [
+      "cppTemplateHeuristic"
+    ]
+  },
+  {
+    "loc": "00082:4-14",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (int)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEi",
+    "confidence": [
+      "cppTemplateHeuristic"
+    ]
+  },
+  {
+    "loc": "00082:4-14",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (int)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEi"
+  },
+  {
+    "loc": "00082:4-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb",
+    "context": "WithOverloads::Caller",
+    "contextsym": "_ZN13WithOverloads6CallerEv"
+  },
+  {
+    "loc": "00082:4-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEf",
+    "context": "WithOverloads::Caller",
+    "contextsym": "_ZN13WithOverloads6CallerEv"
+  },
+  {
+    "loc": "00082:4-14",
+    "target": 1,
+    "kind": "use",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEi",
+    "context": "WithOverloads::Caller",
+    "contextsym": "_ZN13WithOverloads6CallerEv"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -225,7 +225,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/bug1781178.cpp" class="mimetype-fixed-container mimetype-icon-cpp">bug1781178.cpp</a></td>
           <td class="description"><a href="/tests/source/bug1781178.cpp" title=""></td>
-          <td><a href="/tests/source/bug1781178.cpp">1037</a></td>
+          <td><a href="/tests/source/bug1781178.cpp">1291</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/bug1781178.cpp
+++ b/tests/tests/files/bug1781178.cpp
@@ -71,3 +71,16 @@ void func() {
 }
 
 void test() { func<Foo<int>>(); }
+
+struct WithOverloads {
+  static void Overloaded(int);
+  static void Overloaded(float);
+  static void Overloaded(bool);
+
+  template <typename T>
+  static void Caller() {
+    Overloaded(T());
+  }
+};
+
+void test_overload() { WithOverloads::Caller<int>(); }


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1833555

Now that the context menu allows for differentiating between heuristic and concrete template instantiations, mark OverloadExpr location to be visited in AnalyzeDependent mode to have concrete results.

In the added WithOverloads::Overloaded test case, the float and bool overloads are only found heuristically (and are thus marked with cppTemplateHeuristic) while the int overload is also found by visiting concrete template instantiations.