### PR TITLE
Add Nix to PATH in {indexer,web-server}-provision.sh

### DIFF
--- a/infrastructure/aws/indexer-provision.sh
+++ b/infrastructure/aws/indexer-provision.sh
@@ -89,3 +89,4 @@ date
 
 # Install Nix
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install linux --no-confirm
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh

--- a/infrastructure/aws/web-server-provision.sh
+++ b/infrastructure/aws/web-server-provision.sh
@@ -85,3 +85,4 @@ date
 
 # Install Nix
 curl -fsSL https://install.determinate.systems/nix | sh -s -- install linux --no-confirm
+. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh


### PR DESCRIPTION
This fixes the following scripts checking if the nix command is available and using it.