### PR TITLE
Bug 1933325 - Link calls to emplace-like functions to the constructors they invoke.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1181,6 +1181,15 @@ public:
     AutoTemplateContext Atc(this);
     Super::TraverseClassTemplateDecl(D);
 
+    // Gather dependent locations from partial specializations too
+    SmallVector<ClassTemplatePartialSpecializationDecl *> PS;
+    D->getPartialSpecializations(PS);
+    for (auto *Spec : PS) {
+      for (auto *Rd : Spec->redecls()) {
+        TraverseDecl(Rd);
+      }
+    }
+
     if (!Atc.needsAnalysis()) {
       return true;
     }

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2144,11 +2144,6 @@ public:
   }
 
   bool VisitCXXConstructExpr(const CXXConstructExpr *E) {
-    SourceLocation Loc = E->getBeginLoc();
-    if (!isInterestingLocation(Loc)) {
-      return true;
-    }
-
     // If we are in a template and find a Stmt that was registed in
     // ForwardedTemplateLocations, convert the location to an actual Stmt* in
     // ForwardingTemplates
@@ -2159,6 +2154,11 @@ public:
             {getCurrentFunctionTemplateInstantiation(), E});
         return true;
       }
+    }
+
+    SourceLocation Loc = E->getBeginLoc();
+    if (!isInterestingLocation(Loc)) {
+      return true;
     }
 
     return VisitCXXConstructExpr(E, Loc);
@@ -2556,12 +2556,6 @@ public:
   }
 
   bool VisitCXXNewExpr(CXXNewExpr *N) {
-    SourceLocation Loc = N->getExprLoc();
-    normalizeLocation(&Loc);
-    if (!isInterestingLocation(Loc)) {
-      return true;
-    }
-
     // If we are in a template and the new is type-dependent, register it in
     // ForwardedTemplateLocations to forward its uses to the surrounding
     // template call site

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2197,8 +2197,10 @@ public:
     if (TemplateStack && !TemplateStack->inGatherMode()) {
       if (ForwardedTemplateLocations.find(E->getBeginLoc().getRawEncoding()) !=
           ForwardedTemplateLocations.end()) {
-        ForwardingTemplates.insert(
-            {getCurrentFunctionTemplateInstantiation(), E});
+        if (const auto *currentTemplate =
+                getCurrentFunctionTemplateInstantiation()) {
+          ForwardingTemplates.insert({currentTemplate, E});
+        }
         return true;
       }
     }
@@ -2264,8 +2266,10 @@ public:
       } else {
         if (ForwardedTemplateLocations.find(CalleeLocation.getRawEncoding()) !=
             ForwardedTemplateLocations.end()) {
-          ForwardingTemplates.insert(
-              {getCurrentFunctionTemplateInstantiation(), E});
+          if (const auto *currentTemplate =
+                  getCurrentFunctionTemplateInstantiation()) {
+            ForwardingTemplates.insert({currentTemplate, E});
+          }
         }
       }
     }

--- a/tests/tests/checks/inputs/analysis/cpp/template_specialization.cpp/some_function_called_in_partial_specialization
+++ b/tests/tests/checks/inputs/analysis/cpp/template_specialization.cpp/some_function_called_in_partial_specialization
@@ -1,0 +1,1 @@
+filter-analysis template_specialization.cpp -i SomeStruct::some_function

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
@@ -5,16 +5,16 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00084:2-21",
+    "loc": "00085:2-21",
     "source": 1,
-    "nestingRange": "84:24-84:25",
+    "nestingRange": "85:24-85:25",
     "syntax": "def,function",
     "type": "void (void)",
     "pretty": "function StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00084:2-21",
+    "loc": "00085:2-21",
     "structured": 1,
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev",
@@ -28,7 +28,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00084:2-21",
+    "loc": "00085:2-21",
     "target": 1,
     "kind": "def",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
@@ -37,14 +37,14 @@ snapshot_kind: text
     "contextsym": "T_StructUsedInEmplace"
   },
   {
-    "loc": "00089:4-18",
+    "loc": "00090:4-18",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00089:4-18",
+    "loc": "00090:4-18",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
@@ -53,14 +53,30 @@ snapshot_kind: text
     "contextsym": "_Z9use_maybev"
   },
   {
-    "loc": "00090:4-23",
+    "loc": "00091:4-23",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00090:4-23",
+    "loc": "00091:4-23",
+    "target": 1,
+    "kind": "use",
+    "pretty": "StructUsedInEmplace::StructUsedInEmplace",
+    "sym": "_ZN19StructUsedInEmplaceC1Ev",
+    "context": "use_maybe",
+    "contextsym": "_Z9use_maybev"
+  },
+  {
+    "loc": "00094:4-16",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
+    "sym": "_ZN19StructUsedInEmplaceC1Ev"
+  },
+  {
+    "loc": "00094:4-16",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
@@ -5,16 +5,16 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00072:2-21",
+    "loc": "00084:2-21",
     "source": 1,
-    "nestingRange": "72:24-72:25",
+    "nestingRange": "84:24-84:25",
     "syntax": "def,function",
     "type": "void (void)",
     "pretty": "function StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00072:2-21",
+    "loc": "00084:2-21",
     "structured": 1,
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev",
@@ -28,7 +28,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00072:2-21",
+    "loc": "00084:2-21",
     "target": 1,
     "kind": "def",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
@@ -37,14 +37,30 @@ snapshot_kind: text
     "contextsym": "T_StructUsedInEmplace"
   },
   {
-    "loc": "00077:4-11",
+    "loc": "00089:4-18",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00077:4-11",
+    "loc": "00089:4-18",
+    "target": 1,
+    "kind": "use",
+    "pretty": "StructUsedInEmplace::StructUsedInEmplace",
+    "sym": "_ZN19StructUsedInEmplaceC1Ev",
+    "context": "use_maybe",
+    "contextsym": "_Z9use_maybev"
+  },
+  {
+    "loc": "00090:4-23",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
+    "sym": "_ZN19StructUsedInEmplaceC1Ev"
+  },
+  {
+    "loc": "00090:4-23",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInMethodReportedAtCallSite.snap
@@ -5,16 +5,16 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00070:2-21",
+    "loc": "00072:2-21",
     "source": 1,
-    "nestingRange": "70:24-70:25",
+    "nestingRange": "72:24-72:25",
     "syntax": "def,function",
     "type": "void (void)",
     "pretty": "function StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00070:2-21",
+    "loc": "00072:2-21",
     "structured": 1,
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev",
@@ -28,7 +28,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00070:2-21",
+    "loc": "00072:2-21",
     "target": 1,
     "kind": "def",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",
@@ -37,14 +37,14 @@ snapshot_kind: text
     "contextsym": "T_StructUsedInEmplace"
   },
   {
-    "loc": "00075:4-11",
+    "loc": "00077:4-11",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInEmplace::StructUsedInEmplace",
     "sym": "_ZN19StructUsedInEmplaceC1Ev"
   },
   {
-    "loc": "00075:4-11",
+    "loc": "00077:4-11",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInEmplace::StructUsedInEmplace",

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInTemplateReportedAtCallSite.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInTemplateReportedAtCallSite.snap
@@ -163,5 +163,21 @@ snapshot_kind: text
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev",
     "context": "test",
     "contextsym": "_Z4testv"
+  },
+  {
+    "loc": "00058:24-35",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
+    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
+  },
+  {
+    "loc": "00058:24-35",
+    "target": 1,
+    "kind": "use",
+    "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
+    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev",
+    "context": "test",
+    "contextsym": "_Z4testv"
   }
 ]

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInTemplateReportedAtCallSite.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeDependentNewInTemplateReportedAtCallSite.snap
@@ -5,16 +5,16 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00004:2-31",
+    "loc": "00005:2-31",
     "source": 1,
-    "nestingRange": "4:34-4:35",
+    "nestingRange": "5:34-5:35",
     "syntax": "def,function",
     "type": "void (void)",
     "pretty": "function StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
   },
   {
-    "loc": "00004:2-31",
+    "loc": "00005:2-31",
     "structured": 1,
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev",
@@ -28,7 +28,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00004:2-31",
+    "loc": "00005:2-31",
     "target": 1,
     "kind": "def",
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
@@ -37,22 +37,6 @@ snapshot_kind: text
     "contextsym": "T_StructUsedInTypeDependentNew0"
   },
   {
-    "loc": "00041:17-36",
-    "source": 1,
-    "syntax": "use,constructor",
-    "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
-    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
-  },
-  {
-    "loc": "00041:17-36",
-    "target": 1,
-    "kind": "use",
-    "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
-    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev",
-    "context": "test",
-    "contextsym": "_Z4testv"
-  },
-  {
     "loc": "00042:17-36",
     "source": 1,
     "syntax": "use,constructor",
@@ -69,14 +53,14 @@ snapshot_kind: text
     "contextsym": "_Z4testv"
   },
   {
-    "loc": "00045:17-27",
+    "loc": "00043:17-36",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
   },
   {
-    "loc": "00045:17-27",
+    "loc": "00043:17-36",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
@@ -101,14 +85,14 @@ snapshot_kind: text
     "contextsym": "_Z4testv"
   },
   {
-    "loc": "00049:17-36",
+    "loc": "00047:17-27",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
   },
   {
-    "loc": "00049:17-36",
+    "loc": "00047:17-27",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
@@ -133,14 +117,14 @@ snapshot_kind: text
     "contextsym": "_Z4testv"
   },
   {
-    "loc": "00053:17-37",
+    "loc": "00051:17-36",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
   },
   {
-    "loc": "00053:17-37",
+    "loc": "00051:17-36",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
@@ -165,14 +149,30 @@ snapshot_kind: text
     "contextsym": "_Z4testv"
   },
   {
-    "loc": "00058:24-35",
+    "loc": "00055:17-37",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
     "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
   },
   {
-    "loc": "00058:24-35",
+    "loc": "00055:17-37",
+    "target": 1,
+    "kind": "use",
+    "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
+    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev",
+    "context": "test",
+    "contextsym": "_Z4testv"
+  },
+  {
+    "loc": "00059:24-35",
+    "source": 1,
+    "syntax": "use,constructor",
+    "pretty": "constructor StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",
+    "sym": "_ZN29StructUsedInTypeDependentNew0C1Ev"
+  },
+  {
+    "loc": "00059:24-35",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeDependentNew0::StructUsedInTypeDependentNew0",

--- a/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeIndependentNewInTemplateReportedInTemplate.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/ForwardingTemplates.cpp/check_glob@TypeIndependentNewInTemplateReportedInTemplate.snap
@@ -5,16 +5,16 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00012:2-32",
+    "loc": "00013:2-32",
     "source": 1,
-    "nestingRange": "12:35-12:36",
+    "nestingRange": "13:35-13:36",
     "syntax": "def,function",
     "type": "void (void)",
     "pretty": "function StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
     "sym": "_ZN30StructUsedInTypeIndependentNewC1Ev"
   },
   {
-    "loc": "00012:2-32",
+    "loc": "00013:2-32",
     "structured": 1,
     "pretty": "StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
     "sym": "_ZN30StructUsedInTypeIndependentNewC1Ev",
@@ -28,7 +28,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00012:2-32",
+    "loc": "00013:2-32",
     "target": 1,
     "kind": "def",
     "pretty": "StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
@@ -37,14 +37,14 @@ snapshot_kind: text
     "contextsym": "T_StructUsedInTypeIndependentNew"
   },
   {
-    "loc": "00018:10-40",
+    "loc": "00019:10-40",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
     "sym": "_ZN30StructUsedInTypeIndependentNewC1Ev"
   },
   {
-    "loc": "00018:10-40",
+    "loc": "00019:10-40",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
@@ -53,14 +53,14 @@ snapshot_kind: text
     "contextsym": "_Z19MakeUniqueWithIndexiDpOT0_"
   },
   {
-    "loc": "00025:10-40",
+    "loc": "00026:10-40",
     "source": 1,
     "syntax": "use,constructor",
     "pretty": "constructor StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",
     "sym": "_ZN30StructUsedInTypeIndependentNewC1Ev"
   },
   {
-    "loc": "00025:10-40",
+    "loc": "00026:10-40",
     "target": 1,
     "kind": "use",
     "pretty": "StructUsedInTypeIndependentNew::StructUsedInTypeIndependentNew",

--- a/tests/tests/checks/snapshots/analysis/cpp/template_specialization.cpp/check_glob@some_function_called_in_partial_specialization.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/template_specialization.cpp/check_glob@some_function_called_in_partial_specialization.snap
@@ -1,0 +1,42 @@
+---
+source: tests/test_check_insta.rs
+expression: "&json_results"
+snapshot_kind: text
+---
+[
+  {
+    "loc": "00002:14-27",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (void)",
+    "pretty": "function SomeStruct::some_function",
+    "sym": "_ZN10SomeStruct13some_functionEv"
+  },
+  {
+    "loc": "00002:14-27",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "SomeStruct::some_function",
+    "sym": "_ZN10SomeStruct13some_functionEv",
+    "context": "SomeStruct",
+    "contextsym": "T_SomeStruct",
+    "peekRange": "2-2"
+  },
+  {
+    "loc": "00010:35-48",
+    "source": 1,
+    "syntax": "use,function",
+    "type": "void (void)",
+    "pretty": "function SomeStruct::some_function",
+    "sym": "_ZN10SomeStruct13some_functionEv"
+  },
+  {
+    "loc": "00010:35-48",
+    "target": 1,
+    "kind": "use",
+    "pretty": "SomeStruct::some_function",
+    "sym": "_ZN10SomeStruct13some_functionEv",
+    "context": "SomeTemplate<int, type-parameter-0-0>::call_function",
+    "contextsym": "_ZN12SomeTemplateIiT_E13call_functionEv"
+  }
+]

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -303,7 +303,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/ForwardingTemplates.cpp" class="mimetype-fixed-container mimetype-icon-cpp">ForwardingTemplates.cpp</a></td>
           <td class="description"><a href="/tests/source/ForwardingTemplates.cpp" title=""></td>
-          <td><a href="/tests/source/ForwardingTemplates.cpp">2705</a></td>
+          <td><a href="/tests/source/ForwardingTemplates.cpp">3012</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -615,6 +615,12 @@ Spread over multiple lines.
         </tr>
 
         <tr>
+          <td><a href="/tests/source/template_specialization.cpp" class="mimetype-fixed-container mimetype-icon-cpp">template_specialization.cpp</a></td>
+          <td class="description"><a href="/tests/source/template_specialization.cpp" title=""></td>
+          <td><a href="/tests/source/template_specialization.cpp">288</a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/templates_nsTArray.cpp" class="mimetype-fixed-container mimetype-icon-cpp">templates_nsTArray.cpp</a></td>
           <td class="description"><a href="/tests/source/templates_nsTArray.cpp" title=""></td>
           <td><a href="/tests/source/templates_nsTArray.cpp">123</a></td>

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -303,7 +303,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/ForwardingTemplates.cpp" class="mimetype-fixed-container mimetype-icon-cpp">ForwardingTemplates.cpp</a></td>
           <td class="description"><a href="/tests/source/ForwardingTemplates.cpp" title=""></td>
-          <td><a href="/tests/source/ForwardingTemplates.cpp">2634</a></td>
+          <td><a href="/tests/source/ForwardingTemplates.cpp">2705</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -303,7 +303,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/ForwardingTemplates.cpp" class="mimetype-fixed-container mimetype-icon-cpp">ForwardingTemplates.cpp</a></td>
           <td class="description"><a href="/tests/source/ForwardingTemplates.cpp" title=""></td>
-          <td><a href="/tests/source/ForwardingTemplates.cpp">3012</a></td>
+          <td><a href="/tests/source/ForwardingTemplates.cpp">3089</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/ForwardingTemplates.cpp
+++ b/tests/tests/files/ForwardingTemplates.cpp
@@ -59,14 +59,26 @@ void test() {
 }
 
 template <typename T>
+struct Maybe;
+
+template <typename T>
 struct Maybe {
   char storage[sizeof(T)];
 
   template <typename... Args>
-  void emplace(Args&&... args) {
+  void emplace_inline(Args&&... args) {
     new (storage) T(std::forward<Args>(args)...);
   }
+
+  template <typename... Args>
+  void emplace_out_of_line(Args&&... args);
 };
+
+template <typename T>
+template <typename... Args>
+void Maybe<T>::emplace_out_of_line(Args&&... args) {
+  new (storage) T(std::forward<Args>(args)...);
+}
 
 struct StructUsedInEmplace {
   StructUsedInEmplace() {}
@@ -74,5 +86,6 @@ struct StructUsedInEmplace {
 
 void use_maybe() {
   Maybe<StructUsedInEmplace> m;
-  m.emplace();
+  m.emplace_inline();
+  m.emplace_out_of_line();
 }

--- a/tests/tests/files/ForwardingTemplates.cpp
+++ b/tests/tests/files/ForwardingTemplates.cpp
@@ -54,6 +54,8 @@ void test() {
   const auto n = MakeUniqueWithLambda<StructUsedInTypeDependentNew0>();
   const auto o = MakeUniqueWithLambda<StructUsedInTypeDependentNew1>();
   const auto p = MakeUniqueWithLambda<StructUsedInTypeDependentNew1>();
+
+  const auto stl = std::make_unique<StructUsedInTypeDependentNew0>();
 }
 
 template <typename T>

--- a/tests/tests/files/ForwardingTemplates.cpp
+++ b/tests/tests/files/ForwardingTemplates.cpp
@@ -1,4 +1,5 @@
 #include <memory>
+#include <vector>
 
 struct StructUsedInTypeDependentNew0 {
   StructUsedInTypeDependentNew0() {}
@@ -88,4 +89,7 @@ void use_maybe() {
   Maybe<StructUsedInEmplace> m;
   m.emplace_inline();
   m.emplace_out_of_line();
+
+  std::vector<StructUsedInEmplace> v;
+  v.emplace_back();
 }

--- a/tests/tests/files/template_specialization.cpp
+++ b/tests/tests/files/template_specialization.cpp
@@ -1,0 +1,13 @@
+struct SomeStruct {
+  static void some_function();
+};
+
+template <typename T, typename U>
+struct SomeTemplate {};
+
+template <typename U>
+struct SomeTemplate<int, U> {
+  static void call_function() { U::some_function(); }
+};
+
+void test() { SomeTemplate<int, SomeStruct>::call_function(); }


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1933325

This adds the missing bits to be able to get std::vector::emplace_back<T> appear as constructor calls for T.