### PR TITLE
Bug 2047297 - Support CallImportSource.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -1069,6 +1069,7 @@ class ASTVisitor {
       break;
 
     case "CallImport":
+    case "CallImportSource":
       this.callImport(expr);
       break;
 


### PR DESCRIPTION
for [bug 2047297](https://bugzilla.mozilla.org/show_bug.cgi?id=2047297)

This does:
  * Handle CallImportSource (`import.source(...)`) same as CallImport (`import(...)`)