### PR TITLE
Bug 1941480 - Adjust mozsearch plugin code to recent clang trunk API changes. r=asuth

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1411,7 +1411,11 @@ public:
 
         J.attribute("begin",
                     unsigned(localOffsetBits - C.toBits(localOffsetBytes)));
+#if CLANG_VERSION_MAJOR < 20
         J.attribute("width", Field.getBitWidthValue(C));
+#else
+        J.attribute("width", Field.getBitWidthValue());
+#endif
 
         J.objectEnd();
         J.attributeEnd();


### PR DESCRIPTION
This is asuth propagating :glandium's changes from https://phabricator.services.mozilla.com/D234132

I have set the authorship to the commit author from that patch to accurately reflect authorship.