### PR TITLE
fix(css): s/--page-background-color/--page-background for `.nested-sticky-line` elements

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -478,7 +478,7 @@ body {
   /* even with our "stuck" and "last-stuck" classes, it's important to have an
    opaque background color for these because those classes don't take effect
    immediately. */
-  background-color: var(--page-background-color);
+  background-color: var(--page-background);
   top: calc(var(--nesting-level) * var(--base-font-size) * var(--source-line-height));
   z-index: calc(100 - var(--nesting-level));
 }


### PR DESCRIPTION
While perusing Searchfox, I noticed that `stuck` and `last-stuck` weren't applied to line 14 after opening [`python/mozbuild/mozbuild/action/dumpsymbols.py`:70](https://searchfox.org/mozilla-central/rev/202069c4c5113a1a9052d84fa4679d4c1b22113e/python/mozbuild/mozbuild/action/dumpsymbols.py#70). I'm not sure under what conditions this happened (and I can't reproduce it), but the end result is text "underneath" being visually entangled with the sticky text.

This appears to have incorrectly referenced `--page-background` since its introduction in [`8cc6d7e9`](https://github.com/mozsearch/mozsearch/commit/8cc6d7e997ae1ab2f43f2ba591e760ba9fedf28f#diff-c467f65fa9496668efe48e9da75740e9255d8ce0db379ce7595725f017bd8afcR31) (CC @emilio). Perhaps this was a missed rename while working on the implementation?
