### PR TITLE
Use mozsearch tools from PATH

### DIFF
--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -53,12 +53,12 @@ rm -rf ~/.cache/coursier
 PYMODULES=$HOME/pymodules
 mkdir "${PYMODULES}"
 pushd "${PYMODULES}"
-wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/xpcom/idl-parser/xpidl/xpidl.py"
-wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/dom/bindings/parser/WebIDL.py"
+wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/xpcom/idl-parser/xpidl/xpidl.py"
+wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/dom/bindings/parser/WebIDL.py"
 mkdir ply
 pushd ply
 for PLYFILE in __init__.py lex.py yacc.py; do
-    wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/third_party/python/ply/ply/${PLYFILE}"
+    wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/third_party/python/ply/ply/${PLYFILE}"
 done
 popd
 popd

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -59,8 +59,8 @@ make
 popd
 
 pushd mozsearch/tools
-CARGO_INCREMENTAL=false cargo build --release --verbose
-rm -rf target/build target/deps
+CARGO_INCREMENTAL=false cargo install --path . --verbose
+rm -rf target
 popd
 
 pushd mozsearch/scripts/web-analyze/wasm-css-analyzer

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -83,12 +83,12 @@ fi
 if [ ! -d "${PYMODULES}" ]; then
     mkdir "${PYMODULES}"
     pushd "${PYMODULES}"
-    wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/xpcom/idl-parser/xpidl/xpidl.py"
-    wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/dom/bindings/parser/WebIDL.py"
+    wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/xpcom/idl-parser/xpidl/xpidl.py"
+    wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/dom/bindings/parser/WebIDL.py"
     mkdir ply
     pushd ply
     for PLYFILE in __init__.py lex.py yacc.py; do
-        wget "https://hg.mozilla.org/mozilla-central/raw-file/tip/third_party/python/ply/ply/${PLYFILE}"
+        wget "https://github.com/mozilla-firefox/firefox/raw/refs/heads/main/third_party/python/ply/ply/${PLYFILE}"
     done
     popd
     popd

--- a/infrastructure/web-server-run.sh
+++ b/infrastructure/web-server-run.sh
@@ -21,8 +21,8 @@ STATUS_FILE="${SERVER_ROOT}/docroot/status.txt"
 
 pkill -x codesearch || true
 pkill -f router/router.py || true
-pkill -f tools/target/release/web-server || true
-pkill -f tools/target/release/pipeline-server || true
+pkill -x web-server || true
+pkill -x pipeline-server || true
 
 sleep 0.1s
 
@@ -34,7 +34,7 @@ PATH="$LIVEGREP_VENV/bin:$PATH"
 nohup $MOZSEARCH_PATH/router/router.py $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/router.log 2> $SERVER_ROOT/router.err < /dev/null &
 
 export RUST_BACKTRACE=1
-nohup $MOZSEARCH_PATH/tools/target/release/web-server $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/rust-server.log 2> $SERVER_ROOT/rust-server.err < /dev/null &
+nohup web-server $CONFIG_FILE $STATUS_FILE > $SERVER_ROOT/rust-server.log 2> $SERVER_ROOT/rust-server.err < /dev/null &
 
 # Let's try and stop the pipeline-server from causing problems by setting a ulimit
 # on virtual memory usage.  We use du to figure out the total sizes of all of
@@ -64,7 +64,7 @@ ulimit -v $PIPELINE_SERVER_VM_LIMIT_K
 
 # Note that we do not currently wait for the pipeline-server and it does not
 # write to the STATUS_FILE.
-nohup $MOZSEARCH_PATH/tools/target/release/pipeline-server $CONFIG_FILE > $SERVER_ROOT/pipeline-server.log 2> $SERVER_ROOT/pipeline-server.err < /dev/null &
+nohup pipeline-server $CONFIG_FILE > $SERVER_ROOT/pipeline-server.log 2> $SERVER_ROOT/pipeline-server.err < /dev/null &
 
 # If WAIT was passed, wait until the servers report they loaded.
 if [[ ${4:-} = "WAIT" ]]; then

--- a/infrastructure/web-server-update.sh
+++ b/infrastructure/web-server-update.sh
@@ -27,8 +27,8 @@ rustup component remove rust-docs || true
 rustup update
 
 pushd mozsearch/tools
-CARGO_INCREMENTAL=false cargo build --release --verbose
-rm -rf target/build target/deps
+CARGO_INCREMENTAL=false cargo install --path . --verbose
+rm -rf target
 popd
 
 # TODO: remove after next provisioning

--- a/scripts/crossref.sh
+++ b/scripts/crossref.sh
@@ -11,7 +11,7 @@ OTHER_RESOURCES_PATH=$4
 
 echo Root is $INDEX_ROOT
 
-$MOZSEARCH_PATH/tools/target/release/crossref $CONFIG_FILE $TREE_NAME $ANALYSIS_FILES_PATH $OTHER_RESOURCES_PATH
+crossref $CONFIG_FILE $TREE_NAME $ANALYSIS_FILES_PATH $OTHER_RESOURCES_PATH
 
 # Re-sort the identifiers file so that it's case-insensitive.  (It was written
 # to disk from a case-sensitive BTreeMap.)

--- a/scripts/css-analyze.sh
+++ b/scripts/css-analyze.sh
@@ -14,6 +14,5 @@ CONFIG_FILE=$(realpath $1)
 TREE_NAME=$2
 
 cat $INDEX_ROOT/css-files | \
-    parallel $MOZSEARCH_PATH/tools/target/release/css-analyze \
-    $FILES_ROOT {} ">" $INDEX_ROOT/analysis/{}
+    parallel css-analyze $FILES_ROOT {} ">" $INDEX_ROOT/analysis/{}
 echo $?

--- a/scripts/ipdl-analyze.sh
+++ b/scripts/ipdl-analyze.sh
@@ -18,7 +18,7 @@ TREE_NAME=$2
 # all that matters is consistency and so pre-normalizing is fine.
 pushd $FILES_ROOT
 cat $INDEX_ROOT/ipdl-files | \
-    xargs $MOZSEARCH_PATH/tools/target/release/ipdl-analyze $(cat $INDEX_ROOT/ipdl-includes) \
+    xargs ipdl-analyze $(cat $INDEX_ROOT/ipdl-includes) \
           -f $INDEX_ROOT/repo-files \
           -o $INDEX_ROOT/objdir-files \
           -b $(realpath $FILES_ROOT) \

--- a/scripts/output.sh
+++ b/scripts/output.sh
@@ -65,24 +65,24 @@ TMPDIR_PATH=${DIAGS_DIR}
 #   which is obviously suboptimal.
 parallel --jobs 8 --pipepart -a $INDEX_ROOT/all-files --files --joblog $JOBLOG_PATH --tmpdir $TMPDIR_PATH \
     --block -1 --halt 2 --env RUST_BACKTRACE \
-    "$MOZSEARCH_PATH/tools/target/release/output-file $CONFIG_FILE $TREE_NAME $URL_MAP_PATH $DOC_TREES_PATH - 2>&1"
+    "output-file $CONFIG_FILE $TREE_NAME $URL_MAP_PATH $DOC_TREES_PATH - 2>&1"
 
 TOOL_CMD="search-files --limit=0 --include-dirs --group-by=directory | batch-render dir"
 SEARCHFOX_SERVER=${CONFIG_FILE} \
     SEARCHFOX_TREE=${TREE_NAME} \
-    $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
+    searchfox-tool "$TOOL_CMD"
 
 TOOL_CMD="render search-template"
 SEARCHFOX_SERVER=${CONFIG_FILE} \
     SEARCHFOX_TREE=${TREE_NAME} \
-    $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
+    searchfox-tool "$TOOL_CMD"
 
 TOOL_CMD="render help"
 SEARCHFOX_SERVER=${CONFIG_FILE} \
     SEARCHFOX_TREE=${TREE_NAME} \
-    $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
+    searchfox-tool "$TOOL_CMD"
 
 TOOL_CMD="render settings"
 SEARCHFOX_SERVER=${CONFIG_FILE} \
     SEARCHFOX_TREE=${TREE_NAME} \
-    $MOZSEARCH_PATH/tools/target/release/searchfox-tool "$TOOL_CMD"
+    searchfox-tool "$TOOL_CMD"

--- a/scripts/rust-analyze.sh
+++ b/scripts/rust-analyze.sh
@@ -55,7 +55,7 @@ if [ -d "$RUST_ANALYSIS_IN" ]; then
     exit 0 # Nothing to analyze really
   fi
 
-  $MOZSEARCH_PATH/tools/target/release/rust-indexer \
+  rust-indexer \
     "$FILES_ROOT" \
     "$SF_ANALYSIS_OUT" \
     "$GENERATED_SRC" \

--- a/scripts/scip-analyze.sh
+++ b/scripts/scip-analyze.sh
@@ -43,7 +43,7 @@ if [[ $SCIP_SUBTREE_INFOS ]]; then
     scip_tree_name=$(jq -Mr '.key' <<< "$subtree_obj")
     scip_index_path=$(jq -Mr '.value.scip_index_path' <<< "$subtree_obj")
     subtree_root=$(jq -Mr '.value.subtree_root' <<< "$subtree_obj")
-    $MOZSEARCH_PATH/tools/target/release/scip-indexer \
+    scip-indexer \
       "$CONFIG_FILE" \
       "$TREE_NAME" \
       --subtree-name "${scip_tree_name}" \

--- a/scripts/webtest.sh
+++ b/scripts/webtest.sh
@@ -27,6 +27,6 @@ geckodriver >&$FD &
 grep -q 'Listening on' <&$FD
 
 echo "Running tests"
-./tools/target/release/searchfox-tool "webtest ${FILTER}"
+searchfox-tool "webtest ${FILTER}"
 
 stop_geckodriver

--- a/tests/searchfox/setup
+++ b/tests/searchfox/setup
@@ -21,7 +21,7 @@ popd
 rm -rf $BLAME_ROOT
 mkdir -p $BLAME_ROOT
 git init $BLAME_ROOT
-$MOZSEARCH_PATH/tools/target/release/build-blame $GIT_ROOT $BLAME_ROOT
+build-blame $GIT_ROOT $BLAME_ROOT
 
 # When actively developing it's nice to purge the existing contents, but the rest
 # of the time it's nice to not reprocess it all.
@@ -33,7 +33,7 @@ git init $HISTORY_ROOT/syntax
 mkdir -p $HISTORY_ROOT/timeline
 git init $HISTORY_ROOT/timeline
 mkdir -p $HISTORY_ROOT/rev-summaries
-$MOZSEARCH_PATH/tools/target/release/build-syntax-token-tree $GIT_ROOT $HISTORY_ROOT/syntax
+build-syntax-token-tree $GIT_ROOT $HISTORY_ROOT/syntax
 
 
 # Link over the fake metadata and test file information as well.

--- a/tests/tests/build
+++ b/tests/tests/build
@@ -50,13 +50,13 @@ rsync -av $XPIDL_SAVED_ANALYSIS_FILES/ $INDEX_ROOT/analysis/
 scip-java index-semanticdb build/semanticdb-targetroot --no-emit-inverse-relationships --output=$OBJDIR/gradle.scip
 ./gradlew --no-daemon clean
 rm -rf build/
-$MOZSEARCH_PATH/tools/target/release/scip-indexer \
+scip-indexer \
   "$CONFIG_FILE" \
   "$TREE_NAME" \
   --subtree-root "." \
   "$OBJDIR/gradle.scip"
 
-$MOZSEARCH_PATH/tools/target/release/scip-indexer \
+scip-indexer \
   "$CONFIG_FILE" \
   "$TREE_NAME" \
   --subtree-root "." \
@@ -103,7 +103,7 @@ do
   done
 
   pushd $INDEX_ROOT
-  $MOZSEARCH_PATH/tools/target/release/merge-analyses analysis-*/$f > analysis/$f
+  merge-analyses analysis-*/$f > analysis/$f
   popd
 done
 
@@ -112,7 +112,7 @@ done
 scip-python index --show-progress-rate-limit 0 --project-name python --project-version 0.0.0 --environment ../python-scip-env.json --output python.scip
 mv python.scip $INDEX_ROOT
 
-$MOZSEARCH_PATH/tools/target/release/scip-indexer \
+scip-indexer \
   "$CONFIG_FILE" \
   "$TREE_NAME" \
   --subtree-root "." \


### PR DESCRIPTION
This installs Mozsearch tools to .cargo/bin and updates the scripts to expect the tools to be in `$PATH`.

The mercurial `tip` currently points at `tags-unified` instead of `default`, which failed the previous GitHub Actions run [here](https://github.com/nicolas-guichard/mozsearch/actions/runs/16626148101/job/47043005611#step:4:2799).

Also requires https://github.com/mozsearch/mozsearch-mozilla/pull/281.

This is currently deployed on kdab.searchfox.org with the Graphviz index.