### PR TITLE
Bug 1937445 - increase web-server AMI to 16G, latch mise version

### DIFF
--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -49,7 +49,8 @@ popd
 
 date
 
-# Size up our root partition to 12G
+# Size up our root partition to 16G.  This is up from 12G when we were hitting
+# the limit for the self-update process during the rust build.
 #
 # To this end we need to know the volume id in order to issue an EBS resizing
 # command.  Note that the select constraint here is intended more as a check
@@ -61,7 +62,7 @@ ROOT_DEV=$(jq -M -r '.DevicePath' <<< "$ROOT_DEV_INFO")
 
 AWS_REGION=us-west-2
 # The size is in gigs.
-aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 12
+aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 16
 
 # We use an until loop because it can take some time for the change to
 # propagate to this VM.  The error will look like:

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -29,7 +29,14 @@ cargo install cargo-insta
 # invaluable when trying to just get things to work when packages are involved
 # that may involve native modules/libraries which can make it hard to uniformly
 # use the latest revision.  I'm somewhat hopeful that
-cargo install mise
+#
+# We are currently installing an older version of mise because as of 2014-12-15
+# rust nightly has problems with usage-lib related to miette.  The version
+# 2024.10.1 was specifically chosen because it was the version we were using on
+# the last successful provision.  The include graph for this seems potentially
+# way more than we need to be able to run node, so I think we will want to drop
+# this dep in the future absent some very good reason.
+cargo install mise@2024.10.1
 
 # Install node.js for scip-typescript; github lists v18 and v20 as supported;
 # we are sticking with v18 for now because currently all the invocations


### PR DESCRIPTION
The primary intent here is to boost the size of the web-server AMI to 16G to address running out of disk space during the self-update of the web-server at the start of its spin-up.

However, when running `./build-docker.sh` locally initially to validate that the provisioning process was likely to complete on the server, I encountered a provisioning failure during the installation of `mise` which is the tool we use to create a sort-of `venv` for node.  mise seems to be very much under development at this time and we definitely don't need any of the new enhancements, so I picked the version that was released on the last successful provisioning run of 2024-Oct-11.

As added to the comment, I'm not sure we really need to be using mise. I believe my original rationale was that nvm was deprecated and mise (then rtx) was a rust-based tool that seemed to to support the configs for the (non-rust) asdf tool and it seemed to work.  Given that we've updated to Ubuntu 24.04 and our node.js needs are so limited (and the upstream scip tooling so rarely updated) it might be possible to just use the default Ubuntu node.js packages.  (I believe I had looked at getting .deb files for 22.04 and that had eneded up undesirable.)