### PR TITLE
Update test gradle project to Kotlin 2.2.0

### DIFF
--- a/tests/tests/checks/snapshots/web/dirs/main@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/main@root_listing__html.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/test-index.rs
-assertion_line: 116
+assertion_line: 119
 expression: "&fb.contents"
 ---
 <!DOCTYPE html>
@@ -231,7 +231,7 @@ expression: "&fb.contents"
         <tr>
           <td><a href="/tests/source/build.gradle.kts" class="mimetype-fixed-container mimetype-icon-kts">build.gradle.kts</a></td>
           <td class="description"><a href="/tests/source/build.gradle.kts" title=""></td>
-          <td><a href="/tests/source/build.gradle.kts">2436</a></td>
+          <td><a href="/tests/source/build.gradle.kts">2435</a></td>
         </tr>
 
         <tr>

--- a/tests/tests/files/build.gradle.kts
+++ b/tests/tests/files/build.gradle.kts
@@ -7,7 +7,7 @@
 
 plugins {
     // Apply the org.jetbrains.kotlin.jvm Plugin to add support for Kotlin.
-    id("org.jetbrains.kotlin.jvm") version "2.1.20"
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
 
     // Apply the java-library plugin for API and implementation separation.
     `java-library`
@@ -40,7 +40,7 @@ dependencies {
     //
     compileOnly("com.sourcegraph:semanticdb-javac:0.10.3")
     testCompileOnly("com.sourcegraph:semanticdb-javac:0.10.3")
-    kotlinCompilerPluginClasspath("com.github.mozsearch:semanticdb-kotlinc:0.5.0")
+    kotlinCompilerPluginClasspath("com.github.mozsearch:semanticdb-kotlinc:0.6.0")
 }
 
 var sourceroot = rootProject.projectDir.getCanonicalPath()


### PR DESCRIPTION
Mozilla-central updated to Kotlin 2.2.0 almost a month ago with [bug 1975907](https://bugzilla.mozilla.org/show_bug.cgi?id=1975907). This catches up.