### PR TITLE
Bug 1593367 - Remove Mutex in web-server

### DIFF
--- a/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
+++ b/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
@@ -4466,6 +4466,7 @@ dependencies = [
  "serde_repr",
  "shell-words",
  "termcolor",
+ "thread_local 1.1.9",
  "tokio",
  "tokio-stream",
  "toml",

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -4464,6 +4464,7 @@ dependencies = [
  "serde_repr",
  "shell-words",
  "termcolor",
+ "thread_local 1.1.9",
  "tokio",
  "tokio-stream",
  "toml",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -15,6 +15,7 @@ itertools = "0.14"
 serde = { version = "1.0.196", features = ["derive", "rc", "std"] }
 serde_json = { version = "1.0.113", features = ["preserve_order"] }
 serde_repr = "0.1.18"
+thread_local = "1.1.9"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1.0.86"

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -9,7 +9,6 @@ use std::io::BufReader;
 use std::io::{Read, Write};
 use std::path::Path;
 use std::process::Command;
-use std::sync::Mutex;
 
 use git2::Oid;
 use hyper::header::{ContentType, Location};
@@ -338,8 +337,6 @@ fn main() {
 
     let ident_map = IdentMap::load(&cfg);
 
-    let internal_data = Mutex::new((cfg, ident_map));
-
     let handler = move |req: Request, mut res: Response| {
         if req.method != Method::Get {
             *res.status_mut() = StatusCode::MethodNotAllowed;
@@ -356,13 +353,7 @@ fn main() {
             _ => panic!("Unexpected URI"),
         };
 
-        let guard = match internal_data.lock() {
-            Ok(guard) => guard,
-            Err(poisoned) => poisoned.into_inner(),
-        };
-        let (ref cfg, ref ident_map) = *guard;
-
-        let response = handle(cfg, ident_map, WebRequest { path: &path });
+        let response = handle(&cfg, &ident_map, WebRequest { path: &path });
 
         *res.status_mut() = response.status;
         let output = response.output.into_bytes();

--- a/tools/src/file_format/config.rs
+++ b/tools/src/file_format/config.rs
@@ -9,6 +9,7 @@ use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
 use git2::{Oid, Repository};
+use thread_local::ThreadLocal;
 
 use crate::url_encode_path::url_encode_path;
 
@@ -214,10 +215,38 @@ pub struct ScipSubtreeConfig {
     pub subtree_root: String,
 }
 
+/// Thin wrapper around ThreadLocal<Repository> to make GitData Sync
+/// Created From<Repository>, it Derefs to Repository and will create new thread-local Repository instances as needed.
+pub struct ThreadLocalRepository {
+    path: PathBuf,
+    repository: ThreadLocal<Repository>,
+}
+
+impl std::ops::Deref for ThreadLocalRepository {
+    type Target = Repository;
+    fn deref(&self) -> &Self::Target {
+        // ThreadLocalRepository can only be created from an existing Repository, so if we fail here, it means the repo was removed from under our feet.
+        self.repository
+            .get_or(|| Repository::open(&self.path).expect("Failed to re-open git Repository"))
+    }
+}
+
+impl From<Repository> for ThreadLocalRepository {
+    fn from(repository: Repository) -> Self {
+        let path = repository.path().to_owned();
+        let thread_local = ThreadLocal::new();
+        thread_local.get_or(move || repository);
+        Self {
+            path,
+            repository: thread_local,
+        }
+    }
+}
+
 pub struct GitData {
-    pub repo: Repository,
-    pub blame_repo: Option<Repository>,
-    pub coverage_repo: Option<Repository>,
+    pub repo: ThreadLocalRepository,
+    pub blame_repo: Option<ThreadLocalRepository>,
+    pub coverage_repo: Option<ThreadLocalRepository>,
 
     pub blame_map: HashMap<Oid, Oid>, // Maps repo OID to blame_repo OID.
     // Maps repo OID to Hg rev.  This comes from our blame commits, but cinnabar
@@ -518,9 +547,9 @@ pub fn git_data(paths: &TreeConfigPaths, need_indexes: bool) -> Option<GitData> 
         .map(|path| Repository::open(path).unwrap());
 
     Some(GitData {
-        repo,
-        blame_repo,
-        coverage_repo,
+        repo: repo.into(),
+        blame_repo: blame_repo.map(Into::into),
+        coverage_repo: coverage_repo.map(Into::into),
         blame_map,
         hg_map,
         old_map,


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=1593367

web-server had a Mutex which effectively removed any chance of concurrency.

This requires making GitData: Sync, which is achieved with the new ThreadLocalRepository helper.