### PR TITLE
Upstream glandium's clang-21 fixes, switching to clang-21 and fixing a docker rust-analyzer path regression

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -681,6 +681,23 @@ private:
       return cast<FunctionDecl>(Decl)->getNameAsString();
     }
 
+#if CLANG_VERSION_MAJOR >= 21
+    // clang 21 (commit 6d00c4297f67) sets the DeclContext of lambdas inside
+    // requires-expression bodies to RequiresExprBodyDecl, but manglePrefix
+    // has no guard for it and crashes. Use a location-based name instead.
+    // Works around https://github.com/llvm/llvm-project/issues/200336
+    if (const CXXMethodDecl *MD = dyn_cast<CXXMethodDecl>(Decl)) {
+      if (MD->getParent()->isLambda()) {
+        for (const DeclContext *DC = MD->getParent()->getDeclContext(); DC;
+             DC = DC->getParent()) {
+          if (DC->isRequiresExprBody()) {
+            return std::string("L_") + mangleLocation(Decl->getLocation());
+          }
+        }
+      }
+    }
+#endif
+
     if (isa<FunctionDecl>(Decl) || isa<VarDecl>(Decl)) {
       const DeclContext *DC = Decl->getDeclContext();
       if (isa<TranslationUnitDecl>(DC) || isa<NamespaceDecl>(DC) ||
@@ -1582,7 +1599,11 @@ public:
       QualType CanonicalFieldType = FieldType.getCanonicalType();
       LangOptions langOptions;
       PrintingPolicy Policy(langOptions);
+#if CLANG_VERSION_MAJOR >= 21
+      Policy.PrintAsCanonical = true;
+#else
       Policy.PrintCanonicalTypes = true;
+#endif
       J.attribute("type", typeToString(CanonicalFieldType, Policy));
 
       const TagDecl *tagDecl = CanonicalFieldType->getAsTagDecl();

--- a/clang-plugin/from-clangd/HeuristicResolver.cpp
+++ b/clang-plugin/from-clangd/HeuristicResolver.cpp
@@ -12,6 +12,7 @@
 #include "clang/AST/DeclTemplate.h"
 #include "clang/AST/ExprCXX.h"
 #include "clang/AST/Type.h"
+#include "clang/Basic/Version.h"
 
 namespace clang {
 namespace clangd {
@@ -206,9 +207,16 @@ std::vector<const NamedDecl *> HeuristicResolver::resolveDependentNameType(
 std::vector<const NamedDecl *>
 HeuristicResolver::resolveTemplateSpecializationType(
     const DependentTemplateSpecializationType *DTST) const {
+#if CLANG_VERSION_MAJOR >= 21
+  const DependentTemplateStorage &DTN = DTST->getDependentTemplateName();
+  return resolveDependentMember(
+      resolveNestedNameSpecifierToType(DTN.getQualifier()),
+      DTN.getName().getIdentifier(), TemplateFilter);
+#else
   return resolveDependentMember(
       resolveNestedNameSpecifierToType(DTST->getQualifier()),
       DTST->getIdentifier(), TemplateFilter);
+#endif
 }
 
 std::vector<const NamedDecl *>
@@ -250,7 +258,9 @@ const Type *HeuristicResolver::resolveNestedNameSpecifierToType(
   // the TypeSpec cases too.
   switch (NNS->getKind()) {
   case NestedNameSpecifier::TypeSpec:
+#if CLANG_VERSION_MAJOR < 21
   case NestedNameSpecifier::TypeSpecWithTemplate:
+#endif
     return NNS->getAsType();
   case NestedNameSpecifier::Identifier: {
     return resolveDeclsToType(

--- a/flake.nix
+++ b/flake.nix
@@ -57,12 +57,12 @@
             pkg-config
 
             # Must be before (unwrapped) clang in path
-            llvmPackages_19.clang-tools
+            llvmPackages_21.clang-tools
 
             # Dependencies required to build clang-plugin
-            clang_19
-            llvmPackages_19.libllvm
-            llvmPackages_19.libclang
+            clang_21
+            llvmPackages_21.libllvm
+            llvmPackages_21.libclang
 
             gdb
 

--- a/infrastructure/Dockerfile
+++ b/infrastructure/Dockerfile
@@ -29,7 +29,7 @@ RUN /infrastructure/common-provision-post.sh
 
 # installs extra tooling only required for docker
 RUN /infrastructure/docker-provision-post.sh
-ENV PATH=/home/vagrant/mozsearch-firefox:$PATH
+ENV PATH=/home/vagrant/mozsearch-firefox:/home/vagrant/.local/bin:$PATH
 
 EXPOSE 16995/tcp
 

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -17,12 +17,12 @@ MOZSEARCH_CONFIG_BRANCH="${MOZSEARCH_CONFIG_BRANCH:-master}"
 # Note that for the most recent LLVM/clang release (ex: right now v13), you
 # would actually want to leave this empty.  Check out https://apt.llvm.org/ for
 # the latest info in all cases.
-CLANG_SUFFIX=-18
+CLANG_SUFFIX=-21
 # Bumping the priority with each version upgrade lets running the provisioning
 # script on an already provisioned machine do the right thing alternative-wise.
 # Actually, we no longer support re-provisioning, but it's fun to increment
 # numbers.
-CLANG_PRIORITY=414
+CLANG_PRIORITY=415
 # The clang packages build the Ubuntu release name in; let's dynamically extract
 # it since I, asuth, once forgot to update this.
 UBUNTU_RELEASE=$(lsb_release -cs)

--- a/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/main@Foo_Simple.snap
+++ b/tests/tests/checks/snapshots/analysis/cpp/bug1781178.cpp/main@Foo_Simple.snap
@@ -37,9 +37,6 @@ input_file: inputs/analysis/cpp/bug1781178.cpp/Foo_Simple
     "syntax": "function,use",
     "pretty": "function Foo::Simple",
     "sym": "_ZN3Foo6SimpleEv",
-    "type": "void (void)",
-    "confidence": [
-      "cppTemplateHeuristic"
-    ]
+    "type": "void"
   }
 ]

--- a/tests/tests/checks/snapshots/crossref/merge/main@merge__big_cpp.snap
+++ b/tests/tests/checks/snapshots/crossref/merge/main@merge__big_cpp.snap
@@ -2449,7 +2449,7 @@ input_file: inputs/crossref/merge/merge__big_cpp
     "syntax": "function,use",
     "pretty": "function std::shared_ptr::operator=",
     "sym": "_ZNSt10shared_ptraSEOSt10shared_ptrIT_E",
-    "type": "shared_ptr<Human> &",
+    "type": "shared_ptr<outerNS::Human> &",
     "typesym": "T_std::shared_ptr",
     "argRanges": [
       "332:6-332:11",


### PR DESCRIPTION
The main thing here is to upstream https://phabricator.services.mozilla.com/D303283 which is necessary since firefox-main now uses clang-21.  This also moves us to provision clang-21.  While testing locally with docker, I noticed a rust-analyzer filter which is because the Dockerfile sets the PATH which overrides what bash tries to do with the ~/.profile and our changes there, so I update that.  And then there are minor snapshot changes that seem to have more to do with clang-21 than the required change and I've approved those.

Ideally I did the flake stuff correctly; I did not try that yet.

Note that to test/provision locally I needed to force the mozsearch repo and branch to correspond to this one so that provisioning would not fail when trying to compile the clang plugin.  Hopefully the CI approach doesn't run into that.