### PR TITLE
Bug 1782285 - Blonk blame fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,22 @@ serve-mozsearch-repo: check-in-vagrant build-clang-plugin build-rust-tools
 # Notes:
 # - If you want to use a modified version of mozsearch-mozilla, such as one
 #   checked out under "config" in the check-out repo, you can create a symlink
+#   in the VM's home directory via `pushd ~; ln -s /vagrant/config blonk-config`.
+build-blonk-repo: check-in-vagrant build-clang-plugin build-rust-tools
+	[ -e ~/blonk-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/blonk-config
+	mkdir -p ~/blonk-index
+	/vagrant/infrastructure/indexer-setup.sh ~/blonk-config config6.json ~/blonk-index
+	/vagrant/infrastructure/indexer-run.sh ~/blonk-config ~/blonk-index
+	/vagrant/infrastructure/web-server-setup.sh ~/blonk-config config6.json ~/blonk-index ~
+	/vagrant/infrastructure/web-server-run.sh ~/blonk-config ~/blonk-index ~
+
+serve-blonk-repo: check-in-vagrant build-clang-plugin build-rust-tools
+	/vagrant/infrastructure/web-server-setup.sh ~/blonk-config config6.json ~/blonk-index ~
+	/vagrant/infrastructure/web-server-run.sh ~/blonk-config ~/blonk-index ~
+
+# Notes:
+# - If you want to use a modified version of mozsearch-mozilla, such as one
+#   checked out under "config" in the check-out repo, you can create a symlink
 #   in the VM's home directory via `pushd ~; ln -s /vagrant/config llvm-config`.
 build-llvm-repo: check-in-vagrant build-clang-plugin build-rust-tools
 	[ -e ~/llvm-config ] || git clone https://github.com/mozsearch/mozsearch-mozilla ~/llvm-config

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -303,7 +303,7 @@ lazy_static! {
         // There's also an alt over function/generators
         SitterNesting {
             root_node_type: vec![
-                "function",
+                "function_expression",
                 "function_declaration",
                 "generator_function",
                 "generator_function_declaration"


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1782285 this allows us to successfully generate blame for the blonk tree.  Specific details in the specific commit messages (and on the bug).

I was able to successfully run `make build-test-repo` followed by running `make build-searchfox-repo` twice in sequence to help verify that there is indeed no problem with the build-blame handling of the marks file in the success case.

I'm putting this up for a fix now because I'm planning to try and implement the enhancements for the "firefox" tree discussed in matrix that will build on these changes.