### PR TITLE
Update update.sh call in trigger_common.py

### DIFF
--- a/infrastructure/aws/trigger_common.py
+++ b/infrastructure/aws/trigger_common.py
@@ -119,7 +119,7 @@ class TriggerCommandBase:
 
     cd ~ubuntu
     {extra_commands}
-    sudo -i -u ubuntu {cmd_env_vars} ./update.sh "{branch}" "{mozsearch_repo}" "{config_repo}"
+    sudo -i -u ubuntu {cmd_env_vars} ./update.sh "{mozsearch_repo}" "{branch}" "{config_repo}" "{branch}"
     sudo -i -u ubuntu {cmd_env_vars} mozsearch/infrastructure/aws/main.sh {core_script} {max_runtime_hours} "{branch}" "{channel}" {extra_args}
     '''.format(
         core_script=self.core_script,


### PR DESCRIPTION
In 54490508, I updated the indexer's update.sh arguments to match web-server's update.sh, but missed the call in trigger_common.py.