### PR TITLE
Remove --allow-change-held-packages from apt dist-upgrade

### DIFF
--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -56,7 +56,7 @@ sudo DEBIAN_FRONTEND=noninteractive \
   apt-get \
   -o Dpkg::Options::=--force-confold \
   -o Dpkg::Options::=--force-confdef \
-  -y --allow-downgrades --allow-remove-essential --allow-change-held-packages \
+  -y --allow-downgrades --allow-remove-essential \
   dist-upgrade
 
 # unattended upgrades pose a problem for debugging running processes because we


### PR DESCRIPTION
On GitHub CI, this leads to updating containernetworking-plugins, which would then conflict with node-tap for the file /usr/bin/tap.