### PR TITLE
Bug 1990128  - Point hg.m.o links at "default" instead of "tip"

### DIFF
--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -359,7 +359,7 @@ fn main() {
                     .paths
                     .hg_root
                     .as_ref()
-                    .map(|hg_root| format!("{}/log/tip/{}", hg_root, encoded_path));
+                    .map(|hg_root| format!("{}/log/default/{}", hg_root, encoded_path));
                 if let Some(link) = gh_log_link {
                     vcs_panel_items.push(PanelItem {
                         title: "Git log".to_owned(),
@@ -388,7 +388,7 @@ fn main() {
                     .paths
                     .hg_root
                     .as_ref()
-                    .map(|hg_root| format!("{}/raw-file/tip/{}", hg_root, encoded_path));
+                    .map(|hg_root| format!("{}/raw-file/default/{}", hg_root, encoded_path));
                 if let Some(link) = gh_raw_link.or(hg_raw_link) {
                     vcs_panel_items.push(PanelItem {
                         title: "Raw".to_owned(),
@@ -422,7 +422,7 @@ fn main() {
         if let Some(ref hg_root) = tree_config.paths.hg_root {
             tools_items.push(PanelItem {
                 title: "HG Web".to_owned(),
-                link: format!("{}/file/tip/{}", hg_root, encoded_path),
+                link: format!("{}/file/default/{}", hg_root, encoded_path),
                 update_link_lineno: "#l{}",
                 accel_key: None,
                 copyable: false,

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -683,7 +683,7 @@ pub fn format_file_data(
     if let Some(ext) = path_wrapper.extension() {
         if ext.to_str().unwrap() == "svg" {
             if let Some(ref hg_root) = tree_config.paths.hg_root {
-                let url = format!("{}/raw-file/tip/{}", hg_root, path);
+                let url = format!("{}/raw-file/default/{}", hg_root, path);
                 output::generate_svg_preview(writer, &url)?
             }
         }
@@ -966,7 +966,7 @@ pub fn format_path(
         .as_ref()
         .and_then(|git| git.hg_map.get(&commit.id()))
         .map(|rev| rev.as_ref()) // &String to &str conversion
-        .unwrap_or("tip");
+        .unwrap_or("default");
 
     let encoded_path = url_encode_path(path);
 
@@ -1281,7 +1281,7 @@ pub fn format_diff(
         .paths
         .hg_root
         .as_ref()
-        .map(|hg_root| format!("{}/log/tip/{}", hg_root, encoded_path));
+        .map(|hg_root| format!("{}/log/default/{}", hg_root, encoded_path));
     if let Some(link) = gh_log_link {
         vcs_panel_items.push(PanelItem {
             title: "Git log".to_owned(),


### PR DESCRIPTION
Since the git migration, "tip" can point at a changeset on a "tags" branch instead of "default", which won't have the files we're looking for.