### PR TITLE
Bug 2029346 - Fix blame strip height in diff view.

### DIFF
--- a/static/css/mozsearch.css
+++ b/static/css/mozsearch.css
@@ -1256,6 +1256,9 @@ span[data-symbols].selected {
 }
 
 /* ## Blame ## */
+.line-strip {
+  display: flex;
+}
 .blame-strip {
   display: block;
   width: 20px;

--- a/tests/webtest/test_blameDiff.js
+++ b/tests/webtest/test_blameDiff.js
@@ -1,0 +1,17 @@
+"use strict";
+
+add_task(async function test_TestPhabricator() {
+  await TestUtils.loadPath("/searchfox/diff/b17c096ff1eab51aaf27befb5bd97ead09c74110/.gitignore");
+
+  {
+    const blameStrip = frame.contentDocument.querySelector(`#line-1 .blame-strip`);
+    ok(blameStrip.getBoundingClientRect().height > 0,
+       "Blame strip is visible for existing line");
+  }
+
+  {
+    const blameStrip = frame.contentDocument.querySelector(`#line-7 .blame-strip`);
+    ok(blameStrip.getBoundingClientRect().height > 0,
+       "Blame strip is visible for newly added line");
+  }
+});


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=2029346

This does:
  * revert a part of revert in https://github.com/mozsearch/mozsearch/pull/1078 , which affected the blame strip sizing in diff view