### PR TITLE
Bug 1934697 - Replace Raw and Log links with GitHub links.

### DIFF
--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -13,8 +13,6 @@ var Panel = new (class Panel {
 
     this.permalinkNode = this.findItem("Permalink");
     this.unpermalinkNode = this.findItem("Remove the Permalink");
-    this.logNode = this.findItem("Log");
-    this.rawNode = this.findItem("Raw");
 
     this.selectedSymbol = null;
 

--- a/static/js/panel.js
+++ b/static/js/panel.js
@@ -198,6 +198,10 @@ var Panel = new (class Panel {
     return this.panel.querySelector(`.item[title="${title}"]`);
   }
 
+  findAccel(key) {
+    return this.panel.querySelector(`.item[data-accel="${key}"]`);
+  }
+
   maybeHandleAccelerator(event) {
     if (!this.acceleratorsEnabled) {
       return;
@@ -213,22 +217,22 @@ var Panel = new (class Panel {
       switch (event.key) {
         case "y":
         case "Y":
-          return this.permalinkNode;
+          return this.findAccel('Y');
         case "l":
         case "L":
-          return this.logNode;
+          return this.findAccel('L');
         case "r":
         case "R":
-          return this.rawNode;
+          return this.findAccel('R');
         case "f":
         case "F":
-          return this.markdown.filename.node;
+          return this.findAccel('F');
         case "s":
         case "S":
-          return this.markdown.symbol.node;
+          return this.findAccel('S');
         case "c":
         case "C":
-          return this.markdown.block.node;
+          return this.findAccel('C');
       }
     })();
 

--- a/tests/searchfox-config.json
+++ b/tests/searchfox-config.json
@@ -14,6 +14,7 @@
       "objdir_path": "$WORKING/searchfox/objdir",
       "git_path": "$MOZSEARCH_PATH",
       "git_blame_path": "$WORKING/searchfox/blame",
+      "github_repo": "https://github.com/mozsearch/mozsearch",
       "history_path": "$WORKING/searchfox/history",
       "codesearch_path": "$WORKING/searchfox/livegrep.idx",
       "codesearch_port": 8081,

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -335,22 +335,56 @@ fn main() {
                     accel_key: None,
                     copyable: false,
                 });
-                if let Some(ref hg_root) = tree_config.paths.hg_root {
+
+                let gh_log_link = tree_config
+                    .paths
+                    .github_repo
+                    .as_ref()
+                    .map(|gh_root| format!("{}/commits/HEAD/{}", gh_root, encoded_path));
+                let hg_log_link = tree_config
+                    .paths
+                    .hg_root
+                    .as_ref()
+                    .map(|hg_root| format!("{}/log/tip/{}", hg_root, encoded_path));
+                if let Some(link) = gh_log_link {
                     vcs_panel_items.push(PanelItem {
-                        title: "Log".to_owned(),
-                        link: format!("{}/log/tip/{}", hg_root, encoded_path),
+                        title: "Git log".to_owned(),
+                        link,
+                        update_link_lineno: "",
+                        accel_key: hg_log_link.is_none().then_some('L'),
+                        copyable: true,
+                    });
+                }
+                if let Some(link) = hg_log_link {
+                    vcs_panel_items.push(PanelItem {
+                        title: "Mercurial log".to_owned(),
+                        link,
                         update_link_lineno: "",
                         accel_key: Some('L'),
                         copyable: true,
                     });
+                }
+
+                let gh_raw_link = tree_config
+                    .paths
+                    .github_repo
+                    .as_ref()
+                    .map(|gh_root| format!("{}/raw/HEAD/{}", gh_root, encoded_path));
+                let hg_raw_link = tree_config
+                    .paths
+                    .hg_root
+                    .as_ref()
+                    .map(|hg_root| format!("{}/raw-file/tip/{}", hg_root, encoded_path));
+                if let Some(link) = gh_raw_link.or(hg_raw_link) {
                     vcs_panel_items.push(PanelItem {
                         title: "Raw".to_owned(),
-                        link: format!("{}/raw-file/tip/{}", hg_root, encoded_path),
+                        link,
                         update_link_lineno: "",
                         accel_key: Some('R'),
                         copyable: true,
                     });
                 }
+
                 if tree_config.paths.git_blame_path.is_some() {
                     vcs_panel_items.push(PanelItem {
                         title: "Blame".to_owned(),

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -978,22 +978,56 @@ pub fn format_path(
         accel_key: None,
         copyable: true,
     });
-    if let Some(ref hg_root) = tree_config.paths.hg_root {
+
+    let gh_log_link = tree_config
+        .paths
+        .github_repo
+        .as_ref()
+        .map(|gh_root| format!("{}/commits/{}/{}", gh_root, commit.id(), encoded_path));
+    let hg_log_link = tree_config
+        .paths
+        .hg_root
+        .as_ref()
+        .map(|hg_root| format!("{}/log/{}/{}", hg_root, hg_rev, encoded_path));
+    if let Some(link) = gh_log_link {
         vcs_panel_items.push(PanelItem {
-            title: "Log".to_owned(),
-            link: format!("{}/log/{}/{}", hg_root, hg_rev, encoded_path),
+            title: "Git log".to_owned(),
+            link,
+            update_link_lineno: "",
+            accel_key: hg_log_link.is_none().then_some('L'),
+            copyable: true,
+        });
+    }
+    if let Some(link) = hg_log_link {
+        vcs_panel_items.push(PanelItem {
+            title: "Mercurial log".to_owned(),
+            link,
             update_link_lineno: "",
             accel_key: Some('L'),
             copyable: true,
         });
+    }
+
+    let gh_raw_link = tree_config
+        .paths
+        .github_repo
+        .as_ref()
+        .map(|gh_root| format!("{}/raw/{}/{}", gh_root, commit.id(), encoded_path));
+    let hg_raw_link = tree_config
+        .paths
+        .hg_root
+        .as_ref()
+        .map(|hg_root| format!("{}/raw-file/{}/{}", hg_root, hg_rev, encoded_path));
+    if let Some(link) = gh_raw_link.or(hg_raw_link) {
         vcs_panel_items.push(PanelItem {
             title: "Raw".to_owned(),
-            link: format!("{}/raw-file/{}/{}", hg_root, hg_rev, encoded_path),
+            link,
             update_link_lineno: "",
             accel_key: Some('R'),
             copyable: true,
         });
     }
+
     if tree_config.paths.git_blame_path.is_some() {
         vcs_panel_items.push(PanelItem {
             title: "Blame".to_owned(),
@@ -1237,15 +1271,36 @@ pub fn format_diff(
             copyable: false,
         },
     ];
-    if let Some(ref hg_root) = tree_config.paths.hg_root {
+
+    let gh_log_link = tree_config
+        .paths
+        .github_repo
+        .as_ref()
+        .map(|gh_root| format!("{}/commits/HEAD/{}", gh_root, encoded_path));
+    let hg_log_link = tree_config
+        .paths
+        .hg_root
+        .as_ref()
+        .map(|hg_root| format!("{}/log/tip/{}", hg_root, encoded_path));
+    if let Some(link) = gh_log_link {
         vcs_panel_items.push(PanelItem {
-            title: "Log".to_owned(),
-            link: format!("{}/log/tip/{}", hg_root, encoded_path),
+            title: "Git log".to_owned(),
+            link,
+            update_link_lineno: "",
+            accel_key: hg_log_link.is_none().then_some('L'),
+            copyable: true,
+        });
+    }
+    if let Some(link) = hg_log_link {
+        vcs_panel_items.push(PanelItem {
+            title: "Mercurial log".to_owned(),
+            link,
             update_link_lineno: "",
             accel_key: Some('L'),
             copyable: true,
         });
     }
+
     let sections = vec![PanelSection {
         name: "Revision control".to_owned(),
         items: vcs_panel_items,

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -371,6 +371,11 @@ pub fn generate_panel(
                     } else {
                         String::new()
                     };
+                    let data_accel = if let Some(key) = item.accel_key {
+                        format!(r#" data-accel="{key}""#)
+                    } else {
+                        String::new()
+                    };
                     let is_link = !item.link.is_empty();
                     let copy = if item.copyable {
                         if is_link {
@@ -393,8 +398,16 @@ pub fn generate_panel(
                     F::Seq(vec![
                         F::S("<li>"),
                         F::T(format!(
-                            r#"<{}{} title="{}" class="icon item"{}>{}{}{}</{}>"#,
-                            tag, href, item.title, update_attr, item.title, accel, copy, tag
+                            r#"<{}{}{} title="{}" class="icon item"{}>{}{}{}</{}>"#,
+                            tag,
+                            href,
+                            data_accel,
+                            item.title,
+                            update_attr,
+                            item.title,
+                            accel,
+                            copy,
+                            tag
                         )),
                         F::S("</li>"),
                     ])


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1934697

generate_commit_info in format.rs already built link to GitHub for a specific commit.

This re-uses the same data source to build URLs to the GitHub log and GitHub raw content for the navigation pane.

The Raw link is replaced with the GitHub link when available _instead_ of the Mercurial link.

The Mercurial “Log” link is renamed to “Mercurial Log”.

A “Git Log” link is addded to point to GitHub when available.