### PR TITLE
Bug 1970807 - Update from m5d to m6id instances for indexer.

### DIFF
--- a/infrastructure/aws/trigger_common.py
+++ b/infrastructure/aws/trigger_common.py
@@ -84,7 +84,6 @@ class TriggerCommandBase:
         #   using an m5d.2xlarge
         # - release5 (bug 1912078 ish): runtime hit 8.5 hours and much of this
         #   is simply build duration for webkit, so should parallelize easily.
-        #   This also gives us a ton of SSD-backed swap as a release valve.
         #
         # This decision is baked into the script here rather than present in
         # config files because we run this script as part of a lambda job run
@@ -93,9 +92,9 @@ class TriggerCommandBase:
         # could of course be changed, but potentially would make the lambda jobs
         # more complex / brittle.)
         if args.channel == "release4" or args.channel == "release5":
-            instance_type = 'm5d.4xlarge'
+            instance_type = 'm6id.4xlarge'
         else:
-            instance_type = 'm5d.2xlarge'
+            instance_type = 'm6id.2xlarge'
 
         # Terminate any "running" or "stopped" instances.  We used to only
         # terminate "running" instances with the theory that someone might get


### PR DESCRIPTION
This is motivated by config2 hitting the limit of the 300G SSD for m5d.2xlarge. The choice of m6id is being made because it seems to both be faster and gives us a larger 474G SSD which immediately solves our sizing problem.  Also nice is that m6id.4xlarge will have a 950G SSD which means that we won't have to do any clever RAID stuff if we want even more local space than that.

Note that I will need to re-provision the lambda tarballs after this and I will do that.