### PR TITLE
Bug 1833548 - Filter candidate overloads in OverloadExpr by call arity.

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2238,6 +2238,12 @@ public:
     return true;
   }
 
+  CallExpr *CurrentCall = nullptr;
+  bool TraverseCallExpr(CallExpr *E) {
+    const auto _ = ValueRollback(CurrentCall, E);
+    return Super::TraverseCallExpr(E);
+  }
+
   bool VisitCallExpr(CallExpr *E) {
     Expr *CalleeExpr = E->getCallee()->IgnoreParenImpCasts();
 
@@ -2591,6 +2597,46 @@ public:
     }
   }
 
+  bool arityMatchesCurrentCallExpr(const Expr *E, const NamedDecl *Candidate) {
+    const auto IsCurrentCallee = CurrentCall && E == CurrentCall->getCallee();
+    const auto CallNumArgs =
+        IsCurrentCallee ? CurrentCall->getNumArgs() : std::optional<uint>{};
+
+    const FunctionDecl *CandidateFunc;
+    if (const auto *UsingDecl = dyn_cast<UsingShadowDecl>(Candidate)) {
+      CandidateFunc = UsingDecl->getTargetDecl()->getAsFunction();
+    } else {
+      CandidateFunc = Candidate->getAsFunction();
+    }
+
+    // We try and filter candidates by arity, but be conservative and accept
+    // them when we don't know better
+    if (!CandidateFunc || !CallNumArgs) {
+      return true;
+    }
+
+    const auto MinNumArgs = CandidateFunc->getMinRequiredExplicitArguments();
+    const auto MaxNumArgs = [&]() -> std::optional<uint> {
+      const auto IsVariadic =
+          CandidateFunc->isVariadic() ||
+          std::any_of(CandidateFunc->param_begin(), CandidateFunc->param_end(),
+                      [](const ParmVarDecl *param) {
+                        return param->isParameterPack();
+                      });
+
+      if (IsVariadic)
+        return {};
+
+      return CandidateFunc->getNumNonObjectParams();
+    }();
+
+    if (CallNumArgs < MinNumArgs || (MaxNumArgs && CallNumArgs > *MaxNumArgs)) {
+      return false;
+    }
+
+    return true;
+  }
+
   bool VisitOverloadExpr(OverloadExpr *E) {
     SourceLocation Loc = E->getExprLoc();
     normalizeLocation(&Loc);
@@ -2599,7 +2645,8 @@ public:
     }
 
     for (auto *Candidate : E->decls()) {
-      visitHeuristicResult(Loc, Candidate);
+      if (arityMatchesCurrentCallExpr(E, Candidate))
+        visitHeuristicResult(Loc, Candidate);
     }
 
     // Also record this location so that if we have instantiations, we can
@@ -2617,9 +2664,9 @@ public:
       return true;
     }
 
-    // If possible, provide a heuristic result without instantiation.
-    for (const NamedDecl *D : Resolver->resolveMemberExpr(E)) {
-      visitHeuristicResult(Loc, D);
+    for (const NamedDecl *Candidate : Resolver->resolveMemberExpr(E)) {
+      if (arityMatchesCurrentCallExpr(E, Candidate))
+        visitHeuristicResult(Loc, Candidate);
     }
 
     // Also record this location so that if we have instantiations, we can
@@ -2652,8 +2699,9 @@ public:
       return true;
     }
 
-    for (const NamedDecl *D : Resolver->resolveDeclRefExpr(E)) {
-      visitHeuristicResult(Loc, D);
+    for (const NamedDecl *Candidate : Resolver->resolveDeclRefExpr(E)) {
+      if (arityMatchesCurrentCallExpr(E, Candidate))
+        visitHeuristicResult(Loc, Candidate);
     }
 
     // Also record this location so that if we have instantiations, we can

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E.snap
@@ -41,7 +41,7 @@ snapshot_kind: text
     "contextsym": "_ZN3Foo3BarEv"
   },
   {
-    "loc": "00070:20-21",
+    "loc": "00071:20-21",
     "source": 1,
     "syntax": "use,type",
     "type": "enum Foo<int>::E",
@@ -50,7 +50,7 @@ snapshot_kind: text
     "sym": "T_Foo::E"
   },
   {
-    "loc": "00070:20-21",
+    "loc": "00071:20-21",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::E",

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E_Waldo.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_E_Waldo.snap
@@ -44,7 +44,7 @@ snapshot_kind: text
     "contextsym": "_ZN3Foo3BarEv"
   },
   {
-    "loc": "00070:23-28",
+    "loc": "00071:23-28",
     "source": 1,
     "syntax": "use,enum",
     "type": "enum Foo<int>::E",
@@ -53,7 +53,7 @@ snapshot_kind: text
     "sym": "E_<T_Foo::E>_Waldo"
   },
   {
-    "loc": "00070:23-28",
+    "loc": "00071:23-28",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::E::Waldo",

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Foo_Project.snap
@@ -55,30 +55,10 @@ snapshot_kind: text
   },
   {
     "loc": "00026:4-11",
-    "source": 1,
-    "syntax": "use,function",
-    "type": "void (Point<F>, Point<F>)",
-    "pretty": "function Foo::Project",
-    "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_",
-    "confidence": [
-      "cppTemplateHeuristic"
-    ]
-  },
-  {
-    "loc": "00026:4-11",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__E",
-    "context": "Foo::Bar",
-    "contextsym": "_ZN3Foo3BarEv"
-  },
-  {
-    "loc": "00026:4-11",
-    "target": 1,
-    "kind": "use",
-    "pretty": "Foo::Project",
-    "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_",
     "context": "Foo::Bar",
     "contextsym": "_ZN3Foo3BarEv"
   },
@@ -95,30 +75,10 @@ snapshot_kind: text
   },
   {
     "loc": "00029:10-17",
-    "source": 1,
-    "syntax": "use,function",
-    "type": "void (Point<F>, Point<F>)",
-    "pretty": "function Foo::Project",
-    "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_",
-    "confidence": [
-      "cppTemplateHeuristic"
-    ]
-  },
-  {
-    "loc": "00029:10-17",
     "target": 1,
     "kind": "use",
     "pretty": "Foo::Project",
     "sym": "_ZN3Foo7ProjectE5PointITL0__E",
-    "context": "Foo::Bar",
-    "contextsym": "_ZN3Foo3BarEv"
-  },
-  {
-    "loc": "00029:10-17",
-    "target": 1,
-    "kind": "use",
-    "pretty": "Foo::Project",
-    "sym": "_ZN3Foo7ProjectE5PointITL0__ES2_",
     "context": "Foo::Bar",
     "contextsym": "_ZN3Foo3BarEv"
   }

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@Point_IsThereOne.snap
@@ -43,7 +43,7 @@ snapshot_kind: text
     "contextsym": "_Z12TemplateFuncN3FooIT_E7TypedefE"
   },
   {
-    "loc": "00065:21-31",
+    "loc": "00066:21-31",
     "source": 1,
     "syntax": "use,function",
     "type": "_Bool (void)",
@@ -54,7 +54,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00065:21-31",
+    "loc": "00066:21-31",
     "target": 1,
     "kind": "use",
     "pretty": "Point::IsThereOne",

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@WithOverloads_Overloaded.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@WithOverloads_Overloaded.snap
@@ -5,7 +5,7 @@ snapshot_kind: text
 ---
 [
   {
-    "loc": "00076:14-24",
+    "loc": "00077:14-24",
     "source": 1,
     "syntax": "decl,function",
     "type": "void (int)",
@@ -13,29 +13,11 @@ snapshot_kind: text
     "sym": "_ZN13WithOverloads10OverloadedEi"
   },
   {
-    "loc": "00076:14-24",
+    "loc": "00077:14-24",
     "target": 1,
     "kind": "decl",
     "pretty": "WithOverloads::Overloaded",
     "sym": "_ZN13WithOverloads10OverloadedEi",
-    "context": "WithOverloads",
-    "contextsym": "T_WithOverloads",
-    "peekRange": "76-76"
-  },
-  {
-    "loc": "00077:14-24",
-    "source": 1,
-    "syntax": "decl,function",
-    "type": "void (float)",
-    "pretty": "function WithOverloads::Overloaded",
-    "sym": "_ZN13WithOverloads10OverloadedEf"
-  },
-  {
-    "loc": "00077:14-24",
-    "target": 1,
-    "kind": "decl",
-    "pretty": "WithOverloads::Overloaded",
-    "sym": "_ZN13WithOverloads10OverloadedEf",
     "context": "WithOverloads",
     "contextsym": "T_WithOverloads",
     "peekRange": "77-77"
@@ -44,22 +26,40 @@ snapshot_kind: text
     "loc": "00078:14-24",
     "source": 1,
     "syntax": "decl,function",
-    "type": "void (_Bool)",
+    "type": "void (float)",
     "pretty": "function WithOverloads::Overloaded",
-    "sym": "_ZN13WithOverloads10OverloadedEb"
+    "sym": "_ZN13WithOverloads10OverloadedEf"
   },
   {
     "loc": "00078:14-24",
     "target": 1,
     "kind": "decl",
     "pretty": "WithOverloads::Overloaded",
-    "sym": "_ZN13WithOverloads10OverloadedEb",
+    "sym": "_ZN13WithOverloads10OverloadedEf",
     "context": "WithOverloads",
     "contextsym": "T_WithOverloads",
     "peekRange": "78-78"
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00079:14-24",
+    "source": 1,
+    "syntax": "decl,function",
+    "type": "void (_Bool)",
+    "pretty": "function WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb"
+  },
+  {
+    "loc": "00079:14-24",
+    "target": 1,
+    "kind": "decl",
+    "pretty": "WithOverloads::Overloaded",
+    "sym": "_ZN13WithOverloads10OverloadedEb",
+    "context": "WithOverloads",
+    "contextsym": "T_WithOverloads",
+    "peekRange": "79-79"
+  },
+  {
+    "loc": "00083:4-14",
     "source": 1,
     "syntax": "use,function",
     "type": "void (_Bool)",
@@ -70,7 +70,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "source": 1,
     "syntax": "use,function",
     "type": "void (float)",
@@ -81,7 +81,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "source": 1,
     "syntax": "use,function",
     "type": "void (int)",
@@ -92,7 +92,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "source": 1,
     "syntax": "use,function",
     "type": "void (int)",
@@ -100,7 +100,7 @@ snapshot_kind: text
     "sym": "_ZN13WithOverloads10OverloadedEi"
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "target": 1,
     "kind": "use",
     "pretty": "WithOverloads::Overloaded",
@@ -109,7 +109,7 @@ snapshot_kind: text
     "contextsym": "_ZN13WithOverloads6CallerEv"
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "target": 1,
     "kind": "use",
     "pretty": "WithOverloads::Overloaded",
@@ -118,7 +118,7 @@ snapshot_kind: text
     "contextsym": "_ZN13WithOverloads6CallerEv"
   },
   {
-    "loc": "00082:4-14",
+    "loc": "00083:4-14",
     "target": 1,
     "kind": "use",
     "pretty": "WithOverloads::Overloaded",

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@internal_Read.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/check_glob@internal_Read.snap
@@ -21,7 +21,7 @@ snapshot_kind: text
     "peekRange": "48-48"
   },
   {
-    "loc": "00057:2-6",
+    "loc": "00058:2-6",
     "source": 1,
     "syntax": "use,function",
     "type": "void (void)",
@@ -32,7 +32,7 @@ snapshot_kind: text
     ]
   },
   {
-    "loc": "00057:2-6",
+    "loc": "00058:2-6",
     "target": 1,
     "kind": "use",
     "pretty": "internal::Read",

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -225,7 +225,7 @@ snapshot_kind: text
         <tr>
           <td><a href="/tests/source/bug1781178.cpp" class="mimetype-fixed-container mimetype-icon-cpp">bug1781178.cpp</a></td>
           <td class="description"><a href="/tests/source/bug1781178.cpp" title=""></td>
-          <td><a href="/tests/source/bug1781178.cpp">1291</a></td>
+          <td><a href="/tests/source/bug1781178.cpp">1301</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/bug1781178.cpp
+++ b/tests/tests/files/bug1781178.cpp
@@ -55,6 +55,7 @@ void TemplateFunc(typename Foo<T>::Typedef) {
 
   using internal::Read;
   Read(p);
+  Read();
 }
 
 template <typename T>


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1833548

This implements the first strategy proposed by Botond to filter unresolved overload sets: by arity.

We don't have easy access to the CallExpr from OverloadExpr, so we add tracking for that in TraverseCallExpr.