### PR TITLE
Bug 1986051 - Ignore possibly non-existent webidl files.

### DIFF
--- a/scripts/webidl-analyze.py
+++ b/scripts/webidl-analyze.py
@@ -871,6 +871,14 @@ def parse_files(index_root, files_root, analysis_root, cache_dir, bindings_local
         else:
             fname = os.path.join(files_root, local_path)
 
+        if not os.path.exists(fname):
+            # New filename from 144 (See bug 1919582).
+            if 'CSSStyleProperties.webidl' in fname:
+                continue
+            # Old filename.
+            if 'CSS2Properties.webidl' in fname:
+                continue
+
         lines = preprocess(open(fname).readlines())
         text = ''.join(lines)
         cpp_analysis_map[local_path] = read_cpp_analysis(analysis_root, local_path, bindings_local_path)

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -184,6 +184,15 @@ impl TreeConfig {
                 return true;
             }
         }
+        // New filename from 144 (See bug 1919582).
+        // TODO: Move them to config files in future.
+        if path.contains("CSSStyleProperties.webidl") {
+            return true;
+        }
+        // Old filename.
+        if path.contains("CSS2Properties.webidl") {
+            return true;
+        }
         false
     }
 }


### PR DESCRIPTION
For https://bugzilla.mozilla.org/show_bug.cgi?id=1986051

This does:
  * Let the webidl analysis ignore known possibly-non-existent files

There's corresponding change in config repo that adds the renamed file to non-esr branches.

This can be removed once all non-esr branches receive the [bug 1919582](https://bugzilla.mozilla.org/show_bug.cgi?id=1919582) changes.

I'll post update when the test run finishes.
This might require some more fix in the other consumer of the file list.