### PR TITLE
clang-plugin: remove unused iostream include

### DIFF
--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -23,7 +23,6 @@
 
 #include <algorithm>
 #include <fstream>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <stack>


### PR DESCRIPTION
Missed one, and only noticed it in the diff viewer at https://phabricator.services.mozilla.com/D309872?id=1313179.

This brings in the change from bug 2033982.