### PR TITLE
Bug 1890435 - Update robots.txt to include firefox-main

### DIFF
--- a/static/robots.txt
+++ b/static/robots.txt
@@ -9,6 +9,7 @@ Disallow: /
 # Also we don't allow crawls on mozilla-beta and other release repos
 # because it's better if people get directed to mozilla-central instead.
 Allow: /mozilla-central/source/
+Allow: /firefox-main/source/
 Allow: /comm-central/source/
 Allow: /mozilla-mobile/source/
 # There's a copy of mozilla-central inside comm-central, let's skip that


### PR DESCRIPTION
It might make sense to revisit our robots.txt in general, but in the meantime maintaining the rationale for mozilla-central means we should add firefox-main (and leave mozilla-central in place for the redirects).