### PR TITLE
Bug 2047297 - Part 3: Do nothing for ImportSourceDeclaration.

### DIFF
--- a/scripts/js-analyze.js
+++ b/scripts/js-analyze.js
@@ -654,8 +654,11 @@ class ASTVisitor {
       break;
 
     case "ImportDeclaration":
-    case "ImportSourceDeclaration":
       this.importDeclaration(stmt);
+      break;
+
+    case "ImportSourceDeclaration":
+      this.importSourceDeclaration(stmt);
       break;
 
     case "ExportDeclaration":
@@ -887,6 +890,9 @@ class ASTVisitor {
         }
       }
     }
+  }
+
+  importSourceDeclaration(stmt) {
   }
 
   exportDeclaration(stmt) {
@@ -1680,8 +1686,9 @@ class NameAnalysis extends ASTVisitor {
         this.#handleDefPattern(env, stmt.id);
         break;
       case "ImportDeclaration":
-      case "ImportSourceDeclaration":
         this.#handleImportDeclaration(env, stmt);
+      case "ImportSourceDeclaration":
+        this.#handleImportSourceDeclaration(env, stmt);
         break;
       case "ExportDeclaration":
         this.#handleExportDeclaration(env, stmt);
@@ -1707,6 +1714,9 @@ class NameAnalysis extends ASTVisitor {
         }
       }
     }
+  }
+
+  #handleImportSourceDeclaration(env, stmt) {
   }
 
   #handleExportDeclaration(env, stmt) {


### PR DESCRIPTION
for https://bugzilla.mozilla.org/show_bug.cgi?id=2047297

source phase import actually has slightly different Reflect parse AST.
And given that it's not used anywhere, I'll leave the consumer empty.
We can revisit it when the feature gets enabled and people start using it.