### PR TITLE
Bug 1989736 - Add an /oldcommit/ endpoint for old m-c /commit/ links

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -294,6 +294,7 @@ for repo in config['trees']:
         oldtree_name = tree_config['oldtree_name']
         print(f'  rewrite ^/{oldtree_name}/rev/(.*)$ /{repo}/oldrev/$1 permanent;')
         print(f'  rewrite ^/{oldtree_name}/commit/(.*)$ /{repo}/oldcommit/$1 permanent;')
+        print(f'  rewrite ^/{oldtree_name}/diff/(.*)$ /{repo}/olddiff/$1 permanent;')
         print(f'  rewrite ^/{oldtree_name}/(.*)$ /{repo}/$1 permanent;')
         print('')
 
@@ -356,6 +357,7 @@ for repo in config['trees']:
     # Handled by Rust `web-server.rs`.
     location(f'/{repo}/diagnostics', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/diff', ['proxy_pass http://localhost:8001;'])
+    location(f'/{repo}/olddiff', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/commit', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/oldcommit', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/rev', ['proxy_pass http://localhost:8001;'])

--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -293,6 +293,7 @@ for repo in config['trees']:
     if 'oldtree_name' in tree_config:
         oldtree_name = tree_config['oldtree_name']
         print(f'  rewrite ^/{oldtree_name}/rev/(.*)$ /{repo}/oldrev/$1 permanent;')
+        print(f'  rewrite ^/{oldtree_name}/commit/(.*)$ /{repo}/oldcommit/$1 permanent;')
         print(f'  rewrite ^/{oldtree_name}/(.*)$ /{repo}/$1 permanent;')
         print('')
 
@@ -356,6 +357,7 @@ for repo in config['trees']:
     location(f'/{repo}/diagnostics', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/diff', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/commit', ['proxy_pass http://localhost:8001;'])
+    location(f'/{repo}/oldcommit', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/rev', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/hgrev', ['proxy_pass http://localhost:8001;'])
     location(f'/{repo}/oldrev', ['proxy_pass http://localhost:8001;'])

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -175,6 +175,10 @@ fn handle(
         }
 
         "hgrev" => {
+            if path.len() < 3 {
+                return WebResponse::not_found();
+            }
+
             let tree_config = &cfg.trees[*tree_name];
             let git_path = match tree_config.get_git_path() {
                 Ok(git_path) => git_path,
@@ -201,6 +205,10 @@ fn handle(
         }
 
         "oldrev" => {
+            if path.len() < 3 {
+                return WebResponse::not_found();
+            }
+
             let tree_config = &cfg.trees[*tree_name];
             let old_rev = path[2];
             match (&tree_config.git, Oid::from_str(old_rev)) {
@@ -259,6 +267,32 @@ fn handle(
             }
         }
 
+        "oldcommit" => {
+            if path.len() < 3 {
+                return WebResponse::not_found();
+            }
+
+            let tree_config = &cfg.trees[*tree_name];
+            let old_rev = path[2];
+            match (&tree_config.git, Oid::from_str(old_rev)) {
+                (Some(gitdata), Ok(old_oid)) => {
+                    match gitdata.old_map.get(&old_oid) {
+                        Some(new_oid) => WebResponse::redirect(format!(
+                            "/{}/commit/{}",
+                            tree_name,
+                            new_oid,
+                        )),
+                        _ => WebResponse::not_found(),
+                    }
+                }
+                _ => WebResponse::not_found(),
+            }
+        }
+
+        // We don't have an "oldcommit-info" because this endpoint is only for
+        // AJAX-y use by the current blame strip UI that fetches commit-info on
+        // demand, and these links are considered mozsearch-internal and will
+        // never be generated for anything but a current revision.
         "commit-info" => {
             if path.len() < 3 {
                 return WebResponse::not_found();

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -253,6 +253,29 @@ fn handle(
             }
         }
 
+        "olddiff" => {
+            if path.len() < 3 {
+                return WebResponse::not_found();
+            }
+
+            let tree_config = &cfg.trees[*tree_name];
+            let old_rev = path[2];
+            match (&tree_config.git, Oid::from_str(old_rev)) {
+                (Some(gitdata), Ok(old_oid)) => {
+                    match gitdata.old_map.get(&old_oid) {
+                        Some(new_oid) => WebResponse::redirect(format!(
+                            "/{}/diff/{}/{}",
+                            tree_name,
+                            new_oid,
+                            path[3..].join("/")
+                        )),
+                        _ => WebResponse::not_found(),
+                    }
+                }
+                _ => WebResponse::not_found(),
+            }
+        }
+
         "commit" => {
             if path.len() < 3 {
                 return WebResponse::not_found();


### PR DESCRIPTION
In bug 1890435 I'd punted on this mapping early on in the process assuming we'd be burning comparatively costly and limited Elastic Load Balancer rule resources, but we ended up just having all mozilla-central links sent to the firefox-main tree and having nginx then rewrite the m-c links to f-m links so /rev/ could become /oldrev/ and unambiguously be clear about which type of rev we're dealing with.  This means there's only the additional nginx rule and the marginal increase in web-server logic, which is mainly down to copy-and-paste.  (I opted to "repeat yourself" in the interest of clarity.)

When doing the update I noticed that we didn't have path length guards on hgrev and oldrev to match rev, so I added those.  This changes what would have been a 500 because of a (caught) panic to a 404. Note that the rev-flavored guards rely on rust slicing being fine with slicing at its length to produce an empty slice.

The 2nd commit in the stack adds /diff/ mapping.

The only other revision-accepting endpoint we have in web-server.rs is commit-info which is only used for the blame strip hover purposes and so is only ever same-tree, so we're not adding one for that.  I've added a comment in the file to that effect since it seems like a reasonable question someone might have while reading the code.