### PR TITLE
Bug 1959722 - Ignore warnings about redirecting to hg-edge.mozilla.org

### DIFF
--- a/infrastructure/aws/warning-suppression.patterns
+++ b/infrastructure/aws/warning-suppression.patterns
@@ -1,1 +1,2 @@
 ^Warning: The unit file, source configuration file or drop-ins of
+^warning: redirecting to https://hg-edge.mozilla.org/


### PR DESCRIPTION
I tested this against the most recent config1 indexer run using `send-warning-email.py`'s test mechanism for when "test" is specified as the email address to use.  Pre-change, I see what got sent, post-change I see no warnings.