### PR TITLE
Have docker bind IPv4 to avoid localhost failures

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -35,6 +35,12 @@ THIS_DIR=$(pwd)
 # For consistency we mount the source dir at /vagrant still
 INSIDE_CONTAINER_DIR=/vagrant
 
+# Force only passing through on IPv4 since nginx currently only binds as IPv4.
+# This was necessary for me when using podman rootless and trying to connect to
+# http://localhost:16995/ from the browser because "pasta" otherwise does a tcp6
+# bind and at least on my ubuntu machine nightly firefox as packaged by mozilla
+# and curl both try IPv6.
+MAYBE_BIND_IPV4=127.0.0.1:
 # connect to this port on your computer
 OUTSIDE_CONTAINER_PORT=16995
 # which is served at this port inside the container
@@ -98,7 +104,7 @@ else
         --mount type=bind,source=${THIS_DIR},target=${INSIDE_CONTAINER_DIR} \
         "${LINKMOUNTS[@]}" \
         "${VOLMOUNTS[@]}" \
-        -p ${OUTSIDE_CONTAINER_PORT}:${INSIDE_CONTAINER_PORT} \
+        -p ${MAYBE_BIND_IPV4}${OUTSIDE_CONTAINER_PORT}:${INSIDE_CONTAINER_PORT} \
         ${IMAGE_NAME} \
         ${SHELL}
 fi


### PR DESCRIPTION
Without this, on my Ubuntu machine using podman symlinked as docker, browsing to http://localhost:16995/ with Firefox would return an error because it would apparently try and use the IPv6 loopback.  The same thing would happen with curl (but not if explicitly specifying 127.0.0.1).

Note that especially under podman, the container will tend to exist, so we usually end up just using the existing container and so this may not meaningfully take effect without a fresh build-docker.sh or explicitly removing the existing container.