### PR TITLE
Bug 1458882 - Add link to Firefox Source Docs.

### DIFF
--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -73,6 +73,7 @@ $MOZSEARCH_PATH/scripts/objdir-mkdirs.sh
 date
 
 URL_MAP_PATH=$INDEX_ROOT/aliases/url-map.json
+DOC_TREES_MAP=$INDEX_ROOT/doc-trees.json
 
 $MOZSEARCH_PATH/scripts/process-chrome-map.py $GIT_ROOT $URL_MAP_PATH $INDEX_ROOT/*.chrome-map.json || handle_tree_error "process-chrome-map.py"
 
@@ -123,7 +124,7 @@ $MOZSEARCH_PATH/scripts/crossref.sh $CONFIG_FILE $TREE_NAME $ANALYSIS_FILES_PATH
 
 date
 
-$MOZSEARCH_PATH/scripts/output.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME $URL_MAP_PATH || handle_tree_error "output.sh"
+$MOZSEARCH_PATH/scripts/output.sh $CONFIG_REPO $CONFIG_FILE $TREE_NAME $URL_MAP_PATH $DOC_TREES_MAP || handle_tree_error "output.sh"
 
 date
 

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -4,7 +4,7 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-if [ $# -ne 4 ]
+if [ $# -ne 5 ]
 then
     echo "Usage: output.sh config_repo config-file.json tree_name url-map.json"
     exit 1
@@ -14,6 +14,7 @@ CONFIG_REPO=$(realpath $1)
 CONFIG_FILE=$(realpath $2)
 TREE_NAME=$3
 URL_MAP_PATH=$4
+DOC_TREES_PATH=$5
 
 # let's put the "parallel" output in a new `diags` directory, as we're still
 # seeing really poor output-file performance in bug 1567724.
@@ -64,7 +65,7 @@ TMPDIR_PATH=${DIAGS_DIR}
 #   which is obviously suboptimal.
 parallel --jobs 8 --pipepart -a $INDEX_ROOT/all-files --files --joblog $JOBLOG_PATH --tmpdir $TMPDIR_PATH \
     --block -1 --halt 2 --env RUST_BACKTRACE \
-    "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME $URL_MAP_PATH - 2>&1"
+    "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME $URL_MAP_PATH $DOC_TREES_PATH - 2>&1"
 
 TOOL_CMD="search-files --limit=0 --include-dirs --group-by=directory | batch-render dir"
 SEARCHFOX_SERVER=${CONFIG_FILE} \

--- a/tests/tests/checks/inputs/web/docs/docs_md__html
+++ b/tests/tests/checks/inputs/web/docs/docs_md__html
@@ -1,0 +1,1 @@
+cat-html docs/md_test/index.md --select "#panel a[href*=\"firefox-source-docs\"]"

--- a/tests/tests/checks/inputs/web/docs/docs_rst__html
+++ b/tests/tests/checks/inputs/web/docs/docs_rst__html
@@ -1,0 +1,1 @@
+cat-html docs/rst_test/index.rst --select "#panel a[href*=\"firefox-source-docs\"]"

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&fb.contents"
-snapshot_kind: text
 ---
 <!DOCTYPE html>
 <html lang="en-US">
@@ -280,6 +279,12 @@ snapshot_kind: text
           <td><a href="/tests/source/css" class="mimetype-fixed-container mimetype-icon-folder">css</a></td>
           <td class="description"><a href="/tests/source/css" title=""></td>
           <td><a href="/tests/source/css"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/docs" class="mimetype-fixed-container mimetype-icon-folder">docs</a></td>
+          <td class="description"><a href="/tests/source/docs" title=""></td>
+          <td><a href="/tests/source/docs"></a></td>
         </tr>
 
         <tr>

--- a/tests/tests/checks/snapshots/web/docs/check_glob@docs_md__html.snap
+++ b/tests/tests/checks/snapshots/web/docs/check_glob@docs_md__html.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_check_insta.rs
+expression: "&fb.contents"
+---
+<a href="https://firefox-source-docs.mozilla.org/md_test/index.html" title="Source Docs" class="icon item">Source Docs</a>

--- a/tests/tests/checks/snapshots/web/docs/check_glob@docs_rst__html.snap
+++ b/tests/tests/checks/snapshots/web/docs/check_glob@docs_rst__html.snap
@@ -1,0 +1,5 @@
+---
+source: tests/test_check_insta.rs
+expression: "&fb.contents"
+---
+<a href="https://firefox-source-docs.mozilla.org/rst_test/index.html" title="Source Docs" class="icon item">Source Docs</a>

--- a/tests/tests/files/docs/md_test/index.md
+++ b/tests/tests/files/docs/md_test/index.md
@@ -1,0 +1,3 @@
+# Markdown Test
+
+This is a test document with Markdown.

--- a/tests/tests/files/docs/rst_test/index.rst
+++ b/tests/tests/files/docs/rst_test/index.rst
@@ -1,0 +1,4 @@
+reST Test
+=========
+
+This is a test document with reST.

--- a/tests/tests/metadata/doc-trees.json
+++ b/tests/tests/metadata/doc-trees.json
@@ -1,0 +1,1 @@
+{"md_test": "docs/md_test", "rst_test": "docs/rst_test"}

--- a/tests/tests/setup
+++ b/tests/tests/setup
@@ -22,3 +22,4 @@ ln -s -f $CONFIG_REPO/tests/metadata/wpt-metadata-summary.json $INDEX_ROOT
 ln -s -f $CONFIG_REPO/tests/metadata/code-coverage-report.json $INDEX_ROOT
 ln -s -f $CONFIG_REPO/tests/metadata/test.chrome-map.json $INDEX_ROOT
 ln -s -f $CONFIG_REPO/tests/metadata/test2.chrome-map.json $INDEX_ROOT
+ln -s -f $CONFIG_REPO/tests/metadata/doc-trees.json $INDEX_ROOT

--- a/tools/src/abstract_server/local_index.rs
+++ b/tools/src/abstract_server/local_index.rs
@@ -486,7 +486,7 @@ pub fn make_local_server(
     config_path: &str,
     tree_name: &str,
 ) -> Result<Box<dyn AbstractServer + Send + Sync>> {
-    let mut config = load(config_path, false, Some(tree_name), None);
+    let mut config = load(config_path, false, Some(tree_name), None, None);
     let tree_config = match config.trees.remove(tree_name) {
         Some(t) => t,
         None => {
@@ -503,7 +503,7 @@ pub fn make_local_server(
 pub fn make_all_local_servers(
     config_path: &str,
 ) -> Result<BTreeMap<String, Box<dyn AbstractServer + Send + Sync>>> {
-    let config = load(config_path, false, None, None);
+    let config = load(config_path, false, None, None, None);
     let mut servers = BTreeMap::new();
     for (tree_name, tree_config) in config.trees {
         let server = fab_server(tree_config, &tree_name, &config.config_repo_path)?;

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -299,7 +299,7 @@ async fn main() {
     let cli = CrossrefCli::parse();
 
     let tree_name = &cli.tree_name;
-    let cfg = config::load(&cli.config_file, false, Some(tree_name), None);
+    let cfg = config::load(&cli.config_file, false, Some(tree_name), None, None);
 
     let tree_config = cfg.trees.get(tree_name).unwrap();
 

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -1442,7 +1442,7 @@ fn main() {
     let cli = ScipIndexerCli::parse();
 
     let tree_name = &cli.tree_name;
-    let cfg = config::load(&cli.config_file, false, Some(tree_name), None);
+    let cfg = config::load(&cli.config_file, false, Some(tree_name), None, None);
     let tree_config = cfg.trees.get(tree_name).unwrap();
 
     for file in cli.inputs {

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -259,7 +259,7 @@ fn handle(
 fn main() {
     env_logger::init();
 
-    let cfg = config::load(&env::args().nth(1).unwrap(), true, None, None);
+    let cfg = config::load(&env::args().nth(1).unwrap(), true, None, None, None);
 
     let ident_map = IdentMap::load(&cfg);
 

--- a/tools/src/doc_trees_handler.rs
+++ b/tools/src/doc_trees_handler.rs
@@ -1,0 +1,24 @@
+use crate::file_format::config::Config;
+use crate::file_format::doc_trees::{read_doc_trees, DocTrees};
+use std::sync::OnceLock;
+
+pub fn find_doc_url(cfg: &Config, src_path: &str) -> Option<String> {
+    static DOC_TREES: OnceLock<DocTrees> = OnceLock::new();
+
+    if DOC_TREES.get().is_none() {
+        DOC_TREES
+            .set(match &cfg.doc_trees_path {
+                Some(doc_trees_path) => read_doc_trees(doc_trees_path),
+                None => DocTrees::new_empty(),
+            })
+            .unwrap();
+    }
+
+    match DOC_TREES.get().unwrap().find(src_path) {
+        // TODO: Make the URL configurable.
+        Some(target_path) => {
+            Some("https://firefox-source-docs.mozilla.org/".to_string() + target_path.as_str())
+        }
+        None => None,
+    }
+}

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -164,8 +164,9 @@ pub struct Config {
     pub trees: BTreeMap<String, TreeConfig>,
     pub mozsearch_path: String,
     pub config_repo_path: String,
-    // FIXME: Move this to TreeConfig.
+    // FIXME: Move these to TreeConfig.
     pub url_map_path: Option<String>,
+    pub doc_trees_path: Option<String>,
 }
 
 impl Config {
@@ -260,6 +261,7 @@ pub fn load(
     need_indexes: bool,
     only_tree: Option<&str>,
     url_map_path: Option<String>,
+    doc_trees_path: Option<String>,
 ) -> Config {
     let config_file = File::open(config_path).unwrap();
     let mut reader = BufReader::new(&config_file);
@@ -322,6 +324,7 @@ pub fn load(
         mozsearch_path: config.mozsearch_path,
         config_repo_path: config.config_repo,
         url_map_path,
+        doc_trees_path,
     }
 }
 

--- a/tools/src/file_format/doc_trees.rs
+++ b/tools/src/file_format/doc_trees.rs
@@ -1,0 +1,62 @@
+use serde_json::from_reader;
+use std::collections::HashMap;
+use std::fs::File;
+
+#[derive(Debug)]
+pub struct DocTrees {
+    data: HashMap<String, String>,
+}
+
+impl DocTrees {
+    fn new(data: HashMap<String, String>) -> Self {
+        Self { data }
+    }
+
+    pub fn new_empty() -> Self {
+        Self {
+            data: HashMap::new(),
+        }
+    }
+
+    pub fn find(&self, src_path: &str) -> Option<String> {
+        for (target_prefix, src_prefix) in &self.data {
+            match src_path.strip_prefix(src_prefix) {
+                Some(inner_path) => {
+                    let no_ext_inner_path = match inner_path.strip_suffix(".md") {
+                        Some(s) => s,
+                        None => match inner_path.strip_suffix(".rst") {
+                            Some(s) => s,
+                            None => {
+                                return None;
+                            }
+                        },
+                    };
+                    return Some(target_prefix.to_owned() + no_ext_inner_path + ".html");
+                }
+                None => {}
+            }
+        }
+
+        None
+    }
+}
+
+pub fn read_doc_trees(filename: &String) -> DocTrees {
+    let file = match File::open(filename) {
+        Ok(f) => f,
+        Err(_) => {
+            info!("Error trying to open doc trees file [{}]", filename);
+            return DocTrees::new_empty();
+        }
+    };
+
+    let data: HashMap<String, String> = match from_reader(file) {
+        Ok(result) => result,
+        Err(_) => {
+            info!("Error trying to read doc trees file [{}]", filename);
+            return DocTrees::new_empty();
+        }
+    };
+
+    DocTrees::new(data)
+}

--- a/tools/src/file_format/mod.rs
+++ b/tools/src/file_format/mod.rs
@@ -15,6 +15,8 @@ pub mod crossref_converter;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod crossref_lookup;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod doc_trees;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod globbing_file_list;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod identifiers;

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -53,6 +53,8 @@ pub mod blame;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod describe;
 #[cfg(not(target_arch = "wasm32"))]
+pub mod doc_trees_handler;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod file_utils;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod format;


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1458882

This is WIP to add "Source Docs" link for `.rst` and `.md` files, next to the current "Rendered view" link.
This expects the `source-test-doc-generate` jobs's `trees.json` artifact is fetched as `doc-trees.json` by the config's setup script,
and the download part needs to be addressed in separate patch.