### PR TITLE
Populate jumpref table even for no_crossref symbols

### DIFF
--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -485,6 +485,12 @@ async fn main() {
             &mut id_table,
         );
 
+        // For now, infer whether a structured record is for a no_crossref
+        // symbol from its kind.
+        let is_nocrossref = |structured: &AnalysisStructured| {
+          return structured.kind == "localVar" || structured.kind == "parameter";
+        };
+
         // We process the structured records before checking for the source file
         // to allow us to ingest the structured records from SCIP indexing that
         // do not actually correspond to a source file.  This is the case for
@@ -508,6 +514,8 @@ async fn main() {
                     // the table, even if it's empty, so that when we're
                     // building the crossref, the structured record gets emitted.
                     table.entry(piece.sym).or_default();
+                } else if is_nocrossref(&piece) {
+                  table.entry(piece.sym).or_default();
                 }
                 process_analysis_structured(
                     piece,


### PR DESCRIPTION
Not sure whether this makes sense to land in isolation -- it's part of my [semantic tokens WIP](https://github.com/theres-waldo/mozsearch/pull/1), but it's a self-contained change and the only one I've had to make to `crossref.rs` thus far.

I did take a slight shortcut to infer the "no crossref" status of a symbol based on its kind (local var or parameter, matching the [two](https://searchfox.org/mozilla-central/rev/a4935c8cb9edb35981871dee4a9132ab3e77d92b/build/clang-plugin/mozsearch-plugin/MozsearchIndexer.cpp#1986) [cases](https://searchfox.org/mozilla-central/source/build/clang-plugin/mozsearch-plugin/MozsearchIndexer.cpp#2363) where we set this flag in the indexer). I figured we could leave the explicit storing of this info (whether in `AnalysisStructured::impl_kind`, or a new field) to a future enhancement, but if you'd prefer to do it that way from the start, I can revise the approach.