### PR TITLE
Nix-related fixups

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
         commonPackages = with pkgs; [
           livegrep
           mozsearch-tools
+          mozsearch-router
         ];
 
         indexerPackages = with pkgs; [
@@ -80,7 +81,6 @@
         ];
 
         serverPackages = with pkgs; [
-          mozsearch-router
         ];
       in {
         packages = {

--- a/infrastructure/indexer-update.sh
+++ b/infrastructure/indexer-update.sh
@@ -21,6 +21,8 @@ set -o pipefail # Check all commands in a pipeline
 
 # Install Nix-provided packages
 sudo -i nix profile add "$(pwd)/mozsearch#indexerPackages" --accept-flake-config --print-build-logs --priority 3
+# If the package was already installed we need to explicitly upgrade as well
+sudo -i nix profile upgrade indexerPackages --accept-flake-config --print-build-logs
 
 # Install SpiderMonkey.
 rm -rf target.jsshell.zip js

--- a/infrastructure/web-server-update.sh
+++ b/infrastructure/web-server-update.sh
@@ -22,3 +22,5 @@ set -o pipefail # Check all commands in a pipeline
 
 # Install Nix-provided packages
 sudo -i nix profile add "$(pwd)/mozsearch#serverPackages" --accept-flake-config --print-build-logs --priority 4
+# If the package was already installed we need to explicitly upgrade as well
+sudo -i nix profile upgrade serverPackages --accept-flake-config --print-build-logs


### PR DESCRIPTION
Now that the provisioning step installs packages via Nix, the `nix profile add` calls in `{indexer,webserver}-update.sh` don't fully function.
And the indexer also needs the router package.