### PR TITLE
Bug 1934174 - Ignore devtools test file that can contain experimental syntax.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -280,7 +280,13 @@ const FILENAME_INTERVENTIONS = [
     includes_list: ["/wubkat/"],
     severity: "INFO",
     prepend: "Wubkat failsafe: "
-  }
+  },
+  {
+    includes_list: ["devtools/client/debugger/test/mochitest/examples/inline-preview.js",
+                    "devtools/client/debugger/test/mochitest/examples/preview.js"],
+    severity: "INFO",
+    prepend: "It may contain experimental syntax: ",
+  },
 ];
 
 function logError(msg)


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1934174