### PR TITLE
Get clang plugin and wasm analyzer paths from env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,8 @@ jobs:
         run: make -C $GITHUB_WORKSPACE/clang-plugin
       - name: Build Rust tools
         run: make -C $GITHUB_WORKSPACE build-rust-tools
+      - name: Set wasm analyzer path
+        run: echo "MOZSEARCH_WASM_DIR=$GITHUB_WORKSPACE/scripts/web-analyze/wasm-css-analyzer/out" >> "$GITHUB_ENV"
 
       # Test repo
       - run: mkdir ~/index

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,8 @@ jobs:
       # Bulding
       - name: Build Clang plugin
         run: make -C $GITHUB_WORKSPACE/clang-plugin
+      - name: Set Clang plugin path
+        run: echo "MOZSEARCH_CLANG_PLUGIN_DIR=$GITHUB_WORKSPACE/clang-plugin" >> "$GITHUB_ENV"
       - name: Build Rust tools
         run: make -C $GITHUB_WORKSPACE build-rust-tools
       - name: Set wasm analyzer path

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -18,6 +18,7 @@ ENV PATH=/home/vagrant/livegrep-venv/bin:/home/vagrant/.cargo/bin:$PATH
 RUN /infrastructure/indexer-provision.sh
 ENV PYTHONPATH=/home/vagrant/pymodules
 ENV MOZSEARCH_WASM_DIR=/home/vagrant/mozsearch-wasm
+ENV MOZSEARCH_CLANG_PLUGIN_DIR=/home/vagrant/mozsearch-clang-plugin
 
 # indexer-provision.sh installed Coursier, make sure the path is available for
 # the next commands

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -17,6 +17,7 @@ ENV PATH=/home/vagrant/livegrep-venv/bin:/home/vagrant/.cargo/bin:$PATH
 
 RUN /infrastructure/indexer-provision.sh
 ENV PYTHONPATH=/home/vagrant/pymodules
+ENV MOZSEARCH_WASM_DIR=/home/vagrant/mozsearch-wasm
 
 # indexer-provision.sh installed Coursier, make sure the path is available for
 # the next commands

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -64,6 +64,9 @@ popd
 popd
 echo 'export PYTHONPATH="$HOME/pymodules"' >> ~/.profile
 
+# This is where the wasm-css-analyzer will be built
+echo 'export MOZSEARCH_WASM_DIR="$HOME/mozsearch-wasm"' >> ~/.profile
+
 # Create update script.
 cat > update.sh <<"THEEND"
 #!/usr/bin/env bash

--- a/infrastructure/indexer-provision.sh
+++ b/infrastructure/indexer-provision.sh
@@ -67,6 +67,9 @@ echo 'export PYTHONPATH="$HOME/pymodules"' >> ~/.profile
 # This is where the wasm-css-analyzer will be built
 echo 'export MOZSEARCH_WASM_DIR="$HOME/mozsearch-wasm"' >> ~/.profile
 
+# This is where the clang plugin will be built
+echo 'export MOZSEARCH_CLANG_PLUGIN_DIR="$HOME/mozsearch-clang-plugin"' >> ~/.profile
+
 # Create update script.
 cat > update.sh <<"THEEND"
 #!/usr/bin/env bash

--- a/scripts/html-analyze.sh
+++ b/scripts/html-analyze.sh
@@ -23,5 +23,5 @@ export LC_CTYPE=C.UTF-8
 cat $INDEX_ROOT/html-files | nl -w1 -s " " | \
     parallel --jobs 8 --pipe --halt 2 \
     js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \
-    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis
+    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis $MOZSEARCH_WASM_DIR
 echo $?

--- a/scripts/indexer-setup.py
+++ b/scripts/indexer-setup.py
@@ -11,7 +11,7 @@ indexRoot = os.environ['INDEX_ROOT']
 treeRoot = os.environ['FILES_ROOT']
 objdir = os.environ['OBJDIR']
 
-plugin_folder = os.path.join(mozSearchRoot, 'clang-plugin')
+plugin_folder = os.environ["MOZSEARCH_CLANG_PLUGIN_DIR"]
 
 flags = [
     '-load', os.path.join(plugin_folder, 'libclang-index-plugin.so'),

--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -2223,7 +2223,6 @@ class CSSAnalyzer {
       return;
     }
 
-    const wasmPath = mozSearchRoot + "/scripts/web-analyze/wasm-css-analyzer/out";
     const wasmBinary = createMappedArrayBuffer(wasmPath + "/wasm_css_analyzer.wasm");
 
     // getrandom crate requires WebCrypto API.
@@ -2456,6 +2455,7 @@ function decodeUTF8(s) {
 mozSearchRoot = scriptArgs[0];
 const localRoot = scriptArgs[1];
 const analysisRoot = scriptArgs[2];
+const wasmPath = scriptArgs[3];
 
 while (true) {
   const line = readline();

--- a/scripts/js-analyze.sh
+++ b/scripts/js-analyze.sh
@@ -25,5 +25,5 @@ export LC_CTYPE=C.UTF-8
 cat $INDEX_ROOT/js-files | nl -w1 -s " " | \
     parallel --jobs 8 --pipe --halt 2 \
     js -f $MOZSEARCH_PATH/scripts/js-analyze.js -- \
-    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis
+    $MOZSEARCH_PATH $FILES_ROOT $INDEX_ROOT/analysis $MOZSEARCH_WASM_DIR
 echo $?

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -35,6 +35,7 @@ PATH="$LIVEGREP_VENV/bin:$PATH"
 
 # TODO: remove after next provisioning
 export MOZSEARCH_WASM_DIR=${MOZSEARCH_WASM_DIR:-"$MOZSEARCH_PATH/scripts/web-analyze/wasm-css-analyzer/out"}
+export MOZSEARCH_CLANG_PLUGIN_DIR=${MOZSEARCH_CLANG_PLUGIN_DIR:-"$MOZSEARCH_PATH/clang-plugin"}
 
 # This was previously "full" but "1" is much more readable.  Obviously change
 # this back if we end up missing things.

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -33,6 +33,9 @@ export PYTHONPATH="$MOZSEARCH_PATH/scripts${PYTHONPATH:+:${PYTHONPATH}}"
 LIVEGREP_VENV="$HOME/livegrep-venv"
 PATH="$LIVEGREP_VENV/bin:$PATH"
 
+# TODO: remove after next provisioning
+export MOZSEARCH_WASM_DIR=${MOZSEARCH_WASM_DIR:-"$MOZSEARCH_PATH/scripts/web-analyze/wasm-css-analyzer/out"}
+
 # This was previously "full" but "1" is much more readable.  Obviously change
 # this back if we end up missing things.
 #


### PR DESCRIPTION
This is another step to be able to point the scripts at prebuilt/prepackaged binaries.

EDIT: forgot to mention this passed a test on kdab.searchfox.org, using the Graphviz tree as usual. It has some html and xml files so html-files and js-files are non-empty and html-analyze.sh and js-analyze.sh actually call js-analyze.js.