### PR TITLE
Bug 1944279 - Unconditionally upgrade Rust to Nightly.

### DIFF
--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -142,11 +142,11 @@ sudo apt-get install -y cmake protobuf-compiler
 if [ ! -d $HOME/.cargo ]; then
   curl https://sh.rustup.rs -sSf | sh -s -- -y
   source $HOME/.cargo/env
-  rustup install nightly
-  rustup default nightly
-  rustup uninstall stable
-  rustup component add rust-analyzer
 fi
+rustup install nightly
+rustup default nightly
+rustup uninstall stable
+rustup component add rust-analyzer
 
 # install ripgrep so we can stop experiencing grep pain / footguns
 sudo apt-get install ripgrep


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1944279

The GitHub Actions runner already has rustup and `$HOME/.cargo`, but we still want to upgrade to the nightly channel.