### PR TITLE
Bug 1671640 - Add the ability to suppress warnings from the warnings email

### DIFF
--- a/infrastructure/aws/index.sh
+++ b/infrastructure/aws/index.sh
@@ -123,7 +123,7 @@ release* )
     ;;
 esac
 
-$AWS_ROOT/send-warning-email.py "$CHANNEL/$BRANCH" "$DEST_EMAIL"
+$AWS_ROOT/send-warning-email.py "$AWS_ROOT/warning-suppression.patterns" "$CHANNEL/$BRANCH" "$DEST_EMAIL" /home/ubuntu/index-log
 
 gzip -k ~ubuntu/index-log
 $AWS_ROOT/upload.py ~ubuntu/index-log.gz indexer-logs "index-$(date -Iminutes)_${CHANNEL}_${CONFIG_FILE_NAME%.*}.gz"

--- a/infrastructure/aws/send-warning-email.py
+++ b/infrastructure/aws/send-warning-email.py
@@ -7,15 +7,32 @@ import os
 import subprocess
 
 client = boto3.client('ses')
-subj_prefix = sys.argv[1]
-dest_email = sys.argv[2]
+suppression_file = sys.argv[1]
+subj_prefix = sys.argv[2]
+dest_email = sys.argv[3]
+log_location = sys.argv[4]
 warning_limit = "50"
 
-try:
-    # The regex here intentionally matches any `warn!` logger output from rust code
-    warnings = subprocess.check_output(["grep", "-B16", "-i", "-m", warning_limit, "-P", "^([ ]*|\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z )warn", "/home/ubuntu/index-log"])
-except subprocess.CalledProcessError:
+# We use the idiom described at
+# https://docs.python.org/3/library/subprocess.html#replacing-shell-pipeline
+# to run a grep that first excludes any warnings we don't care about and
+# then pipe that to our grep that finds warnings and provides "before"
+# context.
+suppress_proc = subprocess.Popen(["grep", "--invert-match", "-f", suppression_file, log_location], stdout=subprocess.PIPE)
+
+# The regex here intentionally matches any `warn!` logger output from rust code
+matches_proc = subprocess.Popen(["grep", "-B16", "-i", "-m", warning_limit, "-P", "^([ ]*|\\[\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z )warn", '-'],
+                                stdin=suppress_proc.stdout,
+                                stdout=subprocess.PIPE)
+suppress_proc.stdout.close() # allow SIGPIPE from matches_proc to suppress_proc
+warnings, _ =  matches_proc.communicate()
+
+if matches_proc.returncode:
     # grep found no matches, so no need to send this email
+    sys.exit(0)
+
+if dest_email == "test":
+    print("warnings:\n", warnings.decode())
     sys.exit(0)
 
 warnings = warnings.decode('utf-8', 'replace')

--- a/infrastructure/aws/warning-suppression.patterns
+++ b/infrastructure/aws/warning-suppression.patterns
@@ -1,0 +1,1 @@
+^Warning: The unit file, source configuration file or drop-ins of


### PR DESCRIPTION
Run our log file through a `grep --invert-match` against the new file `infrastructure/aws/warning-suppression.patterns` which we then pipe into the grep that looks for warnings.  We don't provide line numbers in the email so the omitted lines shouldn't matter, although we could always just replace those lines with blank lines if we started doing that.

To help with testing this, I made a few minor other changes:
- If the email address is "test" we just dump the warnings to stdout.
- I made the log path into an argument rather than the hardcoded path.

So I was able to download the config5 indexer log and run the following and observe that with an empty suppression file we would print out warnings, and with the new suppression in place that's in this commit we early return from the script before both the "test" mode logic and the email sending:
```
infrastructure/aws/send-warning-email.py infrastructure/aws/warning-suppression.patterns FOO test index-log
```