### PR TITLE
Provide mozsearch router via Nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -56,6 +56,9 @@
         mozsearch-wasm-css-analyzer = pkgs.callPackage ./nix/mozsearch/wasm-css-analyzer.nix {
           inherit wasm-snip craneLib;
         };
+        mozsearch-router = pkgs.callPackage ./nix/mozsearch/router {
+          inherit llvmPackages;
+        };
 
         commonPackages = with pkgs; [
           livegrep
@@ -70,11 +73,12 @@
         ];
 
         serverPackages = with pkgs; [
+          mozsearch-router
         ];
       in {
         packages = {
           inherit scip-python wasm-snip;
-          inherit mozsearch-tools mozsearch-clang-plugin mozsearch-wasm-css-analyzer;
+          inherit mozsearch-tools mozsearch-clang-plugin mozsearch-wasm-css-analyzer mozsearch-router;
 
           indexerPackages = pkgs.symlinkJoin {
             name = "indexerPackages";

--- a/infrastructure/common-provision-pre.sh
+++ b/infrastructure/common-provision-pre.sh
@@ -137,34 +137,15 @@ fi
 # install ripgrep so we can stop experiencing grep pain / footguns
 sudo apt-get install ripgrep
 
-# Install codesearch gRPC python libs.
-if [ ! -d livegrep ]; then
-  git clone https://github.com/livegrep/livegrep --revision=44b2fb62ac4685ab3070f030d7130a21c2f67e31 --depth=1
-
-  # Install gRPC python libs and generate the python modules to communicate with the codesearch server
-  # We need to create a venv for this because Ubuntu 24.04 gets very angry if we
-  # use pip to install things outside of a venv.
-  LIVEGREP_VENV=$HOME/livegrep-venv
+# Install six in a Python virtual env for xpidl.py.
+# The venv is called livegrep-venv because it used to host the livegrep python library as well.
+LIVEGREP_VENV=$HOME/livegrep-venv
+if [ ! -d $LIVEGREP_VENV ]; then
   python3 -m venv $LIVEGREP_VENV --system-site-packages
   echo "PATH=$LIVEGREP_VENV/bin:\$PATH" >> ~/.profile
   PATH=$LIVEGREP_VENV/bin:$PATH
 
-  pip install grpcio grpcio-tools
-  # also install "six" in this venv for xpidl.py for now
   pip install six
-
-  mkdir livegrep-grpc3
-  pushd livegrep
-  sed 's|import "src/proto/config.proto";|import "livegrep/config.proto";|' -i src/proto/livegrep.proto
-  mkdir build
-  python3 -m grpc_tools.protoc --python_out=build --grpc_python_out=build -I livegrep=src/proto "src/proto/config.proto" "src/proto/livegrep.proto"
-  popd
-  mv livegrep/build/livegrep livegrep-grpc3/livegrep
-  # Add the generated modules to the python path
-  SITEDIR=$(python3 -c "import site; print(site.getsitepackages()[0])")
-  mkdir -p "$SITEDIR"
-  echo "$PWD/livegrep-grpc3" > "$SITEDIR/livegrep.pth"
-  rm -rf livegrep
 fi
 
 sudo apt-get install -y python3-boto3 python3-rich

--- a/infrastructure/web-server-run.sh
+++ b/infrastructure/web-server-run.sh
@@ -28,7 +28,7 @@ CONFIG_FILE="$SERVER_ROOT/config.json"
 STATUS_FILE="${SERVER_ROOT}/docroot/status.txt"
 
 pkill -x codesearch || true
-pkill -f router/router.py || true
+pkill -x .router-wrapped || true
 pkill -x web-server || true
 pkill -x pipeline-server || true
 
@@ -38,7 +38,7 @@ nohup \
     $MOZSEARCH_PATH/infrastructure/with-auto-restart.sh \
     $MOZSEARCH_PATH $CHANNEL router $DEST_EMAIL $LOG_DIR/router.err \
     \
-    $MOZSEARCH_PATH/router/router.py $CONFIG_FILE $STATUS_FILE \
+    router $CONFIG_FILE $STATUS_FILE \
     > $LOG_DIR/router.log \
     2> $LOG_DIR/router.err \
     < /dev/null &
@@ -92,7 +92,7 @@ nohup \
 
 # If WAIT was passed, wait until the servers report they loaded.
 if [[ $WAIT = "WAIT" ]]; then
-  echo "Waiting for router.py and web-server to report they have started in ${STATUS_FILE}"
+  echo "Waiting for router and web-server to report they have started in ${STATUS_FILE}"
   until [[ $(grep -c loaded ${STATUS_FILE}) -eq 2 ]]; do
     sleep 0.1s
   done

--- a/nix/mozsearch/router/default.nix
+++ b/nix/mozsearch/router/default.nix
@@ -1,0 +1,35 @@
+{
+  stdenvNoCC,
+  callPackage,
+  lib,
+  livegrep,
+  python3Packages,
+  llvmPackages,
+  procps,
+}: let
+  livegrep-grpc3 = callPackage ./livegrep-grpc3.nix {};
+in
+  stdenvNoCC.mkDerivation {
+    pname = "mozsearch-router";
+    version = "unstable";
+
+    src = ../../../router;
+
+    nativeBuildInputs = [
+      python3Packages.wrapPython
+    ];
+
+    pythonPath = map (dep: dep python3Packages) [livegrep-grpc3];
+
+    installPhase = ''
+      mkdir -p "$out/lib/python${python3Packages.python.pythonVersion}/site-packages"
+      cp $src/* "$out/lib/python${python3Packages.python.pythonVersion}/site-packages"
+
+      mkdir -p $out/bin
+      cp $src/router.py $out/bin/router
+      cp $src/codesearch.py $out/bin/codesearchctl
+
+      makeWrapperArgs+=( --prefix PATH : "${lib.makeBinPath [livegrep llvmPackages.bintools procps]}" )
+      wrapPythonPrograms
+    '';
+  }

--- a/nix/mozsearch/router/livegrep-grpc3.nix
+++ b/nix/mozsearch/router/livegrep-grpc3.nix
@@ -1,0 +1,47 @@
+{
+  livegrep,
+  fetchFromGitHub,
+}: {
+  buildPythonPackage,
+  grpcio-tools,
+  grpcio,
+  python,
+  ...
+}:
+buildPythonPackage {
+  pname = "livegrep-grpc3";
+  inherit (livegrep) version src;
+
+  format = "other";
+
+  nativeBuildInputs = [
+    grpcio-tools
+  ];
+
+  dependencies = [
+    grpcio
+  ];
+
+  postPatch = ''
+    sed 's|import "src/proto/config.proto";|import "livegrep/config.proto";|' -i src/proto/livegrep.proto
+  '';
+
+  buildPhase = ''
+    runHook postBuild
+
+    mkdir build
+    python3 -m grpc_tools.protoc --python_out=build --grpc_python_out=build -I livegrep=src/proto "src/proto/config.proto" "src/proto/livegrep.proto"
+    touch build/livegrep/__init__.py
+
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+
+    mkdir -p "$out/lib/python${python.pythonVersion}/site-packages/"
+    mv build/livegrep "$out/lib/python${python.pythonVersion}/site-packages/livegrep"
+
+    runHook postInstall
+  '';
+}

--- a/scripts/mkindex.sh
+++ b/scripts/mkindex.sh
@@ -229,7 +229,7 @@ if should_perform "codesearch-start"; then
     # Check the resulting index for correctness, but there's no webserver so the
     # 4th argument needs to be empty.  We now also need the livegrep server to be
     # available, so start that first.
-    $MOZSEARCH_PATH/router/codesearch.py $CONFIG_FILE start $TREE_NAME
+    codesearchctl $CONFIG_FILE start $TREE_NAME
 fi
 
 if should_perform "check-index"; then
@@ -241,5 +241,5 @@ if should_perform "codesearch-stop"; then
     # still be hanging around, but codesearch.py always stops an existing server
     # first, so we're not really concerned about this affecting a re-run of the
     # indexing process.
-    $MOZSEARCH_PATH/router/codesearch.py $CONFIG_FILE stop $TREE_NAME
+    codesearchctl $CONFIG_FILE stop $TREE_NAME
 fi


### PR DESCRIPTION
This wraps router.py, making it easier to run without having to setup a venv, and removes the livegrep python library shenanigans from the provisioning scripts.

This is the last patch required by my Qt index.