### PR TITLE
Bug 2030422 - Ignore source phase import syntax error.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -32,6 +32,11 @@ const ERROR_INTERVENTIONS = [
     prepend: "Not yet supported: "
   },
   {
+    includes: "expected meta, got 'source'",
+    severity: "INFO",
+    prepend: "Not yet supported: "
+  },
+  {
     includes: "illegal character",
     severity: "INFO",
     prepend: "Illegal characters are probably intentional: "


### PR DESCRIPTION
for [bug 2030422](https://bugzilla.mozilla.org/show_bug.cgi?id=2030422)

This does:
  * Add another pattern of the source phase import syntax error message to ignore them