### PR TITLE
Bug 1948451 - Ignore more import assertions errors.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -75,6 +75,11 @@ const ERROR_INTERVENTIONS = [
     prepend: "(unsupported) import attributes can parse this way: "
   },
   {
+    includes: "import attributes are not currently supported",
+    severity: "INFO",
+    prepend: "(unsupported) import attributes can also parse this way: "
+  },
+  {
     includes: "redeclaration of import",
     severity: "INFO",
     prepend: "Known buggy code pattern is not a problem: "


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=1948451

This adds one more pattern for the error message around import assertions.
