### PR TITLE
Bug 1938622 - Update test gradle project to Kotlin 2.1.20.

### DIFF
--- a/tests/tests/checks/inputs/analysis/java/InlineObject.kt/method__json
+++ b/tests/tests/checks/inputs/analysis/java/InlineObject.kt/method__json
@@ -1,1 +1,1 @@
-filter-analysis src/main/kotlin/sample/InlineObject.kt -r structured -i someFunction
+filter-analysis src/main/kotlin/sample/InlineObject.kt -r structured -s "S_jvm_sample/<anonymous_object_at_137>#someFunction()."

--- a/tests/tests/checks/inputs/analysis/java/InlineObject.kt/method_with_return_type__json
+++ b/tests/tests/checks/inputs/analysis/java/InlineObject.kt/method_with_return_type__json
@@ -1,1 +1,1 @@
-filter-analysis src/main/kotlin/sample/InlineObject.kt -r structured -i someOtherFunction
+filter-analysis src/main/kotlin/sample/InlineObject.kt -r structured -s "S_jvm_sample/<anonymous_object_at_137>#someOtherFunction()."

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method__json.snap
@@ -1,41 +1,18 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&json_results"
+input_file: inputs/analysis/java/InlineObject.kt/method__json
 ---
 [
   {
     "loc": "00010:21-33",
     "structured": 1,
-    "pretty": "someFunction",
-    "sym": "S_jvm_src/main/kotlin/sample/InlineObject.kt/#0",
+    "pretty": "sample::<anonymous object at 137>::someFunction",
+    "sym": "S_jvm_sample/<anonymous_object_at_137>#someFunction().",
     "type_pretty": null,
     "kind": "method",
     "subsystem": null,
-    "implKind": "impl",
-    "sizeBytes": null,
-    "alignmentBytes": null,
-    "ownVFPtrBytes": null,
-    "bindingSlots": [],
-    "ontologySlots": [],
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [
-      {
-        "sym": "S_jvm_sample/Interface#someFunction()."
-      }
-    ],
-    "props": [],
-    "variants": []
-  },
-  {
-    "loc": "00016:21-33",
-    "structured": 1,
-    "pretty": "someFunction",
-    "sym": "S_jvm_src/main/kotlin/sample/InlineObject.kt/#2",
-    "type_pretty": null,
-    "kind": "method",
-    "subsystem": null,
+    "parentsym": "S_jvm_sample/<anonymous_object_at_137>#",
     "implKind": "impl",
     "sizeBytes": null,
     "alignmentBytes": null,

--- a/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
+++ b/tests/tests/checks/snapshots/analysis/java/InlineObject.kt/check_glob@method_with_return_type__json.snap
@@ -1,41 +1,18 @@
 ---
 source: tests/test_check_insta.rs
 expression: "&json_results"
+input_file: inputs/analysis/java/InlineObject.kt/method_with_return_type__json
 ---
 [
   {
     "loc": "00011:21-38",
     "structured": 1,
-    "pretty": "someOtherFunction",
-    "sym": "S_jvm_src/main/kotlin/sample/InlineObject.kt/#1",
+    "pretty": "sample::<anonymous object at 137>::someOtherFunction",
+    "sym": "S_jvm_sample/<anonymous_object_at_137>#someOtherFunction().",
     "type_pretty": null,
     "kind": "method",
     "subsystem": null,
-    "implKind": "impl",
-    "sizeBytes": null,
-    "alignmentBytes": null,
-    "ownVFPtrBytes": null,
-    "bindingSlots": [],
-    "ontologySlots": [],
-    "supers": [],
-    "methods": [],
-    "fields": [],
-    "overrides": [
-      {
-        "sym": "S_jvm_sample/Interface#someOtherFunction()."
-      }
-    ],
-    "props": [],
-    "variants": []
-  },
-  {
-    "loc": "00017:21-38",
-    "structured": 1,
-    "pretty": "someOtherFunction",
-    "sym": "S_jvm_src/main/kotlin/sample/InlineObject.kt/#3",
-    "type_pretty": null,
-    "kind": "method",
-    "subsystem": null,
+    "parentsym": "S_jvm_sample/<anonymous_object_at_137>#",
     "implKind": "impl",
     "sizeBytes": null,
     "alignmentBytes": null,

--- a/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/check_glob@root_listing__html.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/test_check_insta.rs
+assertion_line: 116
 expression: "&fb.contents"
 ---
 <!DOCTYPE html>
@@ -230,7 +231,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/build.gradle.kts" class="mimetype-fixed-container mimetype-icon-kts">build.gradle.kts</a></td>
           <td class="description"><a href="/tests/source/build.gradle.kts" title=""></td>
-          <td><a href="/tests/source/build.gradle.kts">2370</a></td>
+          <td><a href="/tests/source/build.gradle.kts">2436</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/build.gradle.kts
+++ b/tests/tests/files/build.gradle.kts
@@ -7,7 +7,7 @@
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "1.9.25"
+    id("org.jetbrains.kotlin.jvm") version "2.1.20"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -16,6 +16,7 @@ plugins {
 repositories {
     // Use Maven Central for resolving dependencies.
     mavenCentral()
+    maven { url = uri("https://maven.mozilla.org/maven2/") }
 }
 
 dependencies {
@@ -39,7 +40,7 @@ dependencies {
     //
     compileOnly("com.sourcegraph:semanticdb-javac:0.10.3")
     testCompileOnly("com.sourcegraph:semanticdb-javac:0.10.3")
-    kotlinCompilerPluginClasspath("com.sourcegraph:semanticdb-kotlinc:0.4.0")
+    kotlinCompilerPluginClasspath("com.github.mozsearch:semanticdb-kotlinc:0.5.0")
 }
 
 var sourceroot = rootProject.projectDir.getCanonicalPath()


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1938622

This updates the test gradle project to use Kotlin 2.1.20 and our forked semanticdb-kotlinc.

Like my patch currently on review on Phabricator it's using JitPack for the time being, until we publish the package to Maven Central or maven.mozilla.org.