### PR TITLE
Bug 2033235 - Ignore a non-JS test file for text module.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -318,6 +318,13 @@ const FILENAME_INTERVENTIONS = [
     severity: "INFO",
     prepend: "CSS module: ",
   },
+  {
+    includes_list: [
+      "testing/web-platform/tests/html/semantics/scripting-1/the-script-element/text-module/file.js",
+    ],
+    severity: "INFO",
+    prepend: "Not a JS: ",
+  },
 ];
 
 function logError(msg)


### PR DESCRIPTION
for [bug 2033235](https://bugzilla.mozilla.org/show_bug.cgi?id=2033235)

This does:
  * Ignore warning comes from non-JS file for text module test