### PR TITLE
Bug 2048040 - sync before creating AMI image/snapshot

### DIFF
--- a/infrastructure/aws/trigger-provision.py
+++ b/infrastructure/aws/trigger-provision.py
@@ -93,6 +93,14 @@ fi
 
 echo "Provisioning complete.  Attempting Registration." >> ~ubuntu/provision.log
 
+# Log what the sync is going to do for us for general info.
+grep -E "Dirty|Writeback" /proc/meminfo >> ~ubuntu/provision.log
+
+sync
+
+# hopefully not needed on top of the sync, but since we've had problems, why risk it.
+sleep 5
+
 # AWS commands, etc. should work now if provisioning completed.
 INSTANCE_ID=$(ec2metadata --instance-id)
 # include the hour and minute for sufficient uniqueness


### PR DESCRIPTION
Force all dirty/writeback pages to be synchronously flushed to disk before we create our AMI snapshot to avoid having a corrupt AMI state.

These changes were used to provision yesterday and confirmed that we had a significant amount of dirty data that had not yet been flushed to EBS, explaining why we had 0-length files and truncated logs, etc.

These changes reflect the current provisioned state (and log output).

It could be reasonable to add a little more logging like "date" output to help make it clear how long it's taking for us to flush the backlog of dirty data, although it's not essential.