### PR TITLE
Bug 2030042 - Implement client-side 'Ignore this node' for interactive graphs

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -1923,7 +1923,13 @@ var ContextMenu = new (class ContextMenu extends ContextMenuOrSubMenu {
               icon: "brush",
               section: "diagrams-ignore",
               action: () => {
-                Diagram.ignoreNode(symInfo.pretty);
+                if (window.interactiveGraphInstance) {
+                  window.interactiveGraphInstance.removeNodeByPrettyName(symInfo.pretty);
+                  window.interactiveGraphInstance.updateQueryForIgnoredNode(symInfo.pretty);
+                  this.hide();
+                } else {
+                  Diagram.ignoreNode(symInfo.pretty);
+                }
               },
             }));
           }

--- a/static/js/graph.js
+++ b/static/js/graph.js
@@ -394,6 +394,7 @@ class Graph {
   constructor(viewport, container, input, sources, targets, extraList) {
     this.viewport = viewport;
     this.graphContainer = container;
+    this.extraList = extraList;
 
     const viewportRect = this.viewport.getBoundingClientRect();
     this.viewportSize = {
@@ -411,6 +412,19 @@ class Graph {
     this.edges = [];
 
     this.createBlocksAndEdges(input, sources, targets);
+
+    this.render();
+
+    this.needInitialFitToViewport = true;
+    this.addEventListeners();
+    this.initialFitToViewport();
+    this.addButtons();
+  }
+
+  render() {
+    this.graphContainer.replaceChildren();
+
+    this.resetBlockAndEdgeState();
 
     this.calculateDepth();
 
@@ -442,15 +456,137 @@ class Graph {
 
     this.createLoopEdgeNodes();
 
-    this.needInitialFitToViewport = true;
+    // Re-populate interaction data
+    this.extraList.length = 0;
+    this.populateExtra(this.extraList);
+  }
 
-    this.populateExtra(extraList);
+  resetBlockAndEdgeState() {
+    for (const block of this.blocks) {
+      block.depth = -1;
+      block.breadth = -1;
+    }
 
-    this.addEventListeners();
+    for (const edge of this.edges) {
+      edge.path = [];
+    }
+  }
 
-    this.initialFitToViewport();
+  removeNodeByPrettyName(prettyName) {
+    const blockToRemove = this.blocks.find(b => b.pretty === prettyName);
+    if (!blockToRemove) {
+      return;
+    }
 
-    this.addButtons();
+    const blockIdToRemove = blockToRemove.id;
+
+    this.blocks = this.blocks.filter(block => block.id !== blockIdToRemove);
+
+    this.edges = this.edges.filter(edge => {
+      return edge.pred.id !== blockIdToRemove && edge.succ.id !== blockIdToRemove;
+    });
+
+    for (const block of this.blocks) {
+      block.preds = block.preds.filter(p => p.id !== blockIdToRemove);
+      block.succs = block.succs.filter(s => s.id !== blockIdToRemove);
+    }
+
+    this.pruneUnreachableNodes();
+
+    this.render(false);
+  }
+
+  pruneUnreachableNodes() {
+    const sources = this.blocks.filter(b => b.isSource);
+    const targets = this.blocks.filter(b => b.isTarget);
+
+    const searchInput = document.getElementById("query");
+    const queryStr = searchInput ? searchInput.value : (new URL(window.location.href)).searchParams.get("q") || "";
+    const undirectedNames = [];
+    const regex = /calls-between:(?:'([^']+)'|([^\s]+))/g;
+    let match;
+    while ((match = regex.exec(queryStr)) !== null) {
+      undirectedNames.push(match[1] || match[2]);
+    }
+    const undirectedAnchors = this.blocks.filter(b => undirectedNames.includes(b.pretty));
+
+    const focalNodes = [...new Set([...sources, ...targets, ...undirectedAnchors])];
+
+    if (focalNodes.length === 0) {
+      const isolatedIds = new Set(
+        this.blocks.filter(b => b.preds.length === 0 && b.succs.length === 0 && !b.loopback).map(b => b.id)
+      );
+      if (isolatedIds.size > 0) {
+        this.blocks = this.blocks.filter(b => !isolatedIds.has(b.id));
+      }
+      return;
+    }
+
+    const getReachable = (startNodes, direction) => {
+      const visited = new Set(startNodes.map(b => b.id));
+      const queue = startNodes.slice();
+      while (queue.length > 0) {
+        const curr = queue.shift();
+        for (const next of curr[direction]) {
+          if (!visited.has(next.id)) {
+            visited.add(next.id);
+            queue.push(next);
+          }
+        }
+      }
+      return visited;
+    };
+
+    const isCallsBetweenDirected = sources.length > 0 && targets.length > 0 && !sources.some(s => targets.includes(s));
+    const isCallsBetweenUndirected = undirectedAnchors.length > 1;
+
+    let validIds = new Set();
+
+    if (isCallsBetweenDirected) {
+      const fromSources = getReachable(sources, "succs");
+      const toTargets = getReachable(targets, "preds");
+      validIds = new Set([...fromSources].filter(id => toTargets.has(id)));
+    } else if (isCallsBetweenUndirected) {
+      const fromAnchors = getReachable(undirectedAnchors, "succs");
+      const toAnchors = getReachable(undirectedAnchors, "preds");
+      validIds = new Set([...fromAnchors].filter(id => toAnchors.has(id)));
+    } else {
+      getReachable(focalNodes, "succs").forEach(id => validIds.add(id));
+      getReachable(focalNodes, "preds").forEach(id => validIds.add(id));
+    }
+
+    this.blocks = this.blocks.filter(b => validIds.has(b.id));
+    this.edges = this.edges.filter(e => validIds.has(e.pred.id) && validIds.has(e.succ.id));
+
+    for (const block of this.blocks) {
+      block.preds = block.preds.filter(p => validIds.has(p.id));
+      block.succs = block.succs.filter(s => validIds.has(s.id));
+    }
+  }
+
+  // Updates the search input and URL query string without reloading the page.
+  updateQueryForIgnoredNode(prettyName) {
+    const searchInput = document.getElementById("query");
+    const url = new URL(window.location.href);
+    let query = searchInput ? searchInput.value : url.searchParams.get("q");
+
+    if (query) {
+      let newIgnoreList = prettyName;
+
+      const match = query.match(/ignore-nodes:([^\s]+)/);
+      if (match) {
+        newIgnoreList = match[1] + "," + prettyName;
+      }
+
+      query = query.replace(/ +ignore-nodes:[^\s]+/g, "");
+      query += " ignore-nodes:" + newIgnoreList;
+
+      if (searchInput) {
+        searchInput.value = query.trim();
+      }
+      url.searchParams.set("q", query.trim());
+      window.history.pushState({}, "", url);
+    }
   }
 
   // Create data objects for blocks and edges.
@@ -1518,7 +1654,7 @@ window.addEventListener("load", () => {
     }
   }
 
-  new Graph(
+  window.interactiveGraphInstance = new Graph(
     document.querySelector("#interactive-graph-viewport"),
     document.querySelector("#interactive-graph-container"),
     GRAPH_INPUT[0], sources, targets,

--- a/tests/webtest/test_DiagramInteractive.js
+++ b/tests/webtest/test_DiagramInteractive.js
@@ -257,3 +257,70 @@ add_task(async function test_DiagramInteractive_wheel_zoom_in() {
 
   ok(rect.width > initRect.width, "The node should be shown smaller");
 });
+
+add_task(async function test_DiagramInteractive_Ignore_CallsBetween_Undirected() {
+  await TestUtils.resetFeatureGate("diagramming");
+
+  await TestUtils.loadQuery("tests", "calls-between:'diagram_ignore::F7' calls-between:'diagram_ignore::F1' depth:8 graph-format:mozsearch-interactive");
+
+  const doc = frame.contentDocument;
+  const win = frame.contentWindow;
+
+  ok(doc.querySelector('[data-symbols="_ZN14diagram_ignore2F3Ev"]'), "F3 exists initially");
+  ok(doc.querySelector('[data-symbols="_ZN14diagram_ignore2F2Ev"]'), "F2 exists initially");
+
+  const f2Node = doc.querySelector('[data-symbols="_ZN14diagram_ignore2F2Ev"]');
+  ok(f2Node, "F2 node exists");
+  TestUtils.click(f2Node);
+
+  const menuItems = Array.from(doc.querySelectorAll(".contextmenu-row a"));
+  const ignoreItem = menuItems.find(a => a.textContent && a.textContent.includes("Ignore this node"));
+  TestUtils.click(ignoreItem);
+
+  await waitForCondition(() => !doc.querySelector('[data-symbols="_ZN14diagram_ignore2F2Ev"]'), "F2 removed");
+
+  ok(!doc.querySelector('[data-symbols="_ZN14diagram_ignore2F3Ev"]'), "F3 should be pruned because the undirected path is broken");
+
+  const searchInput = doc.getElementById("query");
+  ok(searchInput.value.includes("ignore-nodes:diagram_ignore::F2"), "Search input should be updated with F2");
+
+  const url = new URL(win.location.href);
+  const qParam = url.searchParams.get("q") || "";
+  ok(qParam.includes("ignore-nodes:diagram_ignore::F2"), "URL should be updated with ignore-nodes syntax for F2");
+});
+
+add_task(async function test_DiagramInteractive_Ignore_Twice() {
+  await TestUtils.resetFeatureGate("diagramming");
+
+  await TestUtils.loadQuery("tests", "calls-to:'diagram_ignore::F1' depth:8 graph-format:mozsearch-interactive");
+
+  const doc = frame.contentDocument;
+  const win = frame.contentWindow;
+
+  let f5Node = doc.querySelector('[data-symbols="_ZN14diagram_ignore2F5Ev"]');
+  TestUtils.click(f5Node);
+  let menuItems = Array.from(doc.querySelectorAll(".contextmenu-row a"));
+  let ignoreItem = menuItems.find(a => a.textContent && a.textContent.includes("Ignore this node"));
+  TestUtils.click(ignoreItem);
+
+  await waitForCondition(() => !doc.querySelector('[data-symbols="_ZN14diagram_ignore2F5Ev"]'), "F5 removed");
+
+  let f3Node = doc.querySelector('[data-symbols="_ZN14diagram_ignore2F3Ev"]');
+  TestUtils.click(f3Node);
+  menuItems = Array.from(doc.querySelectorAll(".contextmenu-row a"));
+  ignoreItem = menuItems.find(a => a.textContent && a.textContent.includes("Ignore this node"));
+  TestUtils.click(ignoreItem);
+
+  await waitForCondition(() => !doc.querySelector('[data-symbols="_ZN14diagram_ignore2F3Ev"]'), "F3 removed");
+
+  const searchInput = doc.getElementById("query");
+  ok(searchInput.value.includes("ignore-nodes:diagram_ignore::F5,diagram_ignore::F3") ||
+     searchInput.value.includes("ignore-nodes:diagram_ignore::F3,diagram_ignore::F5"),
+     "Search input should contain both ignored nodes comma-separated");
+
+  const url = new URL(win.location.href);
+  const qParam = url.searchParams.get("q") || "";
+  ok(qParam.includes("ignore-nodes:diagram_ignore::F5,diagram_ignore::F3") ||
+     qParam.includes("ignore-nodes:diagram_ignore::F3,diagram_ignore::F5"),
+     "URL should contain both ignored nodes comma-separated");
+});


### PR DESCRIPTION
For - https://bugzilla.mozilla.org/show_bug.cgi?id=2030042

This PR implements the client-side **"Ignore this node"** functionality for the interactive graph layout. Previously, ignoring a node required a full server round-trip to re-query and re-render the graph.