### PR TITLE
Bug 1942757 - Use the actual list of files in the objdir for indexing

### DIFF
--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -60,7 +60,7 @@ sudo apt-get remove -y unattended-upgrades
 sudo apt-get install -y gdb python3-dbg
 
 # Other
-sudo apt-get install -y parallel unzip python3-pip python3-venv lz4
+sudo apt-get install -y parallel unzip python3-pip python3-venv lz4 file
 
 # We want to be able to extract stuff from json (jq) and yaml (yq) and more
 # easily emit JSON from the shell (jo).

--- a/scripts/find-objdir-files.sh
+++ b/scripts/find-objdir-files.sh
@@ -4,9 +4,24 @@ set -x # Show commands
 set -eu # Errors/undefined vars are fatal
 set -o pipefail # Check all commands in a pipeline
 
-pushd ${INDEX_ROOT}/analysis/__GENERATED__
-find . -type f | sed -e 's#^./#__GENERATED__/#' > ${INDEX_ROOT}/objdir-files
-find . -mindepth 1 -type d | sed -e 's#^./#__GENERATED__/#' > ${INDEX_ROOT}/objdir-dirs
+# Some repositories don't have objdir.
+mkdir -p ${INDEX_ROOT}/objdir
+
+pushd ${INDEX_ROOT}/objdir
+# All text-like files in objdir are going to be reflected to the output.
+#
+# NOTE: exclude some known binary filename extensions to reduce the cost of
+#       the file type detection.
+set +o pipefail # grep can fail
+find . -type f -not -regex "\.(o|out|so|a|so\..*|scip)$" -exec file --mime {} + \
+    | grep -v 'charset=binary' \
+    | cut -d ":" -f 1 \
+    | sed -e 's#^./#__GENERATED__/#' \
+    > ${INDEX_ROOT}/objdir-files
+set -o pipefail
+find . -mindepth 1 -type d \
+    | sed -e 's#^./#__GENERATED__/#' \
+    > ${INDEX_ROOT}/objdir-dirs
 popd
 
 # This is shuffled for the benefit of the "parallel" invocation in output.sh so that

--- a/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__html.snap
+++ b/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__html.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&aggr_str"
-snapshot_kind: text
 ---
 <div role="row" id="line-43" class="source-line-with-number nesting-sticky-line">
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="43"></div>
-  <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span class="syn_def" data-symbols="S_rs_Loader#new()." data-confidences="[&quot;concrete&quot;]">new</span>(<span class="syn_def" data-symbols="S_rs_new().(deps_dir)" data-confidences="[&quot;concrete&quot;]">deps_dir</span>: <span data-symbols="S_rs_path/PathBuf#" data-confidences="[&quot;concrete&quot;]">PathBuf</span>) -> <span data-symbols="S_rs_Loader#" data-confidences="[&quot;concrete&quot;]">Self</span> {
+  <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span class="syn_def" data-symbols="S_rs_impl#[Loader]new()." data-confidences="[&quot;concrete&quot;]">new</span>(<span class="syn_def" data-symbols="S_rs_simple.rs/#0" data-confidences="[&quot;concrete&quot;]">deps_dir</span>: <span data-symbols="S_rs_path/PathBuf#" data-confidences="[&quot;concrete&quot;]">PathBuf</span>) -> <span data-symbols="S_rs_impl#[Loader]" data-confidences="[&quot;concrete&quot;]">Self</span> {
 </code>
 </div>

--- a/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__json.snap
+++ b/tests/tests/checks/snapshots/analysis/rust/simple.rs/check_glob@simple_Loader_new__json.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&json_results"
-snapshot_kind: text
 ---
 [
   {
@@ -9,7 +8,7 @@ snapshot_kind: text
     "source": 1,
     "syntax": "def,method",
     "pretty": "method Loader::new",
-    "sym": "S_rs_Loader#new().",
+    "sym": "S_rs_impl#[Loader]new().",
     "nestingRange": "43:42-49:5",
     "type": "pub fn new(deps_dir: PathBuf) -> Self"
   },
@@ -18,7 +17,7 @@ snapshot_kind: text
     "target": 1,
     "kind": "def",
     "pretty": "Loader::new",
-    "sym": "S_rs_Loader#new().",
+    "sym": "S_rs_impl#[Loader]new().",
     "context": "Loader",
     "contextsym": "S_rs_Loader#"
   }

--- a/tests/tests/checks/snapshots/analysis/rust/test_rust_dependency/check_glob@MyType__html.snap
+++ b/tests/tests/checks/snapshots/analysis/rust/test_rust_dependency/check_glob@MyType__html.snap
@@ -1,12 +1,11 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&aggr_str"
-snapshot_kind: text
 ---
 <div role="row" id="line-13" class="source-line-with-number nesting-sticky-line">
   <div role="cell"><div class="cov-strip cov-no-data"></div></div>
   <div role="cell"><div class="blame-strip"></div></div>
   <div role="cell" class="line-number" data-line-number="13"></div>
-  <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span class="syn_def" data-symbols="S_rs_MyType#do_foo()." data-confidences="[&quot;concrete&quot;]">do_foo</span>(<span class="syn_def" data-symbols="S_rs_do_foo().(self)" data-confidences="[&quot;concrete&quot;]">self</span>) -> <span data-symbols="S_rs_MyType#" data-confidences="[&quot;concrete&quot;]">MyType</span> {
+  <code role="cell" class="source-line">    <span class="syn_reserved" >pub</span> <span class="syn_reserved" >fn</span> <span class="syn_def" data-symbols="S_rs_impl#[MyType]do_foo()." data-confidences="[&quot;concrete&quot;]">do_foo</span>(<span class="syn_def" data-symbols="S_rs_test_rust_dependency/src/lib.rs/#0" data-confidences="[&quot;concrete&quot;]">self</span>) -> <span data-symbols="S_rs_MyType#" data-confidences="[&quot;concrete&quot;]">MyType</span> {
 </code>
 </div>

--- a/tests/tests/checks/snapshots/analysis/rust/test_rust_dependency/check_glob@MyType__json.snap
+++ b/tests/tests/checks/snapshots/analysis/rust/test_rust_dependency/check_glob@MyType__json.snap
@@ -1,7 +1,6 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&json_results"
-snapshot_kind: text
 ---
 [
   {
@@ -9,7 +8,7 @@ snapshot_kind: text
     "source": 1,
     "syntax": "def,method",
     "pretty": "method MyType::do_foo",
-    "sym": "S_rs_MyType#do_foo().",
+    "sym": "S_rs_impl#[MyType]do_foo().",
     "nestingRange": "13:34-15:5",
     "type": "pub fn do_foo(self) -> MyType"
   },
@@ -18,7 +17,7 @@ snapshot_kind: text
     "target": 1,
     "kind": "def",
     "pretty": "MyType::do_foo",
-    "sym": "S_rs_MyType#do_foo().",
+    "sym": "S_rs_impl#[MyType]do_foo().",
     "context": "MyType",
     "contextsym": "S_rs_MyType#"
   }

--- a/tests/tests/checks/snapshots/jumpref/jumpref/simple.rs/check_glob@loader__needs_hard_reload__lookup__json.snap
+++ b/tests/tests/checks/snapshots/jumpref/jumpref/simple.rs/check_glob@loader__needs_hard_reload__lookup__json.snap
@@ -1,22 +1,20 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&to_value(jvl).unwrap()"
-snapshot_kind: text
 ---
 {
   "values": [
     {
       "value": {
-        "sym": "S_rs_Loader#needs_hard_reload().",
+        "sym": "S_rs_impl#[Loader]needs_hard_reload().",
         "pretty": "Loader::needs_hard_reload",
         "meta": {
           "structured": 1,
           "pretty": "Loader::needs_hard_reload",
-          "sym": "S_rs_Loader#needs_hard_reload().",
+          "sym": "S_rs_impl#[Loader]needs_hard_reload().",
           "type_pretty": "fn needs_hard_reload(&self, _: &Path) -> bool",
           "kind": "method",
           "subsystem": "Core/Simple",
-          "parentsym": "S_rs_Loader#",
           "implKind": "impl",
           "sizeBytes": null,
           "ownVFPtrBytes": null,

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@generated_listing__html.snap
@@ -80,9 +80,51 @@ expression: "&fb.contents"
     </thead>
     <tbody>
         <tr>
+          <td><a href="/tests/source/__GENERATED__/.rustc_info.json" class="mimetype-fixed-container mimetype-icon-json">.rustc_info.json</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/.rustc_info.json" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/.rustc_info.json">1623</a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/__RUST_BUILD_SCRIPT__" class="mimetype-fixed-container mimetype-icon-folder">__RUST_BUILD_SCRIPT__</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/__RUST_BUILD_SCRIPT__" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/__RUST_BUILD_SCRIPT__"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/__win64__" class="mimetype-fixed-container mimetype-icon-folder">__win64__</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/__win64__" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/__win64__"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/CACHEDIR.TAG" class="mimetype-fixed-container mimetype-icon-TAG">CACHEDIR.TAG</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/CACHEDIR.TAG" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/CACHEDIR.TAG">177</a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/cpp" class="mimetype-fixed-container mimetype-icon-folder">cpp</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/cpp" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/cpp"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/debug" class="mimetype-fixed-container mimetype-icon-folder">debug</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/debug" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/debug"></a></td>
+        </tr>
+
+        <tr>
           <td><a href="/tests/source/__GENERATED__/dist" class="mimetype-fixed-container mimetype-icon-folder">dist</a></td>
           <td class="description"><a href="/tests/source/__GENERATED__/dist" title=""></td>
           <td><a href="/tests/source/__GENERATED__/dist"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/dom" class="mimetype-fixed-container mimetype-icon-folder">dom</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/dom" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/dom"></a></td>
         </tr>
 
         <tr>
@@ -101,6 +143,36 @@ expression: "&fb.contents"
           <td><a href="/tests/source/__GENERATED__/ipdl" class="mimetype-fixed-container mimetype-icon-folder">ipdl</a></td>
           <td class="description"><a href="/tests/source/__GENERATED__/ipdl" title=""></td>
           <td><a href="/tests/source/__GENERATED__/ipdl"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/staticprefs" class="mimetype-fixed-container mimetype-icon-folder">staticprefs</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/staticprefs" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/staticprefs"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/subdir" class="mimetype-fixed-container mimetype-icon-folder">subdir</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/subdir" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/subdir"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/urlmap" class="mimetype-fixed-container mimetype-icon-folder">urlmap</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/urlmap" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/urlmap"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/webidl" class="mimetype-fixed-container mimetype-icon-folder">webidl</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/webidl" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/webidl"></a></td>
+        </tr>
+
+        <tr>
+          <td><a href="/tests/source/__GENERATED__/webtest" class="mimetype-fixed-container mimetype-icon-folder">webtest</a></td>
+          <td class="description"><a href="/tests/source/__GENERATED__/webtest" title=""></td>
+          <td><a href="/tests/source/__GENERATED__/webtest"></a></td>
         </tr>
 
     </tbody>

--- a/tests/tests/checks/snapshots/web/files/contextual-keyword/check_glob@contextual-keyword_rs__html.snap
+++ b/tests/tests/checks/snapshots/web/files/contextual-keyword/check_glob@contextual-keyword_rs__html.snap
@@ -1,11 +1,9 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&fb.contents"
-snapshot_kind: text
 ---
 <span data-symbols="FILE_rust/weak_keyword@2Ers">(file symbol)</span>
-<span class="syn_def" data-symbols="S_rs_weak_keyword/rust/f()." data-confidences="[&quot;concrete&quot;]">f</span>
-<span data-symbols="S_rs_rust/weak_keyword.rs/#0" data-confidences="[&quot;concrete&quot;]">i32</span>
+<span class="syn_def" data-symbols="S_rs_rust/weak_keyword/f()." data-confidences="[&quot;concrete&quot;]">f</span>
 <span class="syn_def" data-symbols="S_rs_rust/weak_keyword.rs/#0" data-confidences="[&quot;concrete&quot;]">macro_rules</span>
 <span class="syn_def" data-symbols="S_rs_rust/weak_keyword.rs/#1" data-confidences="[&quot;concrete&quot;]">union</span>
 <span data-symbols="S_rs_rust/weak_keyword.rs/#0" data-confidences="[&quot;concrete&quot;]">macro_rules</span>


### PR DESCRIPTION
This is for https://bugzilla.mozilla.org/show_bug.cgi?id=1943521 and https://bugzilla.mozilla.org/show_bug.cgi?id=1942757

This patch stack does:
  * Update the test snapshot to reflect the new rust SCIP symbol syntax  (This is a part of the stack because otherwise the test fails on the latest rust nightly)
  * Stop generating the C++ `.o` files in the objdir in the test repo, so that those files are not shown in the output
  * Use the list of files in objdir, for the files reflected in __GENERATED__ files.  The newly added files are listed in the bug 1942757 comment 6

Available in https://arai.searchfox.org/