### PR TITLE
Bug 1935484 - GitHub Actions CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,92 @@
+name: Test Mozsearch
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+
+    env:
+      # Force cargo insta to generate all new snapshots so we can upload them
+      INSTA_FORCE_PASS: 1
+      # By default cargo insta detects that we are running on a CI (via the $CI env var) and doesn't save the updated snapshots…
+      # See https://insta.rs/docs/advanced/#controlling-snapshot-updating
+      INSTA_UPDATE: new
+      MOZSEARCH_REPO: ${{ github.server_url }}/${{ github.repository }}
+      MOZSEARCH_BRANCH: ${{ github.ref_name }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-depth: 0
+
+      # Provisioning
+      - name: Common Provision (pre)
+        run: $GITHUB_WORKSPACE/infrastructure/common-provision-pre.sh
+        working-directory: /home/runner
+      - name: Indexer Provision
+        run: $GITHUB_WORKSPACE/infrastructure/indexer-provision.sh
+        working-directory: /home/runner
+      - name: Web Server Provision
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-provision.sh
+        working-directory: /home/runner
+      - name: Common Provision (post)
+        run: $GITHUB_WORKSPACE/infrastructure/common-provision-post.sh
+        working-directory: /home/runner
+      - name: Add scip-java to PATH
+        run: echo "$HOME/.local/share/coursier/bin" >> "$GITHUB_PATH"
+      - name: Give www-data access to the user's home directory
+        run: chmod a+rx ~
+
+      # Bulding
+      - name: Build Clang plugin
+        run: make -C $GITHUB_WORKSPACE/clang-plugin
+      - name: Build Rust tools
+        run: make -C $GITHUB_WORKSPACE build-rust-tools
+
+      # Test repo
+      - run: mkdir ~/index
+      - name: "Test config: Indexer setup"
+        run: $GITHUB_WORKSPACE/infrastructure/indexer-setup.sh $GITHUB_WORKSPACE/tests config.json ~/index
+      - name: "Test config: Indexer run and test"
+        run: $GITHUB_WORKSPACE/infrastructure/indexer-run.sh $GITHUB_WORKSPACE/tests ~/index
+      - name: "Test config: Web server setup"
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-setup.sh $GITHUB_WORKSPACE/tests config.json ~/index ~
+      - name: "Test config: Web server run"
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-run.sh $GITHUB_WORKSPACE/tests ~/index ~ WAIT
+      - name: "Test config: Web server test"
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-check.sh $GITHUB_WORKSPACE/tests ~/index "http://127.0.0.1/"
+      - name: "Test config: Upload updated snapshots"
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-test-snapshots
+          path: tests/tests/checks/snapshots/**/*.snap.new
+          if-no-files-found: ignore
+      - name: "Test config: Fail if any snapshot updated"
+        run: test $(find tests/tests/checks/snapshots -name "*.snap.new" -printf '.' | wc -c) -eq 0
+      - run: rm -rf ~/index
+
+      # Webtest repo
+      - run: mkdir ~/index
+      - name: "Webtest config: Indexer setup"
+        run: $GITHUB_WORKSPACE/infrastructure/indexer-setup.sh $GITHUB_WORKSPACE/tests webtest-config.json ~/index
+      - name: "Webtest config: Indexer run and test"
+        run: $GITHUB_WORKSPACE/infrastructure/indexer-run.sh $GITHUB_WORKSPACE/tests ~/index
+      - name: "Webtest config: Web server setup"
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-setup.sh $GITHUB_WORKSPACE/tests webtest-config.json ~/index ~
+      - name: "Webtest config: Web server run"
+        run: $GITHUB_WORKSPACE/infrastructure/web-server-run.sh $GITHUB_WORKSPACE/tests ~/index ~ WAIT
+      - name: "Webtest config: Web server test"
+        run: $GITHUB_WORKSPACE/scripts/webtest.sh
+      - name: "Webtest config: Upload updated snapshots"
+        uses: actions/upload-artifact@v4
+        with:
+          name: updated-webtest-snapshots
+          path: tests/tests/checks/snapshots/**/*.snap.new
+          if-no-files-found: ignore
+      - name: "Webtest config: Fail if any snapshot updated"
+        run: test $(find tests/tests/checks/snapshots -name "*.snap.new" -printf '.' | wc -c) -eq 0
+      - run: rm -rf ~/index

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -134,6 +134,7 @@ if [ ! -d $HOME/.cargo ]; then
   rustup install nightly
   rustup default nightly
   rustup uninstall stable
+  rustup component add rust-analyzer
 fi
 
 # install ripgrep so we can stop experiencing grep pain / footguns
@@ -220,10 +221,3 @@ fi
 SCIP_VERSION=v0.5.0
 curl -L https://github.com/sourcegraph/scip/releases/download/$SCIP_VERSION/scip-linux-amd64.tar.gz | tar xzf - scip
 sudo ln -fs $(pwd)/scip /usr/local/bin/scip
-
-# Install rust-analyzer
-RUST_ANALYZER_VERSION=nightly
-rm -rf rust-analyzer rust-analyzer-linux-x64.vsix
-wget https://github.com/rust-lang/rust-analyzer/releases/download/$RUST_ANALYZER_VERSION/rust-analyzer-linux-x64.vsix
-unzip -o -d rust-analyzer rust-analyzer-linux-x64.vsix
-sudo ln -fs $(pwd)/rust-analyzer/extension/server/rust-analyzer /usr/local/bin/rust-analyzer

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -175,29 +175,6 @@ if [ ! -d livegrep ]; then
   rm -rf livegrep
 fi
 
-# Install AWS scripts and command-line tool.
-#
-# In order to get the AWS CLI v2 the current options[1] are to use snap or do
-# the curl + shell dance.  We don't have snap support installed by default and are
-# currently intentionally avoiding adding snaps, so we choose curl + shell.
-#
-# 1: https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html
-#
-# awscli can get credentials via `Ec2InstanceMetadata` which will give it the
-# authorities of the role assigned to the image it's running in.  Look for the
-# `IamInstanceProfile` definition in `trigger_indexer.py` and similar.
-#
-# (We check if the install directory already exists because on AWS we install
-# the CLI earlier out of necessity.)
-if [ ! -d awscliv2-install ]; then
-  mkdir -p awscliv2-install
-  pushd awscliv2-install
-  curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-  unzip awscliv2.zip
-  sudo ./aws/install
-  popd
-fi
-
 sudo apt-get install -y python3-boto3 python3-rich
 
 # Install git-cinnabar.

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -36,7 +36,7 @@ git config --global pull.ff only
 # we have git, so let's check out mozsearch now so we can have our email sending
 # script in case of an error.
 if [ ! -d mozsearch ]; then
-  git clone -b master https://github.com/mozsearch/mozsearch mozsearch
+  git clone -b master https://github.com/mozsearch/mozsearch mozsearch --depth=1
 fi
 
 # the base image we're building against is inherently not up-to-date (new base
@@ -145,7 +145,7 @@ cargo install wasm-snip
 
 # Install codesearch.
 if [ ! -d livegrep ]; then
-  git clone -b mozsearch-version7 https://github.com/mozsearch/livegrep
+  git clone -b mozsearch-version7 https://github.com/mozsearch/livegrep --depth=1
   pushd livegrep
   $BAZEL build //src/tools:codesearch
   sudo install bazel-bin/src/tools/codesearch /usr/local/bin
@@ -205,9 +205,8 @@ if [ ! -d git-cinnabar ]; then
   # We started pinning in https://bugzilla.mozilla.org/show_bug.cgi?id=1779939
   # and it seems reasonable to stick to this for more deterministic provisioning.
   CINNABAR_REVISION=0.6.3
-  git clone https://github.com/glandium/git-cinnabar
+  git clone https://github.com/glandium/git-cinnabar -b $CINNABAR_REVISION --depth=1
   pushd git-cinnabar
-    git checkout $CINNABAR_REVISION
     ./download.py --branch release
     # These need to be symlinks rather than `install`d binaries because cinnabar
     # uses other python code from the repo.

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -4,6 +4,11 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+MOZSEARCH_REPO="${MOZSEARCH_REPO:-https://github.com/mozsearch/mozsearch}"
+MOZSEARCH_BRANCH="${MOZSEARCH_BRANCH:-master}"
+MOZSEARCH_CONFIG_REPO="${MOZSEARCH_CONFIG_REPO:-https://github.com/mozsearch/mozsearch-mozilla}"
+MOZSEARCH_CONFIG_BRANCH="${MOZSEARCH_CONFIG_BRANCH:-master}"
+
 # We currently try to keep the version of clang we use matching the one that
 # will be used by the Firefox build process.  If you have a "mach bootstrap"ped
 # system then you can see the current version locally via
@@ -36,7 +41,7 @@ git config --global pull.ff only
 # we have git, so let's check out mozsearch now so we can have our email sending
 # script in case of an error.
 if [ ! -d mozsearch ]; then
-  git clone -b master https://github.com/mozsearch/mozsearch mozsearch --depth=1
+  git clone -b $MOZSEARCH_BRANCH $MOZSEARCH_REPO mozsearch --depth=1
 fi
 
 # the base image we're building against is inherently not up-to-date (new base

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -138,7 +138,7 @@ if [ ! -d $HOME/.cargo ]; then
 fi
 
 # install ripgrep so we can stop experiencing grep pain / footguns
-cargo install ripgrep
+sudo apt-get install ripgrep
 
 # Install tools for web-analyze WASM bindings.
 cargo install wasm-pack
@@ -172,6 +172,7 @@ if [ ! -d livegrep ]; then
   SITEDIR=$($LIVEGREP_VENV/bin/python3 -c "import site; print(site.getsitepackages()[0])")
   mkdir -p "$SITEDIR"
   echo "$PWD/livegrep-grpc3" > "$SITEDIR/livegrep.pth"
+  rm -rf livegrep
 fi
 
 # Install AWS scripts and command-line tool.

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -93,7 +93,7 @@ echo Config repository is $CONFIG_REPO
 
 # Install mozsearch.
 rm -rf mozsearch
-git clone -b $BRANCH $MOZSEARCH_REPO mozsearch
+git clone -b $BRANCH $MOZSEARCH_REPO mozsearch --depth=1
 pushd mozsearch
 git submodule init
 git submodule update
@@ -101,10 +101,7 @@ popd
 
 # Install files from the config repo.
 rm -rf config
-git clone $CONFIG_REPO config
-pushd config
-git checkout $BRANCH -- || true
-popd
+git clone -b $BRANCH $CONFIG_REPO config --depth=1
 
 date
 

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -17,40 +17,18 @@ sudo apt-get install -y ninja-build
 # the update process.
 cargo install cargo-insta
 
-# To help install node.js and similar, we install mise, a rust-based "asdf"
-# alternative, which if you don't know what "asdf" is, but know what "nvm" is,
-# it's basically a super-nvm for multiple languages, etc.  We use the install
-# method documented at https://mise.jdx.dev/getting-started.html#cargo but there
-# are a bunch of other options.
-#
-# The core rationale here is that I've locally been using "nvm" for node.js
-# purposes for a while now and it's been a much better experience than trying to
-# use debian/ubuntu distro-provided versions of node, and in particular can be
-# invaluable when trying to just get things to work when packages are involved
-# that may involve native modules/libraries which can make it hard to uniformly
-# use the latest revision.  I'm somewhat hopeful that
-#
-# We are currently installing an older version of mise because as of 2014-12-15
-# rust nightly has problems with usage-lib related to miette.  The version
-# 2024.10.1 was specifically chosen because it was the version we were using on
-# the last successful provision.  The include graph for this seems potentially
-# way more than we need to be able to run node, so I think we will want to drop
-# this dep in the future absent some very good reason.
-cargo install mise@2024.10.1
-
 # Install node.js for scip-typescript; github lists v18 and v20 as supported;
 # we are sticking with v18 for now because currently all the invocations
 # hardcode v18 as well; that will need to be addressed.
-SCIP_NODEJS_VERSION=nodejs@18
-mise install ${SCIP_NODEJS_VERSION}
+sudo apt install -y npm
 
 # Install scip-typescript under node.js v18
-mise exec ${SCIP_NODEJS_VERSION} -- npm install -g @sourcegraph/scip-typescript
+sudo npm install -g @sourcegraph/scip-typescript
 
 # Install scip-python under node.js v18 as well
-#mise exec ${SCIP_NODEJS_VERSION} -- npm install -g @sourcegraph/scip-python
+#npm install -g @sourcegraph/scip-python
 # To get my fix https://github.com/sourcegraph/scip-python/pull/150
-mise exec ${SCIP_NODEJS_VERSION} -- npm install -g @asutherland/scip-python
+sudo npm install -g @asutherland/scip-python
 
 # Install a JDK and Coursier.
 # v21 is currently the most recent available version of Ubuntu 24.04 (and v19 was

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -42,6 +42,7 @@ PATH="$PATH:$HOME/.local/share/coursier/bin"
 
 # Install scip-java
 cs install --contrib scip-java
+rm -rf ~/.cache/coursier
 
 # Create update script.
 cat > update.sh <<"THEEND"

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -59,7 +59,8 @@ make
 popd
 
 pushd mozsearch/tools
-cargo build --release --verbose
+CARGO_INCREMENTAL=false cargo build --release --verbose
+rm -rf target/build target/deps
 popd
 
 pushd mozsearch/scripts/web-analyze/wasm-css-analyzer

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -37,19 +37,15 @@ echo Config repository is $CONFIG_REPO rev $CONFIG_REV
 # Note: This seems needlessly wasteful but I'm not going to change this while
 # changing other things.
 rm -rf mozsearch
-git clone $MOZSEARCH_REPO mozsearch
+git clone -b $MOZSEARCH_REV $MOZSEARCH_REPO mozsearch --depth=1
 pushd mozsearch
-git checkout $MOZSEARCH_REV
 git submodule init
 git submodule update
 popd
 
 # Install files from the config repo.
 rm -rf config
-git clone $CONFIG_REPO config
-pushd config
-git checkout $CONFIG_REV
-popd
+git clone -b $CONFIG_REV $CONFIG_REPO config --depth=1
 
 date
 

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -4,6 +4,11 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
+MOZSEARCH_REPO="${MOZSEARCH_REPO:-https://github.com/mozsearch/mozsearch}"
+MOZSEARCH_BRANCH="${MOZSEARCH_BRANCH:-master}"
+MOZSEARCH_CONFIG_REPO="${MOZSEARCH_CONFIG_REPO:-https://github.com/mozsearch/mozsearch-mozilla}"
+MOZSEARCH_CONFIG_BRANCH="${MOZSEARCH_CONFIG_BRANCH:-master}"
+
 # Nginx
 sudo apt-get install -y nginx
 
@@ -66,10 +71,10 @@ chmod +x update.sh
 # this really is just:
 # - Validating the image can compile and use rust and clang correctly.
 # - Caching some crates in `~/.cargo`.
-./update.sh https://github.com/mozsearch/mozsearch master https://github.com/mozsearch/mozsearch-mozilla master
+./update.sh "$MOZSEARCH_REPO" "$MOZSEARCH_BRANCH" "$MOZSEARCH_CONFIG_REPO" "$MOZSEARCH_CONFIG_BRANCH"
 mv update-log provision-update-log-1
 
 # Run this a second time to make sure the script is actually idempotent, so we
 # don't have any surprises when the update script gets run when the VM spins up.
-./update.sh https://github.com/mozsearch/mozsearch master https://github.com/mozsearch/mozsearch-mozilla master
+./update.sh "$MOZSEARCH_REPO" "$MOZSEARCH_BRANCH" "$MOZSEARCH_CONFIG_REPO" "$MOZSEARCH_CONFIG_BRANCH"
 mv update-log provision-update-log-2

--- a/infrastructure/web-server-update.sh
+++ b/infrastructure/web-server-update.sh
@@ -27,5 +27,6 @@ rustup component remove rust-docs || true
 rustup update
 
 pushd mozsearch/tools
-cargo build --release --verbose
+CARGO_INCREMENTAL=false cargo build --release --verbose
+rm -rf target/build target/deps
 popd

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -109,7 +109,7 @@ done
 
 ## Python Stuff
 
-mise exec nodejs@18 -- scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
+scip-python index --show-progress-rate-limit 0 --project-name python --output python.scip
 mv python.scip $INDEX_ROOT
 
 $MOZSEARCH_PATH/tools/target/release/scip-indexer \


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1935484

This implements a simple GitHub Actions workflow for pull requests and pushes to master. It runs the existing provisioning scripts then runs the equivalent of `make build-test-repo` and `make webtest`.
It takes ±50 minutes to run, see a successful run here: https://github.com/nicolas-guichard/mozsearch/actions/runs/12690265272.

I had to:
- reduce the output size of the provisioning scripts, see all the “space savings” commits
- change css-analyze a bit to avoid leaking the index location in a symbol
- make sure the provisioning scripts clone the repo and branch that is being tested and not the master branch of https://github.com/mozsearch/mozsearch

The last point that bothers me is that the graphviz-dependent tests have different numerical results than what I get locally in my Podman test env, see 46352f3a4b83c48df4a2f4822cb2495611cae6e8. Any ideas why and what to do about it?