### PR TITLE
Bug 2042873 - Bump the web-server volume size to 20GB.

### DIFF
--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -49,8 +49,9 @@ popd
 
 date
 
-# Size up our root partition to 18G.  This is up from 12G when we were hitting
-# the limit for the self-update process during the rust build.
+# Size up our root partition to 20G.  This is up from 12G and then from 18G
+# both when we were hitting the limit for the self-update process during the
+# rust build.
 #
 # To this end we need to know the volume id in order to issue an EBS resizing
 # command.  Note that the select constraint here is intended more as a check
@@ -62,7 +63,7 @@ ROOT_DEV=$(jq -M -r '.DevicePath' <<< "$ROOT_DEV_INFO")
 
 AWS_REGION=us-west-2
 # The size is in gigs.
-aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 18
+aws ec2 modify-volume --region ${AWS_REGION} --volume-id ${ROOT_VOL_ID} --size 20
 
 # We use an until loop because it can take some time for the change to
 # propagate to this VM.  The error will look like:


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=2042873

This does:
  * Increase the root volume size of web-server instance from 18GB to 20GB, to avoid the "no space" error during the provision