### PR TITLE
Bug 2046479 - Add firefox-esr153 to the tree list.

### DIFF
--- a/tests/tree-list.js
+++ b/tests/tree-list.js
@@ -13,6 +13,7 @@ var TREE_LIST = [
         { value: "firefox-main" },
         { value: "firefox-beta" },
         { value: "firefox-release" },
+        { value: "firefox-esr153" },
         { value: "firefox-esr140" },
         { value: "firefox-esr128" },
         { value: "firefox-esr115" },


### PR DESCRIPTION
for [bug 2046479](https://bugzilla.mozilla.org/show_bug.cgi?id=2046479)

This does:
  * Add firefox-esr153 to the tree list

depends on https://github.com/mozsearch/mozsearch-mozilla/pull/322