### PR TITLE
Bug 2035871 - Ignore wpt negative testcases.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -325,6 +325,13 @@ const FILENAME_INTERVENTIONS = [
     severity: "INFO",
     prepend: "Not a JS: ",
   },
+  {
+    includes_list: [
+      "testing/web-platform/tests/infrastructure/test262/negative-",
+    ],
+    severity: "INFO",
+    prepend: "Negative testcases: ",
+  },
 ];
 
 function logError(msg)


### PR DESCRIPTION
for [bug 2035871](https://bugzilla.mozilla.org/show_bug.cgi?id=2035871)

This does:
  * Ignore errors comes from intentionally invalid code