### PR TITLE
Bug 1933960 - Fallback to concrete confidence when data-confidences is missing.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -393,7 +393,12 @@ var ContextMenu = new (class ContextMenu extends ContextMenuBase {
       }
 
       let symbols = symbolToken.getAttribute("data-symbols").split(",");
-      const confidences = JSON.parse(symbolToken.getAttribute("data-confidences"));
+      let confidences = JSON.parse(symbolToken.getAttribute("data-confidences"));
+      // if data-confidences is missing, assume everything is concrete
+      if (!confidences) {
+        confidences = Array(symbols.length);
+        confidences.fill("concrete");
+      }
 
       const seenSyms = new Set();
       // For debugging/investigation purposes, expose the symbols that got


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1933960

When implementing bug 1833552 I assumed we would always have the data-confidences attribute next to the data-symbols attribute. This isn't the case for diagrams at the moment.

When data-confidences is missing, assume everything is concrete.