### PR TITLE
Update SCIP Rust crate to upstream 0.9.0 release (and remove unused dependencies)

### DIFF
--- a/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
+++ b/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
@@ -131,28 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,17 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,12 +969,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fst"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures"
@@ -1958,15 +1919,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2156,12 +2108,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json-structural-diff"
@@ -3313,42 +3259,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rls-analysis"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85293f293444a5f569dd394024b2af9e91fc6b71d336f35c02bc936a29a5fe7e"
-dependencies = [
- "derive-new",
- "fst",
- "itertools 0.10.5",
- "json",
- "log",
- "rls-data",
- "rls-span",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rls-data"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58135eb039f3a3279a33779192f0ee78b56f57ae636e25cec83530e41debb99"
-dependencies = [
- "rls-span",
- "serde",
-]
-
-[[package]]
-name = "rls-span"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e80f614ad4b37910bfe9b029af19c6f92612bb8e1af66e37d35829bf4ef6d1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4276,12 +4186,10 @@ name = "tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream",
  "async-trait",
  "axum",
  "axum-macros",
  "bitflags",
- "bytes",
  "chrono",
  "clap",
  "cssparser 0.37.0",
@@ -4323,8 +4231,6 @@ dependencies = [
  "query-parser",
  "regex 1.12.4",
  "reqwest",
- "rls-analysis",
- "rls-data",
  "scip",
  "serde",
  "serde_json",

--- a/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
+++ b/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
@@ -3418,8 +3418,9 @@ dependencies = [
 
 [[package]]
 name = "scip"
-version = "0.6.1"
-source = "git+https://github.com/mozsearch/scip?rev=9ffd696ad0d32e594f48ccf937138d0c9fa77004#9ffd696ad0d32e594f48ccf937138d0c9fa77004"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a72133c2d6fd45c9a3a343bcb3db2faa30f68f0919bfa3370ca85add5460c3"
 dependencies = [
  "protobuf",
 ]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3416,8 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "scip"
-version = "0.6.1"
-source = "git+https://github.com/mozsearch/scip?rev=9ffd696ad0d32e594f48ccf937138d0c9fa77004#9ffd696ad0d32e594f48ccf937138d0c9fa77004"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26a72133c2d6fd45c9a3a343bcb3db2faa30f68f0919bfa3370ca85add5460c3"
 dependencies = [
  "protobuf",
 ]

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -131,28 +131,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,17 +675,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,12 +969,6 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "fst"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab85b9b05e3978cc9a9cf8fea7f01b494e1a09ed3037e16ba39edc7a29eb61a"
 
 [[package]]
 name = "futures"
@@ -1956,15 +1917,6 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -2154,12 +2106,6 @@ dependencies = [
  "futures-util",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "json"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "078e285eafdfb6c4b434e0d31e8cfcb5115b651496faca5749b88fafd4f23bfd"
 
 [[package]]
 name = "json-structural-diff"
@@ -3311,42 +3257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rls-analysis"
-version = "0.18.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85293f293444a5f569dd394024b2af9e91fc6b71d336f35c02bc936a29a5fe7e"
-dependencies = [
- "derive-new",
- "fst",
- "itertools 0.10.5",
- "json",
- "log",
- "rls-data",
- "rls-span",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "rls-data"
-version = "0.19.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a58135eb039f3a3279a33779192f0ee78b56f57ae636e25cec83530e41debb99"
-dependencies = [
- "rls-span",
- "serde",
-]
-
-[[package]]
-name = "rls-span"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e80f614ad4b37910bfe9b029af19c6f92612bb8e1af66e37d35829bf4ef6d1"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "rustc-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4274,12 +4184,10 @@ name = "tools"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-stream",
  "async-trait",
  "axum",
  "axum-macros",
  "bitflags",
- "bytes",
  "chrono",
  "clap",
  "cssparser 0.37.0",
@@ -4321,8 +4229,6 @@ dependencies = [
  "query-parser",
  "regex 1.12.4",
  "reqwest",
- "rls-analysis",
- "rls-data",
  "scip",
  "serde",
  "serde_json",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -21,13 +21,10 @@ tower = { version = "0.5.3", features = ["limit"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 anyhow = "1.0.86"
-async-stream = "0.3.2"
 async-trait = "0.1.50"
 axum = "0.8.9"
 axum-macros = "0.5.1"
 bitflags = { version = "2.4.2", features = ["serde"] }
-# NOTE: jaq-json requires newer bytes.
-bytes = "1.11.0"
 chrono = "0.4"
 clap = { version = "4.0", features = ["cargo", "derive", "env"] }
 dot-generator = "0.2.0"
@@ -66,8 +63,6 @@ protobuf = "3.7.2"
 query-parser = "0.2.0"
 regex = "1"
 reqwest = "0.13.2"
-rls-analysis = "0.18.1"
-rls-data = "0.19.1"
 scip = { git = "https://github.com/mozsearch/scip", rev = "9ffd696ad0d32e594f48ccf937138d0c9fa77004" }
 # NOTE: serde_json dependency is also defined above, without "std" feature.
 #       The "std" feature should be enabled only for non-wasm case.

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -63,7 +63,7 @@ protobuf = "3.7.2"
 query-parser = "0.2.0"
 regex = "1"
 reqwest = "0.13.2"
-scip = { git = "https://github.com/mozsearch/scip", rev = "9ffd696ad0d32e594f48ccf937138d0c9fa77004" }
+scip = "0.9.0"
 # NOTE: serde_json dependency is also defined above, without "std" feature.
 #       The "std" feature should be enabled only for non-wasm case.
 serde_json = { version = "1.0.113", features = ["preserve_order", "std"] }


### PR DESCRIPTION
Upstream seems to be active again and merged @arai-a's patch.

This also removes a couple of unused crates from Cargo.toml.