### PR TITLE
Bug 1890435 - Redirects should be relative, not absolute

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -252,6 +252,7 @@ map $status $expires {
 
 server {
   listen 16995 default_server;
+  absolute_redirect off;
 
   access_log /tmp/searchfox.log custom_cache_log ;
 


### PR DESCRIPTION
By default, rewrite redirects issued by nginx are absolute which ends up trying to rewrite to an "http" scheme on port 16995, which does not work well.  We set the `absolute_redirect` setting to off.