### PR TITLE
Bug 1959582 - Correct mozsearch-mozilla specific revision checkout for web-server

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -81,15 +81,20 @@ mkdir mozsearch
 pushd mozsearch
 git init
 git remote add origin "$MOZSEARCH_REPO"
-git fetch origin "$MOZSEARCH_REV"
-git switch --detach FETCH_HEAD
-git submodule init
-git submodule update
+git fetch origin --depth=1 "$MOZSEARCH_REV"
+git reset --hard FETCH_HEAD
+git submodule update --init --depth 1
 popd
 
 # Install files from the config repo.
 rm -rf config
-git clone -b $CONFIG_REV $CONFIG_REPO config --depth=1
+mkdir config
+pushd config
+git init
+git remote add origin "$CONFIG_REPO"
+git fetch origin --depth=1 "$CONFIG_REV"
+git reset --hard FETCH_HEAD
+popd
 
 date
 

--- a/infrastructure/web-server-provision.sh
+++ b/infrastructure/web-server-provision.sh
@@ -46,15 +46,20 @@ mkdir mozsearch
 pushd mozsearch
 git init
 git remote add origin "$MOZSEARCH_REPO"
-git fetch origin "$MOZSEARCH_REV"
-git switch --detach FETCH_HEAD
-git submodule init
-git submodule update
+git fetch origin --depth=1 "$MOZSEARCH_REV"
+git reset --hard FETCH_HEAD
+git submodule update --init --depth 1
 popd
 
 # Install files from the config repo.
 rm -rf config
-git clone -b $CONFIG_REV $CONFIG_REPO config --depth=1
+mkdir config
+pushd config
+git init
+git remote add origin "$CONFIG_REPO"
+git fetch origin --depth=1 "$CONFIG_REV"
+git reset --hard FETCH_HEAD
+popd
 
 date
 


### PR DESCRIPTION
I'm also speculatively trying to leverage the ability to perform a shallow checkout of submodules as well to help the disk space usage for the CI runners.  It sounds like there might have been problems in very old verisons of git if the revision wasn't the branch head but that it's no longer a problem.  We also do try and stick to the tip of the branches, so that also should moot things.