### PR TITLE
Use gradle from PATH if available

### DIFF
--- a/tests/tests/build
+++ b/tests/tests/build
@@ -45,10 +45,17 @@ rsync -av $XPIDL_SAVED_GENERATED_FILES/ $OBJDIR
 mkdir -p $INDEX_ROOT/analysis/
 rsync -av $XPIDL_SAVED_ANALYSIS_FILES/ $INDEX_ROOT/analysis/
 
+# Use Gradle from PATH if available
+if which gradle &> /dev/null; then
+  GRADLE=gradle
+else
+  GRADLE=./gradlew
+fi
+
 ## Java stuff
-./gradlew --no-daemon clean build
+"$GRADLE" --no-daemon clean build
 scip-java index-semanticdb build/semanticdb-targetroot --no-emit-inverse-relationships --output=$OBJDIR/gradle.scip
-./gradlew --no-daemon clean
+"$GRADLE" --no-daemon clean
 rm -rf build/
 scip-indexer \
   "$CONFIG_FILE" \


### PR DESCRIPTION
On GitHub Actions, Gradle is already installed and we don't need the wrapper.

With Nix, Gradle will be wrapped with a MITM proxy to package and lock dependencies.