### PR TITLE
Bug 1627778 - Do not float the SVG preview.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1183,6 +1183,10 @@ input::placeholder {
   }
 }
 
+.svg-preview {
+  padding: 0 1rem;
+}
+
 .svg-preview > h4 {
   margin-bottom: 0;
 }

--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1196,8 +1196,6 @@ input::placeholder {
 }
 
 .svg-preview > a > img {
-  float: left;
-  clear: both;
   min-height: 50px;
   max-height: 300px;
   min-width: 50px;
@@ -1208,11 +1206,7 @@ input::placeholder {
   margin-bottom: 1em;
 }
 
-#svg-preview-checkerboard {
-  margin-inline-start: 0;
-}
-
-#svg-preview-checkerboard:checked + label + a > img {
+#svg-preview-background-checkerboard:checked ~ a > img {
   background-image: linear-gradient(
       45deg,
       #555 25%,
@@ -1231,6 +1225,16 @@ input::placeholder {
     );
   background-size: 10px 10px;
   background-position: 0 0, 5px 5px;
+}
+
+#svg-preview-background-light:checked ~ a > img {
+  background-color: #d8d8d8;
+  color-scheme: light;
+}
+
+#svg-preview-background-dark:checked ~ a > img {
+  background-color: #181818;
+  color-scheme: dark;
 }
 
 .syn_def {

--- a/tools/src/output.rs
+++ b/tools/src/output.rs
@@ -475,8 +475,14 @@ pub fn generate_svg_preview(writer: &mut dyn Write, url: &str) -> Result<(), &'s
         F::S(r#"<div class="svg-preview">"#),
         F::Indent(vec![
             F::S("<h4>SVG Preview (Scaled)</h4>"),
-            F::S(r#"<input type="checkbox" id="svg-preview-checkerboard"/>"#),
-            F::S(r#"<label for="svg-preview-checkerboard">Checkerboard</label>"#),
+            F::S(r#"<input id="svg-preview-background-default" type="radio" name="svg-preview-background" value="default" checked>"#),
+            F::S(r#"<label for="svg-preview-background-default">Default</label>"#),
+            F::S(r#"<input id="svg-preview-background-checkerboard" type="radio" name="svg-preview-background" value="checkerboard">"#),
+            F::S(r#"<label for="svg-preview-background-checkerboard">Checkerboard</label>"#),
+            F::S(r#"<input id="svg-preview-background-light" type="radio" name="svg-preview-background" value="light">"#),
+            F::S(r#"<label for="svg-preview-background-light">Light</label>"#),
+            F::S(r#"<input id="svg-preview-background-dark" type="radio" name="svg-preview-background" value="dark">"#),
+            F::S(r#"<label for="svg-preview-background-dark">Dark</label>"#),
             F::T(format!(r#"<a href="{}">"#, url)),
             F::Indent(vec![F::T(format!(
                 r#"<img src="{0}" alt="Preview of {0}"/>"#,


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1627778

This does:
  * Make the SVG preview not float, so that it's displayed before the source, and it doesn't break the layout of the source
  * Add more background options (explicit light and dark), given it now has more horizontal space in the control part, and the default background depends on the current theme (light/dark)

<img width="1411" alt="preview" src="https://github.com/user-attachments/assets/9b7ba3e2-e9ec-4610-bd38-0f4a16fb92f2" />

available in https://arai.searchfox.org/mozilla-central/source/browser/branding/aurora/content/about-logo.svg

This doesn't have testcase because the preview is available only with hg repository.