### PR TITLE
identifiers lookup: reduce number of temporary allocations

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,7 @@
             llvmPackages.clang-tools
 
             gdb
+            heaptrack
 
             scip
             protobuf

--- a/tools/src/bin/crossref.rs
+++ b/tools/src/bin/crossref.rs
@@ -1589,7 +1589,7 @@ fn write_identifiers(tree_config: &TreeConfig, id_table: IdTable) {
         .flat_map(|(key, syms)| syms.into_iter().map(move |sym| (key, sym)))
         .map(|(id, sym)| format!("{} {}\n", id, sym))
         .collect();
-    lines.sort_unstable_by(|lhs, rhs| case_semisensitive_cmp(lhs, rhs));
+    lines.sort_unstable_by(|lhs, rhs| case_semisensitive_cmp(lhs.chars(), rhs.chars()));
 
     for line in lines {
         let _ = idf.write_all(line.as_bytes());

--- a/tools/src/file_format/identifiers.rs
+++ b/tools/src/file_format/identifiers.rs
@@ -1,6 +1,9 @@
 extern crate memmap;
 
+use crate::utils::case_insensitive_cmp;
+
 use self::memmap::Mmap;
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::BufRead;
@@ -14,8 +17,11 @@ use serde_json::to_string;
 
 use super::config::Config;
 
-fn uppercase(s: &[u8]) -> Vec<u8> {
-    s.iter().map(u8::to_ascii_uppercase).collect()
+fn uppercase(s: &[u8]) -> impl Iterator<Item = char> + Clone {
+    s.iter()
+        .copied()
+        .map(char::from)
+        .flat_map(char::to_uppercase)
 }
 
 #[derive(Clone, Debug)]
@@ -111,10 +117,8 @@ impl IdentMap {
     }
 
     fn bisect(&self, needle: &[u8], upper_bound: bool) -> usize {
-        let mut needle = uppercase(needle);
-        if upper_bound {
-            needle.push(b'~');
-        }
+        let needle = uppercase(needle);
+        let needle = needle.chain(upper_bound.then_some('~').into_iter());
 
         let mut first = 0;
         let mut count = self.mmap.len();
@@ -123,13 +127,15 @@ impl IdentMap {
             let step = count / 2;
             let pos = first + step;
 
-            let line = self.get_line(pos);
-            let line_upper = uppercase(line);
-            if line_upper < needle || (upper_bound && line_upper == needle) {
-                first = pos + 1;
-                count -= step + 1;
-            } else {
-                count = step;
+            let line = self.get_line(pos).iter().copied().map(char::from);
+            match (upper_bound, case_insensitive_cmp(line, needle.clone())) {
+                (_, Ordering::Less) | (true, Ordering::Equal) => {
+                    first = pos + 1;
+                    count -= step + 1;
+                }
+                _ => {
+                    count = step;
+                }
             }
         }
 

--- a/tools/src/utils/mod.rs
+++ b/tools/src/utils/mod.rs
@@ -8,17 +8,18 @@ pub use owned_or_borrowed::OwnedOrBorrowed;
 /// ```
 /// # use tools::utils::case_insensitive_cmp;
 /// # use core::cmp::Ordering::*;
-/// assert_eq!(case_insensitive_cmp("ABCD", "ABC"), Greater);
-/// assert_eq!(case_insensitive_cmp("ABC", "ABCD"), Less);
-/// assert_eq!(case_insensitive_cmp("ABC", "ABC"), Equal);
-/// assert_eq!(case_insensitive_cmp("ABC", "abc"), Equal);
+/// assert_eq!(case_insensitive_cmp("ABCD".chars(), "ABC".chars()), Greater);
+/// assert_eq!(case_insensitive_cmp("ABC".chars(), "ABCD".chars()), Less);
+/// assert_eq!(case_insensitive_cmp("ABC".chars(), "ABC".chars()), Equal);
+/// assert_eq!(case_insensitive_cmp("ABC".chars(), "abc".chars()), Equal);
 /// ```
-pub fn case_insensitive_cmp(lhs: impl AsRef<str>, rhs: impl AsRef<str>) -> core::cmp::Ordering {
-    let lhs = lhs.as_ref();
-    let rhs = rhs.as_ref();
-
-    let lhs_uppercase = lhs.chars().flat_map(char::to_uppercase);
-    let rhs_uppercase = rhs.chars().flat_map(char::to_uppercase);
+pub fn case_insensitive_cmp<Lhs, Rhs>(lhs: Lhs, rhs: Rhs) -> core::cmp::Ordering
+where
+    Lhs: Iterator<Item = char>,
+    Rhs: Iterator<Item = char>,
+{
+    let lhs_uppercase = lhs.flat_map(char::to_uppercase);
+    let rhs_uppercase = rhs.flat_map(char::to_uppercase);
     lhs_uppercase.cmp(rhs_uppercase)
 }
 
@@ -31,14 +32,15 @@ pub fn case_insensitive_cmp(lhs: impl AsRef<str>, rhs: impl AsRef<str>) -> core:
 /// ```
 /// # use tools::utils::case_semisensitive_cmp;
 /// # use core::cmp::Ordering::*;
-/// assert_eq!(case_semisensitive_cmp("ABCD", "ABC"), Greater);
-/// assert_eq!(case_semisensitive_cmp("ABC", "ABCD"), Less);
-/// assert_eq!(case_semisensitive_cmp("ABC", "ABC"), Equal);
-/// assert_eq!(case_semisensitive_cmp("ABC", "abc"), Less);
+/// assert_eq!(case_semisensitive_cmp("ABCD".chars(), "ABC".chars()), Greater);
+/// assert_eq!(case_semisensitive_cmp("ABC".chars(), "ABCD".chars()), Less);
+/// assert_eq!(case_semisensitive_cmp("ABC".chars(), "ABC".chars()), Equal);
+/// assert_eq!(case_semisensitive_cmp("ABC".chars(), "abc".chars()), Less);
 /// ```
-pub fn case_semisensitive_cmp(lhs: impl AsRef<str>, rhs: impl AsRef<str>) -> core::cmp::Ordering {
-    let lhs = lhs.as_ref();
-    let rhs = rhs.as_ref();
-
-    case_insensitive_cmp(lhs, rhs).then_with(|| lhs.cmp(rhs))
+pub fn case_semisensitive_cmp<Lhs, Rhs>(lhs: Lhs, rhs: Rhs) -> core::cmp::Ordering
+where
+    Lhs: Iterator<Item = char> + Clone,
+    Rhs: Iterator<Item = char> + Clone,
+{
+    case_insensitive_cmp(lhs.clone(), rhs.clone()).then_with(move || lhs.cmp(rhs))
 }


### PR DESCRIPTION
This avoids creating Strings for the needle and for each line and instead compares the strings case-insensitively using iterators.