### PR TITLE
CI: Fix cloning repo from pull request

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       # See https://insta.rs/docs/advanced/#controlling-snapshot-updating
       INSTA_UPDATE: new
       MOZSEARCH_REPO: ${{ github.server_url }}/${{ github.repository }}
-      MOZSEARCH_BRANCH: ${{ github.ref_name }}
+      MOZSEARCH_BRANCH: ${{ github.ref }}
 
     steps:
       - uses: actions/checkout@v4

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -41,7 +41,13 @@ git config --global pull.ff only
 # we have git, so let's check out mozsearch now so we can have our email sending
 # script in case of an error.
 if [ ! -d mozsearch ]; then
-  git clone -b $MOZSEARCH_BRANCH $MOZSEARCH_REPO mozsearch --depth=1
+  mkdir mozsearch
+  pushd mozsearch
+  git init
+  git remote add origin "$MOZSEARCH_REPO"
+  git fetch origin "$MOZSEARCH_BRANCH"
+  git switch --detach FETCH_HEAD
+  popd
 fi
 
 # the base image we're building against is inherently not up-to-date (new base

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -77,8 +77,12 @@ echo Config repository is $CONFIG_REPO rev $CONFIG_REV
 
 # Install mozsearch.
 rm -rf mozsearch
-git clone -b $MOZSEARCH_REV $MOZSEARCH_REPO mozsearch --depth=1
+mkdir mozsearch
 pushd mozsearch
+git init
+git remote add origin "$MOZSEARCH_REPO"
+git fetch origin "$MOZSEARCH_REV"
+git switch --detach FETCH_HEAD
 git submodule init
 git submodule update
 popd

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -42,8 +42,12 @@ echo Config repository is $CONFIG_REPO rev $CONFIG_REV
 # Note: This seems needlessly wasteful but I'm not going to change this while
 # changing other things.
 rm -rf mozsearch
-git clone -b $MOZSEARCH_REV $MOZSEARCH_REPO mozsearch --depth=1
+mkdir mozsearch
 pushd mozsearch
+git init
+git remote add origin "$MOZSEARCH_REPO"
+git fetch origin "$MOZSEARCH_REV"
+git switch --detach FETCH_HEAD
 git submodule init
 git submodule update
 popd


### PR DESCRIPTION
GitHub merge repos are not available as an actual branch and can't be directly cloned with `git clone -b ... --depth=1`. Instead, perform the manual steps of creating the repo, adding the remote, fetching and switching.