### PR TITLE
Bug 1990128 - Various changes to use git instead of hg and use git branch names when available

### DIFF
--- a/scripts/nginx-setup.py
+++ b/scripts/nginx-setup.py
@@ -350,24 +350,24 @@ for repo in config['trees']:
         ])
 
     # Handled by router/router.py
-    location(f'/{repo}/search', ['proxy_pass http://localhost:8000;'])
-    location(f'/{repo}/sorch', ['proxy_pass http://localhost:8000;'])
-    location(f'/{repo}/define', ['proxy_pass http://localhost:8000;'])
+    location(f'/{repo}/search', ['proxy_pass http://127.0.0.1:8000;'])
+    location(f'/{repo}/sorch', ['proxy_pass http://127.0.0.1:8000;'])
+    location(f'/{repo}/define', ['proxy_pass http://127.0.0.1:8000;'])
 
     # Handled by Rust `web-server.rs`.
-    location(f'/{repo}/diagnostics', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/diff', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/olddiff', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/commit', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/oldcommit', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/rev', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/hgrev', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/oldrev', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/complete', ['proxy_pass http://localhost:8001;'])
-    location(f'/{repo}/commit-info', ['proxy_pass http://localhost:8001;'])
+    location(f'/{repo}/diagnostics', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/diff', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/olddiff', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/commit', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/oldcommit', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/rev', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/hgrev', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/oldrev', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/complete', ['proxy_pass http://127.0.0.1:8001;'])
+    location(f'/{repo}/commit-info', ['proxy_pass http://127.0.0.1:8001;'])
 
     # Handled by Rust `pipeline-server.rs`
-    location(f'/{repo}/query', ['proxy_pass http://localhost:8002;'])
+    location(f'/{repo}/query', ['proxy_pass http://127.0.0.1:8002;'])
 
 
 location('= /', [

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -350,11 +350,14 @@ fn main() {
                     copyable: false,
                 });
 
-                let gh_log_link = tree_config
-                    .paths
-                    .github_repo
-                    .as_ref()
-                    .map(|gh_root| format!("{}/commits/HEAD/{}", gh_root, encoded_path));
+                let gh_log_link = tree_config.paths.github_repo.as_ref().map(|gh_root| {
+                    format!(
+                        "{}/commits/{}/{}",
+                        gh_root,
+                        tree_config.paths.git_branch.as_deref().unwrap_or("HEAD"),
+                        encoded_path
+                    )
+                });
                 let hg_log_link = tree_config
                     .paths
                     .hg_root

--- a/tools/src/bin/output-file.rs
+++ b/tools/src/bin/output-file.rs
@@ -379,17 +379,7 @@ fn main() {
                     });
                 }
 
-                let gh_raw_link = tree_config
-                    .paths
-                    .github_repo
-                    .as_ref()
-                    .map(|gh_root| format!("{}/raw/HEAD/{}", gh_root, encoded_path));
-                let hg_raw_link = tree_config
-                    .paths
-                    .hg_root
-                    .as_ref()
-                    .map(|hg_root| format!("{}/raw-file/default/{}", hg_root, encoded_path));
-                if let Some(link) = gh_raw_link.or(hg_raw_link) {
+                if let Some(link) = tree_config.paths.make_raw_resource_branch_url(&path) {
                     vcs_panel_items.push(PanelItem {
                         title: "Raw".to_owned(),
                         link,

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -1265,11 +1265,14 @@ pub fn format_diff(
         },
     ];
 
-    let gh_log_link = tree_config
-        .paths
-        .github_repo
-        .as_ref()
-        .map(|gh_root| format!("{}/commits/HEAD/{}", gh_root, encoded_path));
+    let gh_log_link = tree_config.paths.github_repo.as_ref().map(|gh_root| {
+        format!(
+            "{}/commits/{}/{}",
+            gh_root,
+            tree_config.paths.git_branch.as_deref().unwrap_or("HEAD"),
+            encoded_path
+        )
+    });
     let hg_log_link = tree_config
         .paths
         .hg_root

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -682,8 +682,7 @@ pub fn format_file_data(
 
     if let Some(ext) = path_wrapper.extension() {
         if ext.to_str().unwrap() == "svg" {
-            if let Some(ref hg_root) = tree_config.paths.hg_root {
-                let url = format!("{}/raw-file/default/{}", hg_root, path);
+            if let Some(url) = tree_config.paths.make_raw_resource_branch_url(path) {
                 output::generate_svg_preview(writer, &url)?
             }
         }
@@ -1008,17 +1007,11 @@ pub fn format_path(
         });
     }
 
-    let gh_raw_link = tree_config
-        .paths
-        .github_repo
-        .as_ref()
-        .map(|gh_root| format!("{}/raw/{}/{}", gh_root, commit.id(), encoded_path));
-    let hg_raw_link = tree_config
-        .paths
-        .hg_root
-        .as_ref()
-        .map(|hg_root| format!("{}/raw-file/{}/{}", hg_root, hg_rev, encoded_path));
-    if let Some(link) = gh_raw_link.or(hg_raw_link) {
+    if let Some(link) =
+        tree_config
+            .paths
+            .make_raw_resource_rev_url(&commit.id().to_string(), hg_rev, path)
+    {
         vcs_panel_items.push(PanelItem {
             title: "Raw".to_owned(),
             link,


### PR DESCRIPTION
This is up on https://asuth.searchfox.org/firefox-main/source/ (not that the changes are particularly complicated, but the test repo can't replicate the situation we have for firefox-main and there are changes to output-file so a fresh indexing was required).

More detail in the specific commits, but this basically is doing what https://bugzilla.mozilla.org/show_bug.cgi?id=1990128 proposes in terms of using git instead of hg for raw and doing it directly via the raw.githubusercontent.com domain plus two slipstream fixes:
- allow trigger_indexer to specify a config revision to use that differs from the revision specified for the mozsearch repo, details in comments and commit message
- nginx fix because "localhost" in docker for us can end up pointing at our IPv6 loopback which we don't bind to.

The extraction out into helpers for config.rs was mainly motivated by the need to manipulate the github.com URLs into raw.githubusercontent.com URLs and not wanting to replicate that additional logic too much.