### PR TITLE
Bug 2053134 - Sync Clang plugin with in-tree version

### DIFF
--- a/clang-plugin/BindingOperations.cpp
+++ b/clang-plugin/BindingOperations.cpp
@@ -93,11 +93,13 @@ struct AbstractBinding {
   enum class Lang {
     Cpp,
     Jvm,
+    Idl,
   };
-  static constexpr size_t LangLength = 2;
+  static constexpr size_t LangLength = 3;
   static constexpr std::array<StringRef, LangLength> langNames = {
       "cpp",
       "jvm",
+      "idl",
   };
 
   static std::optional<Lang> langFromString(StringRef langName) {
@@ -608,15 +610,7 @@ void findBindingToJavaMember(ASTContext &C, CXXMethodDecl &method) {
 
 // class [parent]
 // {
-//   struct [methodStruct] {
-//     static constexpr char name[] = "[methodNameFieldValue]";
-//   }
-//   [method]
-//   {
-//     ...
-//     mozilla::jni::{Method,Constructor,Field}<[methodStruct]>::{Call,Get,Set}(...)
-//     ...
-//   }
+//   static constexpr [field] = ...;
 // }
 void findBindingToJavaConstant(ASTContext &C, VarDecl &field) {
   const auto *parent = dyn_cast_or_null<CXXRecordDecl>(field.getDeclContext());
@@ -625,6 +619,9 @@ void findBindingToJavaConstant(ASTContext &C, VarDecl &field) {
 
   const auto classBinding = getBindingTo(*parent);
   if (!classBinding)
+    return;
+
+  if (classBinding->lang != BindingTo::Lang::Jvm)
     return;
 
   const auto symbol = javaScipSymbol(classBinding->symbol, field.getName(),

--- a/clang-plugin/Makefile
+++ b/clang-plugin/Makefile
@@ -49,7 +49,7 @@ $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/%.o: from-clangd/%.cpp
 	$(CXX) $(CXXFLAGS) -c $^ -o $@
 endif
 
-$(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so: $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/FileOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/StringOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/BindingOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/MozsearchIndexer.o $(if $(findstring $(USE_VENDORED_HEURISTIC_RESOLVER),true), $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/HeuristicResolver.o)
+$(MOZSEARCH_CLANG_PLUGIN_DIR)/libclang-index-plugin.so: $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/Registration.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/FileOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/StringOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/BindingOperations.o $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/MozsearchIndexer.o $(if $(findstring $(USE_VENDORED_HEURISTIC_RESOLVER),true), $(MOZSEARCH_CLANG_PLUGIN_OBJDIR)/from-clangd/HeuristicResolver.o)
 	$(CXX) $(LDFLAGS) $^ -o $@ -lclangASTMatchers
 
 check: build

--- a/clang-plugin/MozsearchAction.h
+++ b/clang-plugin/MozsearchAction.h
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+#ifndef MozsearchAction_h_
+#define MozsearchAction_h_
+
+#include "clang/AST/AST.h"
+#include "clang/AST/ASTConsumer.h"
+
+class MozsearchAction : public clang::PluginASTAction {
+public:
+  std::unique_ptr<clang::ASTConsumer> CreateASTConsumer(clang::CompilerInstance &CI,
+                                                 clang::StringRef F) override;
+
+  bool ParseArgs(const clang::CompilerInstance &CI,
+                 const std::vector<std::string> &Args) override;
+
+  ActionType getActionType() override;
+};
+
+#endif /* MozsearchAction_h_ */

--- a/clang-plugin/MozsearchIndexer.cpp
+++ b/clang-plugin/MozsearchIndexer.cpp
@@ -35,6 +35,7 @@
 #include "BindingOperations.h"
 #include "FileOperations.h"
 #include "StringOperations.h"
+#include "MozsearchAction.h"
 
 using namespace clang;
 
@@ -3293,58 +3294,50 @@ void PreprocessorHook::Ifndef(SourceLocation Loc, const Token &Tok,
   Indexer->macroUsed(Tok, Md.getMacroInfo());
 }
 
-class IndexAction : public PluginASTAction {
-protected:
-  std::unique_ptr<ASTConsumer> CreateASTConsumer(CompilerInstance &CI,
-                                                 llvm::StringRef F) {
-    return std::make_unique<IndexConsumer>(CI);
+std::unique_ptr<ASTConsumer> MozsearchAction::CreateASTConsumer(CompilerInstance &CI,
+                                                llvm::StringRef F) {
+  return std::make_unique<IndexConsumer>(CI);
+}
+
+bool MozsearchAction::ParseArgs(const CompilerInstance &CI,
+                const std::vector<std::string> &Args) {
+  if (Args.size() != 3) {
+    DiagnosticsEngine &D = CI.getDiagnostics();
+    unsigned DiagID = D.getCustomDiagID(
+        DiagnosticsEngine::Error,
+        "Need arguments for the source, output, and object directories");
+    D.Report(DiagID);
+    return false;
   }
 
-  bool ParseArgs(const CompilerInstance &CI,
-                 const std::vector<std::string> &Args) {
-    if (Args.size() != 3) {
-      DiagnosticsEngine &D = CI.getDiagnostics();
-      unsigned DiagID = D.getCustomDiagID(
-          DiagnosticsEngine::Error,
-          "Need arguments for the source, output, and object directories");
-      D.Report(DiagID);
-      return false;
-    }
-
-    // Load our directories
-    Srcdir = getAbsolutePath(Args[0]);
-    if (Srcdir.empty()) {
-      DiagnosticsEngine &D = CI.getDiagnostics();
-      unsigned DiagID = D.getCustomDiagID(
-          DiagnosticsEngine::Error, "Source directory '%0' does not exist");
-      D.Report(DiagID) << Args[0];
-      return false;
-    }
-
-    ensurePath(Args[1] + PATHSEP_STRING);
-    Outdir = getAbsolutePath(Args[1]);
-    Outdir += PATHSEP_STRING;
-
-    Objdir = getAbsolutePath(Args[2]);
-    if (Objdir.empty()) {
-      DiagnosticsEngine &D = CI.getDiagnostics();
-      unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
-                                          "Objdir '%0' does not exist");
-      D.Report(DiagID) << Args[2];
-      return false;
-    }
-    Objdir += PATHSEP_STRING;
-
-    printf("MOZSEARCH: %s %s %s\n", Srcdir.c_str(), Outdir.c_str(),
-           Objdir.c_str());
-
-    return true;
+  // Load our directories
+  Srcdir = getAbsolutePath(Args[0]);
+  if (Srcdir.empty()) {
+    DiagnosticsEngine &D = CI.getDiagnostics();
+    unsigned DiagID = D.getCustomDiagID(
+        DiagnosticsEngine::Error, "Source directory '%0' does not exist");
+    D.Report(DiagID) << Args[0];
+    return false;
   }
 
-  void printHelp(llvm::raw_ostream &Ros) {
-    Ros << "Help for mozsearch plugin goes here\n";
-  }
-};
+  ensurePath(Args[1] + PATHSEP_STRING);
+  Outdir = getAbsolutePath(Args[1]);
+  Outdir += PATHSEP_STRING;
 
-static FrontendPluginRegistry::Add<IndexAction>
-    Y("mozsearch-index", "create the mozsearch index database");
+  Objdir = getAbsolutePath(Args[2]);
+  if (Objdir.empty()) {
+    DiagnosticsEngine &D = CI.getDiagnostics();
+    unsigned DiagID = D.getCustomDiagID(DiagnosticsEngine::Error,
+                                        "Objdir '%0' does not exist");
+    D.Report(DiagID) << Args[2];
+    return false;
+  }
+  Objdir += PATHSEP_STRING;
+
+  printf("MOZSEARCH: %s %s %s\n", Srcdir.c_str(), Outdir.c_str(),
+          Objdir.c_str());
+
+  return true;
+}
+
+PluginASTAction::ActionType MozsearchAction::getActionType() { return CmdlineBeforeMainAction; }

--- a/clang-plugin/Registration.cpp
+++ b/clang-plugin/Registration.cpp
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+// DO NOT copy this file over to the Firefox-vendored version of the plugin, it has its own Registration.cpp.
+
+#include "clang/Frontend/FrontendPluginRegistry.h"
+
+#include "MozsearchAction.h"
+
+using namespace clang;
+
+static FrontendPluginRegistry::Add<MozsearchAction>
+    X("mozsearch-index", "create the mozsearch index database");


### PR DESCRIPTION
This is the counterpart of:
- https://phabricator.services.mozilla.com/D310855 for the new enum variant
- https://phabricator.services.mozilla.com/D310854 for the action registration

I'll wait on the second one being reviewed before merging this.