### PR TITLE
Bug 2047759 - Revert DerivedSymbolInfo::crossref_info to be optional

### DIFF
--- a/tools/src/cmd_pipeline/cmd_format_symbols.rs
+++ b/tools/src/cmd_pipeline/cmd_format_symbols.rs
@@ -976,7 +976,7 @@ impl ClassMap {
     ) -> Result<()> {
         let (root_sym_id, _) = self.stt.node_set.add_symbol(DerivedSymbolInfo::new(
             nom_sym_info.symbol,
-            nom_sym_info.crossref_info,
+            Some(nom_sym_info.crossref_info),
             0,
         ));
 

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -266,7 +266,7 @@ impl PipelineCommand for GraphCommand {
 
         let decorate_node = |node: &mut Node, sym_info: &DerivedSymbolInfo| {
             for (i, colorize) in self.args.colorize_callees.iter().enumerate() {
-                if let Some(arr) = &sym_info.crossref_info.callees {
+                if let Some(arr) = sym_info.crossref_info.as_ref().and_then(|ci| ci.callees.as_ref()) {
                     for callee in arr {
                         if let Some(pretty) = callee.pretty
                             && pretty.ends_with(colorize)

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -220,7 +220,7 @@ impl PipelineCommand for TraverseCommand {
             considered.insert(info.symbol);
 
             let (sym_node_id, _info) =
-                sym_node_set.add_symbol(DerivedSymbolInfo::new(info.symbol, info.crossref_info, 0));
+                sym_node_set.add_symbol(DerivedSymbolInfo::new(info.symbol, Some(info.crossref_info), 0));
             // Explicitly put the node in the graph so if we don't find any
             // edges, we still display the node.  This is important for things
             // like "class-diagram" where showing nothing is very confusing.
@@ -494,9 +494,7 @@ impl PipelineCommand for TraverseCommand {
                 // its own depth addition.
                 let sym_info = sym_node_set.get(&sym_id);
                 let member_uses = sym_info
-                    .crossref_info
-                    .field_member_uses
-                    .clone()
+                    .crossref_info.as_ref().and_then(|ci| ci.field_member_uses.clone())
                     .unwrap_or_default();
 
                 if member_uses.len() as u32 >= self.args.skip_field_member_uses_at_count {
@@ -1176,7 +1174,7 @@ impl PipelineCommand for TraverseCommand {
                 let sym_info = sym_node_set.get_mut(&sym_id);
                 let callees = match (
                     self.args.retain_all_symbol_data,
-                    sym_info.crossref_info.callees.as_mut(),
+                    sym_info.crossref_info.as_mut().and_then(|ci| ci.callees.as_mut()),
                 ) {
                     (true, Some(v)) => v.clone(),
                     (false, Some(v)) => core::mem::take(v),
@@ -1243,7 +1241,7 @@ impl PipelineCommand for TraverseCommand {
                 let sym_info = sym_node_set.get_mut(&sym_id);
                 let uses = match (
                     self.args.retain_all_symbol_data,
-                    sym_info.crossref_info.uses.as_mut(),
+                    sym_info.crossref_info.as_mut().and_then(|ci| ci.uses.as_mut()),
                 ) {
                     (true, Some(v)) => v.clone(),
                     (false, Some(v)) => core::mem::take(v),

--- a/tools/src/cmd_pipeline/interface.rs
+++ b/tools/src/cmd_pipeline/interface.rs
@@ -94,7 +94,7 @@ impl SymbolTreeTableList {
                 let info = sym_info.crossref_info.clone();
                 jumprefs.insert(
                     sym_info.symbol,
-                    convert_crossref_value_to_sym_info_rep(Some(info), &sym_info.symbol, None),
+                    convert_crossref_value_to_sym_info_rep(info, &sym_info.symbol, None),
                 );
             }
             for (sym, info) in &table.extra_syms {

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -22,7 +22,7 @@ use ustr::{Ustr, UstrMap, ustr};
 use crate::{
     abstract_server::{AbstractServer, ErrorDetails, ErrorLayer, Result, ServerError},
     file_format::{
-        analysis::{AnalysisStructured, BindingSlotKind},
+        analysis::{AnalysisStructured, BindingSlotKind, PathSearchResult},
         analysis_manglings::split_pretty,
         crossref::CrossrefData,
         jumpref::{JumprefData, convert_crossref_value_to_sym_info_rep},
@@ -101,7 +101,7 @@ pub fn make_safe_port_id(dubious_id: &str) -> String {
 #[derive(Clone, Debug)]
 pub struct DerivedSymbolInfo {
     pub symbol: Ustr,
-    pub crossref_info: CrossrefData,
+    pub crossref_info: Option<CrossrefData>,
     pub badges: Vec<SymbolBadge>,
     /// For symbols that are fields with pointer_infos, we set the effective
     /// subsystem to be the subsystem of the first pointer_info payload.  We
@@ -250,9 +250,17 @@ impl DerivedSymbolInfo {
         }
     }
 
+    pub fn get_crossref_info(&self) -> Option<&CrossrefData> {
+        self.crossref_info.as_ref()
+    }
+
+    pub fn get_definitions(&self) -> Option<&[PathSearchResult]> {
+        self.get_crossref_info().and_then(|ci| ci.definitions.as_deref())
+    }
+
     /// Provide the structured rep of this symbol if it has one.
     pub fn get_structured(&self) -> Option<&AnalysisStructured> {
-        self.crossref_info.meta.as_ref()
+        self.get_crossref_info().and_then(|ci| ci.meta.as_ref())
     }
 
     /// For hierarchy purposes we want to skip over namespace or namespace-like
@@ -293,9 +301,7 @@ impl DerivedSymbolInfo {
     /// should ideally only be a single definition path, even if we might have
     /// multiple line hits at the path because of #ifdefs.)
     pub fn get_def_path(&self) -> Option<Ustr> {
-        self.crossref_info
-            .definitions
-            .as_ref()
+        self.get_definitions()
             .and_then(|defs| defs.get(0).map(|def| def.path))
     }
 
@@ -303,9 +309,7 @@ impl DerivedSymbolInfo {
     /// This is intended to assist with lexically ordering fields within a
     /// structure/class.
     pub fn get_def_lno(&self) -> u64 {
-        self.crossref_info
-            .definitions
-            .as_ref()
+        self.get_definitions()
             .and_then(|defs| {
                 defs.get(0)
                     .and_then(|def| def.lines.get(0).map(|line| line.lineno.into()))
@@ -316,13 +320,15 @@ impl DerivedSymbolInfo {
     // Potentially reduce our memory usage by dropping our uses and calls fields
     // if they are present, as they won't be used for jumpref production.
     pub fn reduce_memory_usage_by_dropping_non_jumpref_info(&mut self) {
-        self.crossref_info.uses = None;
-        self.crossref_info.callees = None;
+        if let Some (crossref_info) = self.crossref_info.as_mut() {
+            crossref_info.uses = None;
+            crossref_info.callees = None;
+        }
     }
 }
 
 impl DerivedSymbolInfo {
-    pub fn new(symbol: Ustr, crossref_info: CrossrefData, depth: u32) -> Self {
+    pub fn new(symbol: Ustr, crossref_info: Option<CrossrefData>, depth: u32) -> Self {
         DerivedSymbolInfo {
             symbol,
             crossref_info,
@@ -2393,8 +2399,8 @@ impl SymbolGraphNodeSet {
         // useful in the context of the class.)
         if let Some(labels) = sym_info
             .crossref_info
-            .meta
             .as_ref()
+            .and_then(|ci| ci.meta.as_ref())
             .map(|meta| &meta.labels)
         {
             for label in labels {
@@ -2437,12 +2443,7 @@ impl SymbolGraphNodeSet {
             return Ok((SymbolGraphNodeId(*index), sym_info));
         }
 
-        let Some(info) = server.crossref_lookup(sym).await? else {
-            return Err(ServerError::StickyProblem(ErrorDetails {
-                layer: ErrorLayer::DataLayer,
-                message: "ensure_symbol: symbol not found in crossref table".to_owned(),
-            }));
-        };
+        let info = server.crossref_lookup(sym).await?;
         Ok(self.add_symbol(DerivedSymbolInfo::new(*sym, info, depth)))
     }
 
@@ -2465,7 +2466,7 @@ impl SymbolGraphNodeSet {
             let info = std::mem::take(&mut sym_info.crossref_info);
             jumprefs.insert(
                 sym_info.symbol,
-                convert_crossref_value_to_sym_info_rep(Some(info), &sym_info.symbol, None),
+                convert_crossref_value_to_sym_info_rep(info, &sym_info.symbol, None),
             );
         }
 
@@ -2480,7 +2481,7 @@ impl SymbolGraphNodeSet {
             let info = sym_info.crossref_info.clone();
             jumprefs.insert(
                 sym_info.symbol,
-                convert_crossref_value_to_sym_info_rep(Some(info), &sym_info.symbol, None),
+                convert_crossref_value_to_sym_info_rep(info, &sym_info.symbol, None),
             );
         }
 


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2047759
Example: https://searchfox.org/firefox-main/query/default?q=calls-to%3A%27mozilla%3A%3Adom%3A%3ANavigator_Binding%3A%3AgetBattery_promiseWrapper%27%20depth%3A4

Since it used to be a `serde_json::Value`, `DerivedSymbolInfo::crossref_info` could previously be `Value::Null`. It seems I need to be less strict there and use `Option<CrossrefData>`.