### PR TITLE
crossref: sort identifiers directly in Rust

### DIFF
--- a/scripts/crossref.sh
+++ b/scripts/crossref.sh
@@ -11,9 +11,3 @@ ANALYSIS_FILES_PATH=$3
 echo Root is $INDEX_ROOT
 
 crossref $CONFIG_FILE $TREE_NAME $ANALYSIS_FILES_PATH 16
-
-# Re-sort the identifiers file so that it's case-insensitive.  (It was written
-# to disk from a case-sensitive BTreeMap.)
-ID_FILE=$INDEX_ROOT/identifiers
-LC_ALL=C sort -f $ID_FILE > ${TMPDIR:-/tmp}/ids
-mv ${TMPDIR:-/tmp}/ids $ID_FILE

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -49,6 +49,7 @@ use tools::logging::LoggedSpan;
 use tools::logging::init_logging;
 use tools::templating::builder::build_and_parse_ontology_ingestion_explainer;
 use tools::templating::builder::build_and_parse_repo_ingestion_explainer;
+use tools::utils::case_semisensitive_cmp;
 use ustr::Ustr;
 use ustr::UstrMap;
 use ustr::UstrSet;
@@ -1582,11 +1583,16 @@ fn write_identifiers(tree_config: &TreeConfig, id_table: IdTable) {
     let id_file = format!("{}/identifiers", tree_config.paths.index_path);
 
     let mut idf = File::create(id_file).unwrap();
-    for (id, syms) in id_table {
-        for sym in syms {
-            let line = format!("{} {}\n", id, sym);
-            let _ = idf.write_all(line.as_bytes());
-        }
+
+    let mut lines: Vec<_> = id_table
+        .into_iter()
+        .flat_map(|(key, syms)| syms.into_iter().map(move |sym| (key, sym)))
+        .map(|(id, sym)| format!("{} {}\n", id, sym))
+        .collect();
+    lines.sort_unstable_by(|lhs, rhs| case_semisensitive_cmp(lhs, rhs));
+
+    for line in lines {
+        let _ = idf.write_all(line.as_bytes());
     }
 }
 

--- a/tools/src/cmd_pipeline/cmd_graph.rs
+++ b/tools/src/cmd_pipeline/cmd_graph.rs
@@ -266,7 +266,11 @@ impl PipelineCommand for GraphCommand {
 
         let decorate_node = |node: &mut Node, sym_info: &DerivedSymbolInfo| {
             for (i, colorize) in self.args.colorize_callees.iter().enumerate() {
-                if let Some(arr) = sym_info.crossref_info.as_ref().and_then(|ci| ci.callees.as_ref()) {
+                if let Some(arr) = sym_info
+                    .crossref_info
+                    .as_ref()
+                    .and_then(|ci| ci.callees.as_ref())
+                {
                     for callee in arr {
                         if let Some(pretty) = callee.pretty
                             && pretty.ends_with(colorize)

--- a/tools/src/cmd_pipeline/cmd_traverse.rs
+++ b/tools/src/cmd_pipeline/cmd_traverse.rs
@@ -219,8 +219,11 @@ impl PipelineCommand for TraverseCommand {
             }
             considered.insert(info.symbol);
 
-            let (sym_node_id, _info) =
-                sym_node_set.add_symbol(DerivedSymbolInfo::new(info.symbol, Some(info.crossref_info), 0));
+            let (sym_node_id, _info) = sym_node_set.add_symbol(DerivedSymbolInfo::new(
+                info.symbol,
+                Some(info.crossref_info),
+                0,
+            ));
             // Explicitly put the node in the graph so if we don't find any
             // edges, we still display the node.  This is important for things
             // like "class-diagram" where showing nothing is very confusing.
@@ -494,7 +497,9 @@ impl PipelineCommand for TraverseCommand {
                 // its own depth addition.
                 let sym_info = sym_node_set.get(&sym_id);
                 let member_uses = sym_info
-                    .crossref_info.as_ref().and_then(|ci| ci.field_member_uses.clone())
+                    .crossref_info
+                    .as_ref()
+                    .and_then(|ci| ci.field_member_uses.clone())
                     .unwrap_or_default();
 
                 if member_uses.len() as u32 >= self.args.skip_field_member_uses_at_count {
@@ -1174,7 +1179,10 @@ impl PipelineCommand for TraverseCommand {
                 let sym_info = sym_node_set.get_mut(&sym_id);
                 let callees = match (
                     self.args.retain_all_symbol_data,
-                    sym_info.crossref_info.as_mut().and_then(|ci| ci.callees.as_mut()),
+                    sym_info
+                        .crossref_info
+                        .as_mut()
+                        .and_then(|ci| ci.callees.as_mut()),
                 ) {
                     (true, Some(v)) => v.clone(),
                     (false, Some(v)) => core::mem::take(v),
@@ -1241,7 +1249,10 @@ impl PipelineCommand for TraverseCommand {
                 let sym_info = sym_node_set.get_mut(&sym_id);
                 let uses = match (
                     self.args.retain_all_symbol_data,
-                    sym_info.crossref_info.as_mut().and_then(|ci| ci.uses.as_mut()),
+                    sym_info
+                        .crossref_info
+                        .as_mut()
+                        .and_then(|ci| ci.uses.as_mut()),
                 ) {
                     (true, Some(v)) => v.clone(),
                     (false, Some(v)) => core::mem::take(v),

--- a/tools/src/cmd_pipeline/symbol_graph.rs
+++ b/tools/src/cmd_pipeline/symbol_graph.rs
@@ -255,7 +255,8 @@ impl DerivedSymbolInfo {
     }
 
     pub fn get_definitions(&self) -> Option<&[PathSearchResult]> {
-        self.get_crossref_info().and_then(|ci| ci.definitions.as_deref())
+        self.get_crossref_info()
+            .and_then(|ci| ci.definitions.as_deref())
     }
 
     /// Provide the structured rep of this symbol if it has one.
@@ -320,7 +321,7 @@ impl DerivedSymbolInfo {
     // Potentially reduce our memory usage by dropping our uses and calls fields
     // if they are present, as they won't be used for jumpref production.
     pub fn reduce_memory_usage_by_dropping_non_jumpref_info(&mut self) {
-        if let Some (crossref_info) = self.crossref_info.as_mut() {
+        if let Some(crossref_info) = self.crossref_info.as_mut() {
             crossref_info.uses = None;
             crossref_info.callees = None;
         }

--- a/tools/src/lib.rs
+++ b/tools/src/lib.rs
@@ -81,4 +81,4 @@ pub mod url_encode_path;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod url_map_handler;
 
-mod utils;
+pub mod utils;

--- a/tools/src/utils/mod.rs
+++ b/tools/src/utils/mod.rs
@@ -2,3 +2,43 @@ mod owned_or_borrowed;
 
 #[allow(unused_imports)]
 pub use owned_or_borrowed::OwnedOrBorrowed;
+
+/// Compares strings in lexicographic order case-insensitively
+///
+/// ```
+/// # use tools::utils::case_insensitive_cmp;
+/// # use core::cmp::Ordering::*;
+/// assert_eq!(case_insensitive_cmp("ABCD", "ABC"), Greater);
+/// assert_eq!(case_insensitive_cmp("ABC", "ABCD"), Less);
+/// assert_eq!(case_insensitive_cmp("ABC", "ABC"), Equal);
+/// assert_eq!(case_insensitive_cmp("ABC", "abc"), Equal);
+/// ```
+pub fn case_insensitive_cmp(lhs: impl AsRef<str>, rhs: impl AsRef<str>) -> core::cmp::Ordering {
+    let lhs = lhs.as_ref();
+    let rhs = rhs.as_ref();
+
+    let lhs_uppercase = lhs.chars().flat_map(char::to_uppercase);
+    let rhs_uppercase = rhs.chars().flat_map(char::to_uppercase);
+    lhs_uppercase.cmp(rhs_uppercase)
+}
+
+/// Compares strings in lexicographic order:
+/// - first case-insensitively
+/// - then case-sensitively if they compare equal
+///
+/// This is meant to provide a more stable ordering than pure case-insensitive comparison.
+///
+/// ```
+/// # use tools::utils::case_semisensitive_cmp;
+/// # use core::cmp::Ordering::*;
+/// assert_eq!(case_semisensitive_cmp("ABCD", "ABC"), Greater);
+/// assert_eq!(case_semisensitive_cmp("ABC", "ABCD"), Less);
+/// assert_eq!(case_semisensitive_cmp("ABC", "ABC"), Equal);
+/// assert_eq!(case_semisensitive_cmp("ABC", "abc"), Less);
+/// ```
+pub fn case_semisensitive_cmp(lhs: impl AsRef<str>, rhs: impl AsRef<str>) -> core::cmp::Ordering {
+    let lhs = lhs.as_ref();
+    let rhs = rhs.as_ref();
+
+    case_insensitive_cmp(lhs, rhs).then_with(|| lhs.cmp(rhs))
+}


### PR DESCRIPTION
Instead of outputing the identifiers file in random order then sorting it using sort, this directly sorts the file from the Rust binary.

Note: the comment was outdated, this was changed from a BTreeMap to a HashMap some time ago.

This is required by https://github.com/KDABLabs/mozsearch-qt which doesn't use the `crossref.sh` wrapper and IMO makes more sense.

+ I'm sneaking in a fixup for https://github.com/mozsearch/mozsearch/pull/1102. It was late and I forgot to run `cargo fmt`.