### PR TITLE
Align clang-plugin minimal versions with ESR115.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ addons
 !/tree-configs/README.md
 .direnv
 .envrc
+/result*
 mozsearch-firefox*
 /tests/tests/checks/target
 /tests/tests/files/target

--- a/clang-plugin/BindingOperations.cpp
+++ b/clang-plugin/BindingOperations.cpp
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/BindingOperations.cpp
+++ b/clang-plugin/BindingOperations.cpp
@@ -12,18 +12,11 @@
 #include <algorithm>
 #include <array>
 #include <cuchar>
+#include <optional>
 #include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
-
-#ifdef __cpp_lib_optional
-#include <optional>
-template <typename T> using optional = std::optional<T>;
-#else
-#include <llvm/ADT/Optional.h>
-template <typename T> using optional = clang::Optional<T>;
-#endif
 
 using namespace clang;
 
@@ -79,7 +72,7 @@ const NamedDecl *fieldNamed(StringRef name, const RecordDecl &strukt) {
   return {};
 }
 
-optional<StringRef> nameFieldValue(const RecordDecl &strukt) {
+std::optional<StringRef> nameFieldValue(const RecordDecl &strukt) {
   const auto *nameField = dyn_cast_or_null<VarDecl>(fieldNamed("name", strukt));
   if (!nameField)
     return {};
@@ -107,7 +100,7 @@ struct AbstractBinding {
       "jvm",
   };
 
-  static optional<Lang> langFromString(StringRef langName) {
+  static std::optional<Lang> langFromString(StringRef langName) {
     const auto it = std::find(langNames.begin(), langNames.end(), langName);
     if (it == langNames.end())
       return {};
@@ -129,7 +122,7 @@ struct AbstractBinding {
       "class", "method", "getter", "setter", "const",
   };
 
-  static optional<Kind> kindFromString(StringRef kindName) {
+  static std::optional<Kind> kindFromString(StringRef kindName) {
     const auto it = std::find(kindNames.begin(), kindNames.end(), kindName);
     if (it == kindNames.end())
       return {};
@@ -180,7 +173,7 @@ void setBindingAttr(ASTContext &C, Decl &decl, B binding) {
   decl.addAttr(attr);
 }
 
-optional<AbstractBinding> readBinding(const AnnotateAttr &attr) {
+std::optional<AbstractBinding> readBinding(const AnnotateAttr &attr) {
   if (attr.args_size() != 3)
     return {};
 
@@ -212,7 +205,7 @@ optional<AbstractBinding> readBinding(const AnnotateAttr &attr) {
   };
 }
 
-optional<BindingTo> getBindingTo(const Decl &decl) {
+std::optional<BindingTo> getBindingTo(const Decl &decl) {
   for (const auto *attr : decl.specific_attrs<AnnotateAttr>()) {
     if (attr->getAnnotation() != BindingTo::ANNOTATION)
       continue;
@@ -253,18 +246,18 @@ public:
     StringRef name;
   };
 
-  static optional<Result> search(Stmt *statement) {
+  static std::optional<Result> search(Stmt *statement) {
     FindCallCall finder;
     finder.TraverseStmt(statement);
     return finder.result;
   }
 
 private:
-  optional<Result> result;
+  std::optional<Result> result;
 
   friend RecursiveASTVisitor<FindCallCall>;
 
-  optional<Result> tryParseCallCall(CallExpr *callExpr) {
+  std::optional<Result> tryParseCallCall(CallExpr *callExpr) {
     const auto *callee =
         dyn_cast_or_null<CXXMethodDecl>(callExpr->getDirectCallee());
     if (!callee)
@@ -402,7 +395,7 @@ void addBindingSlotsAttribute(llvm::json::OStream &J, const Decl &decl) {
 //  second the demangled overload specification
 // But we don't use the later for now because we have no way to map that to how
 // SCIP resolves overloads.
-optional<std::string> demangleJnicallPart(StringRef &remainder) {
+std::optional<std::string> demangleJnicallPart(StringRef &remainder) {
   std::string demangled;
 
   std::mbstate_t ps = {};
@@ -476,7 +469,7 @@ optional<std::string> demangleJnicallPart(StringRef &remainder) {
   return demangled;
 }
 
-optional<std::string>
+std::optional<std::string>
 scipSymbolFromJnicallFunctionName(StringRef functionName) {
   if (!functionName.consume_front("Java_"))
     return {};

--- a/clang-plugin/BindingOperations.h
+++ b/clang-plugin/BindingOperations.h
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/BindingOperations.h
+++ b/clang-plugin/BindingOperations.h
@@ -3,6 +3,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
+#ifndef BUILD_CLANG_PLUGIN_MOZSEARCH_PLUGIN_BINDINGOPERATIONS_H_
+#define BUILD_CLANG_PLUGIN_MOZSEARCH_PLUGIN_BINDINGOPERATIONS_H_
+
 #include <clang/AST/ASTContext.h>
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclCXX.h>
@@ -17,3 +20,5 @@ void findBindingToJavaMember(clang::ASTContext &C,
 void findBindingToJavaConstant(clang::ASTContext &C, clang::VarDecl &field);
 
 void emitBindingAttributes(llvm::json::OStream &json, const clang::Decl &decl);
+
+#endif  // BUILD_CLANG_PLUGIN_MOZSEARCH_PLUGIN_BINDINGOPERATIONS_H_

--- a/clang-plugin/FileOperations.cpp
+++ b/clang-plugin/FileOperations.cpp
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/FileOperations.h
+++ b/clang-plugin/FileOperations.h
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -7,14 +7,19 @@ CXXFLAGS := $(shell ${LLVM_CONFIG} --cxxflags) -fPIC -Wall -Wno-strict-aliasing 
 LDFLAGS := -fPIC -g -Wl,-R -Wl,'$$ORIGIN' $(LLVM_LDFLAGS) -shared
 MOZSEARCH_CLANG_PLUGIN_DIR ?= .
 MOZSEARCH_CLANG_PLUGIN_OBJDIR ?= .
+CLANG_VERSION := $(shell ${LLVM_CONFIG} --version | cut -d'.' -f 1)
+# "true" if CLANG_VERSION < 20 else "false"
+USE_VENDORED_HEURISTIC_RESOLVER := $(shell if [ ${CLANG_VERSION} -lt 20 ]; then echo true; else echo false; fi)
 
 build: dirs $(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so
 
 dirs:
-	mkdir -p from-clangd
 	mkdir -p $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)
-	mkdir -p $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd
 	mkdir -p $(MOZSEARCH_CLANG_PLUGIN_DIR)
+ifeq ($(USE_VENDORED_HEURISTIC_RESOLVER),true)
+	mkdir -p from-clangd
+	mkdir -p $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd
+endif
 
 build_with_version_check: clang-version-guard build
 
@@ -39,10 +44,12 @@ clang-version-guard:
 $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/%.o: %.cpp
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
 
+ifeq ($(USE_VENDORED_HEURISTIC_RESOLVER),true)
 $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/%.o: from-clangd/%.cpp
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
+endif
 
-$(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so: $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/FileOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/StringOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/BindingOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/MozsearchIndexer.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/HeuristicResolver.o
+$(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so: $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/FileOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/StringOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/BindingOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/MozsearchIndexer.o $(if $(findstring $(USE_VENDORED_HEURISTIC_RESOLVER),true), $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/HeuristicResolver.o)
 	$(CXX) $(LDFLAGS) $^ -o $@ -lclangASTMatchers
 
 check: build
@@ -51,7 +58,10 @@ check: build
 
 clean: dirs
 clean:
-	$(RM) $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/*.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/*.o *.dwo $(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so
+	$(RM) $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/*.o *.dwo $(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so
+ifeq ($(USE_VENDORED_HEURISTIC_RESOLVER),true)
+	$(RM) $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/*.o
+endif
 
 dump: build
 	-clang++ -c -Xclang -ast-dump testfiles/test.cpp

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -2,7 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-#include "clang/AST/AST.h"
 #include "clang/AST/ASTConsumer.h"
 #include "clang/AST/ASTContext.h"
 #include "clang/AST/Expr.h"
@@ -10,7 +9,6 @@
 #include "clang/AST/Mangle.h"
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/RecursiveASTVisitor.h"
-#include "clang/Basic/FileManager.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Version.h"
 #include "clang/Format/Format.h"
@@ -20,7 +18,6 @@
 #include "clang/Lex/PPCallbacks.h"
 #include "clang/Lex/Preprocessor.h"
 #include "clang/Lex/TokenConcatenation.h"
-#include "llvm/ADT/SmallString.h"
 #include "llvm/Support/JSON.h"
 #include "llvm/Support/raw_ostream.h"
 
@@ -29,7 +26,6 @@
 #include <iostream>
 #include <map>
 #include <memory>
-#include <sstream>
 #include <stack>
 #include <string>
 #include <unordered_set>

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -43,19 +43,6 @@
 #define getBeginLoc getLocStart
 #define getEndLoc getLocEnd
 #endif
-// We want std::make_unique, but that's only available in c++14.  In versions
-// prior to that, we need to fall back to llvm's make_unique.  It's also the
-// case that we expect clang 10 to build with c++14 and clang 9 and earlier to
-// build with c++11, at least as suggested by the llvm-config --cxxflags on
-// non-windows platforms.  firefox-main seems to build with -std=c++17 on
-// windows so we need to make this decision based on __cplusplus instead of
-// the CLANG_VERSION_MAJOR.
-#if __cplusplus < 201402L
-using llvm::make_unique;
-#else
-using std::make_unique;
-#endif
-
 using namespace clang;
 
 const std::string GENERATED("__GENERATED__" PATHSEP_STRING);
@@ -345,7 +332,7 @@ private:
           Absolute = Filename;
         }
       }
-      std::unique_ptr<FileInfo> Info = make_unique<FileInfo>(Absolute, CI.getHeaderSearchOpts());
+      std::unique_ptr<FileInfo> Info = std::make_unique<FileInfo>(Absolute, CI.getHeaderSearchOpts());
       It = FileMap.insert(std::make_pair(Id, std::move(Info))).first;
     }
     return It->second.get();
@@ -788,7 +775,7 @@ public:
         CurMangleContext(nullptr), AstContext(nullptr),
         ConcatInfo(CI.getPreprocessor()), CurDeclContext(nullptr),
         TemplateStack(nullptr) {
-    CI.getPreprocessor().addPPCallbacks(make_unique<PreprocessorHook>(this));
+    CI.getPreprocessor().addPPCallbacks(std::make_unique<PreprocessorHook>(this));
     CI.getPreprocessor().setTokenWatcher(
         [this](const auto &token) { onTokenLexed(token); });
   }
@@ -3337,7 +3324,7 @@ class IndexAction : public PluginASTAction {
 protected:
   std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
                                                  llvm::StringRef F) {
-    return make_unique<IndexConsumer>(CI);
+    return std::make_unique<IndexConsumer>(CI);
   }
 
   bool ParseArgs(const CompilerInstance &CI,

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -38,11 +38,6 @@
 #include "StringOperations.h"
 #include "from-clangd/HeuristicResolver.h"
 
-#if CLANG_VERSION_MAJOR < 8
-// Starting with Clang 8.0 some basic functions have been renamed
-#define getBeginLoc getLocStart
-#define getEndLoc getLocEnd
-#endif
 using namespace clang;
 
 const std::string GENERATED("__GENERATED__" PATHSEP_STRING);
@@ -240,13 +235,7 @@ public:
   virtual void InclusionDirective(SourceLocation HashLoc,
                                   const Token &IncludeTok, StringRef FileName,
                                   bool IsAngled, CharSourceRange FileNameRange,
-#if CLANG_VERSION_MAJOR >= 16
                                   OptionalFileEntryRef File,
-#elif CLANG_VERSION_MAJOR >= 15
-                                  Optional<FileEntryRef> File,
-#else
-                                  const FileEntry *File,
-#endif
                                   StringRef SearchPath, StringRef RelativePath,
 #if CLANG_VERSION_MAJOR >= 19
                                   const Module *SuggestedModule,
@@ -688,7 +677,6 @@ private:
           isa<TagDecl>(DC)) {
         llvm::SmallVector<char, 512> Output;
         llvm::raw_svector_ostream Out(Output);
-#if CLANG_VERSION_MAJOR >= 11
         // This code changed upstream in version 11:
         // https://github.com/llvm/llvm-project/commit/29e1a16be8216066d1ed733a763a749aed13ff47
         GlobalDecl GD;
@@ -701,16 +689,6 @@ private:
           GD = GlobalDecl(Decl);
         }
         Ctx->mangleName(GD, Out);
-#else
-        if (const CXXConstructorDecl *D = dyn_cast<CXXConstructorDecl>(Decl)) {
-          Ctx->mangleCXXCtor(D, CXXCtorType::Ctor_Complete, Out);
-        } else if (const CXXDestructorDecl *D =
-                       dyn_cast<CXXDestructorDecl>(Decl)) {
-          Ctx->mangleCXXDtor(D, CXXDtorType::Dtor_Complete, Out);
-        } else {
-          Ctx->mangleName(Decl, Out);
-        }
-#endif
         return Out.str().str();
       } else {
         return std::string("V_") + mangleLocation(Decl->getLocation()) +
@@ -3264,13 +3242,7 @@ void PreprocessorHook::FileChanged(SourceLocation Loc, FileChangeReason Reason,
 void PreprocessorHook::InclusionDirective(
     SourceLocation HashLoc, const Token &IncludeTok, StringRef FileName,
     bool IsAngled, CharSourceRange FileNameRange,
-#if CLANG_VERSION_MAJOR >= 16
     OptionalFileEntryRef File,
-#elif CLANG_VERSION_MAJOR >= 15
-    Optional<FileEntryRef> File,
-#else
-    const FileEntry *File,
-#endif
     StringRef SearchPath, StringRef RelativePath,
 #if CLANG_VERSION_MAJOR >= 19
     const Module *SuggestedModule, bool ModuleImported,
@@ -3278,15 +3250,11 @@ void PreprocessorHook::InclusionDirective(
     const Module *Imported,
 #endif
     SrcMgr::CharacteristicKind FileType) {
-#if CLANG_VERSION_MAJOR >= 15
   if (!File) {
     return;
   }
   Indexer->inclusionDirective(HashLoc, FileNameRange.getAsRange(),
                               &File->getFileEntry());
-#else
-  Indexer->inclusionDirective(HashLoc, FileNameRange.getAsRange(), File);
-#endif
 }
 
 void PreprocessorHook::MacroDefined(const Token &Tok,

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -36,9 +36,15 @@
 #include "BindingOperations.h"
 #include "FileOperations.h"
 #include "StringOperations.h"
-#include "from-clangd/HeuristicResolver.h"
 
 using namespace clang;
+
+#if CLANG_VERSION_MAJOR >= 20
+#include "clang/Sema/HeuristicResolver.h"
+#else
+#include "from-clangd/HeuristicResolver.h"
+using HeuristicResolver = clangd::HeuristicResolver;
+#endif
 
 const std::string GENERATED("__GENERATED__" PATHSEP_STRING);
 
@@ -270,7 +276,7 @@ private:
   std::map<FileID, std::unique_ptr<FileInfo>> FileMap;
   MangleContext *CurMangleContext;
   ASTContext *AstContext;
-  std::unique_ptr<clangd::HeuristicResolver> Resolver;
+  std::unique_ptr<HeuristicResolver> Resolver;
 
   // Used during a macro expansion to build the expanded string
   TokenConcatenation ConcatInfo;
@@ -785,7 +791,7 @@ public:
         clang::ItaniumMangleContext::create(Ctx, CI.getDiagnostics());
 
     AstContext = &Ctx;
-    Resolver = std::make_unique<clangd::HeuristicResolver>(Ctx);
+    Resolver = std::make_unique<HeuristicResolver>(Ctx);
     TraverseDecl(Ctx.getTranslationUnitDecl());
 
     // Emit the JSON data for all files now.

--- a/clang-plugin/StringOperations.cpp
+++ b/clang-plugin/StringOperations.cpp
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/StringOperations.h
+++ b/clang-plugin/StringOperations.h
@@ -1,4 +1,3 @@
-/* -*- Mode: C++; tab-width: 2; indent-tabs-mode: nil; c-basic-offset: 2 -*- */
 /* This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */

--- a/clang-plugin/StringOperations.h
+++ b/clang-plugin/StringOperations.h
@@ -7,7 +7,6 @@
 #define StringOperations_h
 
 #include <memory>
-#include <string.h>
 #include <string>
 
 std::string hash(const std::string &Str);

--- a/clang-plugin/from-clangd/README.md
+++ b/clang-plugin/from-clangd/README.md
@@ -5,6 +5,5 @@ The files here are currently copies of the following upstream files:
 https://github.com/llvm/llvm-project/blob/2bcbcbefcd0f7432f99cc07bb47d1e1ecb579a3f/clang-tools-extra/clangd/HeuristicResolver.h
 https://github.com/llvm/llvm-project/blob/2bcbcbefcd0f7432f99cc07bb47d1e1ecb579a3f/clang-tools-extra/clangd/HeuristicResolver.cpp
 
-If, in the future, these facilities are moved from clangd to
-to libclangTooling and exposed in the clang API headers, we can
-switch to consuming them from there directly.
+Starting with Clang 20, these facilities are exposed in the clang API
+headers. We can drop them when we stop supporting Clang < 20.


### PR DESCRIPTION
This drops support for C++ < 17 (requiring std::make_unique and std::optional), and Clang < 16 which are the versions we use for building ESR 115.
It also stops using our vendored HeuristicResolver with Clang 20+.