### PR TITLE
Bug 2053875 -  Parse binding information from SCIP symbol documentation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780331254,
-        "narHash": "sha256-ZgicGl13cOdZSxb9dLZl1k9XB44oKd5jo6Mjv64lMw4=",
+        "lastModified": 1783513756,
+        "narHash": "sha256-VGKWOC5zI50gOLoJKJSw7Yexpg8S2uq+cZdb2KUe8tc=",
         "owner": "mozsearch",
         "repo": "scip-typescript",
-        "rev": "5fec9871c381ae75f0efdd75221c8071df08c0e8",
+        "rev": "9137ccfccce3cc98891fc4fe1c6a22a357f3488e",
         "type": "github"
       },
       "original": {

--- a/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
+++ b/scripts/web-analyze/wasm-css-analyzer/Cargo.lock
@@ -3768,6 +3768,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4237,6 +4258,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "shell-words",
+ "strum",
  "termcolor",
  "thread_local 1.1.9",
  "tokio",

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/attribute__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/attribute__json
@@ -1,0 +1,1 @@
+search-identifiers tsAttribute | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/class__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/class__json
@@ -1,0 +1,1 @@
+search-identifiers tsClass | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/const_inbound__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/const_inbound__json
@@ -1,0 +1,1 @@
+search-identifiers tsConstInbound | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/count_outbound__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/count_outbound__json
@@ -1,0 +1,1 @@
+search-identifiers tsConstOutbound | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/enum__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/enum__json
@@ -1,0 +1,1 @@
+search-identifiers tsEnum | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/getter__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/getter__json
@@ -1,0 +1,1 @@
+search-identifiers tsGetter | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/method__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/method__json
@@ -1,0 +1,1 @@
+search-identifiers tsMethod | crossref-lookup

--- a/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/setter__json
+++ b/tests/tests/checks/inputs/crossref/typescript/bindings.d.ts/setter__json
@@ -1,0 +1,1 @@
+search-identifiers tsSetter | crossref-lookup

--- a/tests/tests/checks/snapshots/analysis/ts/property-assignments/object-assign/main@method.snap
+++ b/tests/tests/checks/snapshots/analysis/ts/property-assignments/object-assign/main@method.snap
@@ -10,14 +10,15 @@ input_file: inputs/analysis/ts/property-assignments/object-assign/method
     "syntax": "def,method",
     "pretty": "method objectAssign::method",
     "sym": "S_js_ts/src/property-assignments/object-assign.js/objectAssign.method().",
-    "nestingRange": "8:11-10:3"
+    "nestingRange": "8:11-10:3",
+    "type": "(method) method\"method\""
   },
   {
     "loc": "00008:2-8",
     "structured": 1,
     "pretty": "objectAssign::method",
     "sym": "S_js_ts/src/property-assignments/object-assign.js/objectAssign.method().",
-    "type_pretty": null,
+    "type_pretty": "(method) method\"method\"",
     "kind": "method",
     "subsystem": null,
     "implKind": "impl",
@@ -45,7 +46,8 @@ input_file: inputs/analysis/ts/property-assignments/object-assign/method
     "source": 1,
     "syntax": "use,method",
     "pretty": "method objectAssign::method",
-    "sym": "S_js_ts/src/property-assignments/object-assign.js/objectAssign.method()."
+    "sym": "S_js_ts/src/property-assignments/object-assign.js/objectAssign.method().",
+    "type": "(method) method\"method\""
   },
   {
     "loc": "00021:13-19",

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@attribute__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@attribute__json.snap
@@ -1,0 +1,67 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/attribute__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/tsClass#tsAttribute.",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 4,
+                "bounds": [
+                  0,
+                  11
+                ],
+                "line": "tsAttribute: string;",
+                "context": "tsClass",
+                "contextsym": "S_js_ts/src/bindings.d.ts/tsClass#"
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "tsClass::tsAttribute",
+          "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsAttribute.",
+          "type_pretty": "string",
+          "kind": "field",
+          "subsystem": null,
+          "parentsym": "S_js_ts/src/bindings.d.ts/tsClass#",
+          "slotOwner": {
+            "slotKind": "attribute",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "idl",
+            "sym": "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+        ]
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@class__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@class__json.snap
@@ -1,0 +1,90 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/class__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/tsClass#",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 2,
+                "bounds": [
+                  14,
+                  21
+                ],
+                "line": "declare class tsClass  {",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "tsClass",
+          "sym": "S_js_ts/src/bindings.d.ts/tsClass#",
+          "type_pretty": "class tsClass",
+          "kind": "class",
+          "subsystem": null,
+          "slotOwner": {
+            "slotKind": "class",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "idl",
+            "sym": "XPIDL_nsIXPCTestObjectReadWrite"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [
+            {
+              "pretty": "tsClass::tsGetter",
+              "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsGetter().",
+              "props": [],
+              "args": []
+            },
+            {
+              "pretty": "tsClass::tsSetter",
+              "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsSetter().",
+              "props": [],
+              "args": []
+            }
+          ],
+          "fields": [
+            {
+              "lineRange": "",
+              "pretty": "tsClass::tsAttribute",
+              "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsAttribute.",
+              "type": "string",
+              "typesym": "",
+              "offsetBytes": 0,
+              "bitPositions": null,
+              "sizeBytes": null
+            }
+          ],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "XPIDL_nsIXPCTestObjectReadWrite"
+        ]
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@const_inbound__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@const_inbound__json.snap
@@ -1,0 +1,72 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/const_inbound__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstInbound.",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 19,
+                "bounds": [
+                  0,
+                  14
+                ],
+                "line": "TsConstInbound,",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "TsEnum::TsConstInbound",
+          "sym": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstInbound.",
+          "type_pretty": "(enum member) TsConstInbound",
+          "kind": "field",
+          "subsystem": null,
+          "parentsym": "S_js_ts/src/bindings.d.ts/TsEnum#",
+          "slotOwner": {
+            "slotKind": "const",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "cpp",
+            "sym": "E_<T_NS::R::XYZ>_TAG1"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "E_<T_NS::R::XYZ>_TAG1"
+        ]
+      },
+      "relation": "Queried",
+      "quality": {
+        "IdentifierPrefix": [
+          14,
+          0
+        ]
+      },
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@count_outbound__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@count_outbound__json.snap
@@ -1,0 +1,70 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/count_outbound__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstOutbound.",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 21,
+                "bounds": [
+                  0,
+                  15
+                ],
+                "line": "TsConstOutbound,",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "TsEnum::TsConstOutbound",
+          "sym": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstOutbound.",
+          "type_pretty": "(enum member) TsConstOutbound",
+          "kind": "field",
+          "subsystem": null,
+          "parentsym": "S_js_ts/src/bindings.d.ts/TsEnum#",
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [
+            {
+              "slotKind": "const",
+              "slotLang": "cpp",
+              "implKind": null,
+              "ownerLang": "js",
+              "sym": "E_<T_NS::R::XYZ>_TAG2"
+            }
+          ],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        }
+      },
+      "relation": "Queried",
+      "quality": {
+        "IdentifierPrefix": [
+          15,
+          0
+        ]
+      },
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@enum__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@enum__json.snap
@@ -1,0 +1,92 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/enum__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/TsEnum#",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 17,
+                "bounds": [
+                  5,
+                  11
+                ],
+                "line": "enum TsEnum {",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "TsEnum",
+          "sym": "S_js_ts/src/bindings.d.ts/TsEnum#",
+          "type_pretty": "enum TsEnum",
+          "kind": "class",
+          "subsystem": null,
+          "slotOwner": {
+            "slotKind": "class",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "cpp",
+            "sym": "T_NS::R::XYZ"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [
+            {
+              "lineRange": "",
+              "pretty": "TsEnum::TsConstInbound",
+              "sym": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstInbound.",
+              "type": "(enum member) TsConstInbound",
+              "typesym": "",
+              "offsetBytes": 0,
+              "bitPositions": null,
+              "sizeBytes": null
+            },
+            {
+              "lineRange": "",
+              "pretty": "TsEnum::TsConstOutbound",
+              "sym": "S_js_ts/src/bindings.d.ts/TsEnum#TsConstOutbound.",
+              "type": "(enum member) TsConstOutbound",
+              "typesym": "",
+              "offsetBytes": 0,
+              "bitPositions": null,
+              "sizeBytes": null
+            }
+          ],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "T_NS::R::XYZ"
+        ]
+      },
+      "relation": "Queried",
+      "quality": {
+        "IdentifierPrefix": [
+          6,
+          0
+        ]
+      },
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@getter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@getter__json.snap
@@ -1,0 +1,67 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/getter__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/tsClass#tsGetter().",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 7,
+                "bounds": [
+                  0,
+                  8
+                ],
+                "line": "tsGetter(): string;",
+                "context": "tsClass",
+                "contextsym": "S_js_ts/src/bindings.d.ts/tsClass#"
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "tsClass::tsGetter",
+          "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsGetter().",
+          "type_pretty": "string",
+          "kind": "method",
+          "subsystem": null,
+          "parentsym": "S_js_ts/src/bindings.d.ts/tsClass#",
+          "slotOwner": {
+            "slotKind": "getter",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "idl",
+            "sym": "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+        ]
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@method__json-2.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@method__json-2.snap
@@ -1,0 +1,66 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/method__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/tsMethod().",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 14,
+                "bounds": [
+                  17,
+                  25
+                ],
+                "line": "declare function tsMethod(a: boolean, b: boolean): boolean;",
+                "context": "",
+                "contextsym": ""
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "tsMethod",
+          "sym": "S_js_ts/src/bindings.d.ts/tsMethod().",
+          "type_pretty": "boolean",
+          "kind": "method",
+          "subsystem": null,
+          "slotOwner": {
+            "slotKind": "method",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "idl",
+            "sym": "XPIDL_nsIXPCTestParams_testBoolean"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "XPIDL_nsIXPCTestParams_testBoolean"
+        ]
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@setter__json.snap
+++ b/tests/tests/checks/snapshots/crossref/typescript/bindings.d.ts/main@setter__json.snap
@@ -1,0 +1,67 @@
+---
+source: src/bin/test-index.rs
+expression: "&to_value(scil).unwrap()"
+input_file: inputs/crossref/typescript/bindings.d.ts/setter__json
+---
+{
+  "symbol_crossref_infos": [
+    {
+      "symbol": "S_js_ts/src/bindings.d.ts/tsClass#tsSetter().",
+      "crossref_info": {
+        "defs": [
+          {
+            "path": "ts/src/bindings.d.ts",
+            "path_kind": "Normal",
+            "lines": [
+              {
+                "lno": 10,
+                "bounds": [
+                  0,
+                  8
+                ],
+                "line": "tsSetter(value: string);",
+                "context": "tsClass",
+                "contextsym": "S_js_ts/src/bindings.d.ts/tsClass#"
+              }
+            ]
+          }
+        ],
+        "meta": {
+          "structured": 1,
+          "pretty": "tsClass::tsSetter",
+          "sym": "S_js_ts/src/bindings.d.ts/tsClass#tsSetter().",
+          "type_pretty": "any",
+          "kind": "method",
+          "subsystem": null,
+          "parentsym": "S_js_ts/src/bindings.d.ts/tsClass#",
+          "slotOwner": {
+            "slotKind": "setter",
+            "slotLang": "js",
+            "implKind": null,
+            "ownerLang": "idl",
+            "sym": "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+          },
+          "implKind": "impl",
+          "sizeBytes": null,
+          "alignmentBytes": null,
+          "ownVFPtrBytes": null,
+          "bindingSlots": [],
+          "ontologySlots": [],
+          "supers": [],
+          "methods": [],
+          "fields": [],
+          "overrides": [],
+          "props": [],
+          "variants": []
+        },
+        "idl_syms": [
+          "XPIDL_nsIXPCTestObjectReadWrite_stringProperty"
+        ]
+      },
+      "relation": "Queried",
+      "quality": "ExactIdentifier",
+      "overloads_hit": []
+    }
+  ],
+  "unknown_symbols": []
+}

--- a/tests/tests/files/ts/src/bindings.d.ts
+++ b/tests/tests/files/ts/src/bindings.d.ts
@@ -1,0 +1,22 @@
+/** <!-- binding_to(idl, class, XPIDL_nsIXPCTestObjectReadWrite) --> */
+declare class tsClass  {
+    /** <!-- binding_to(idl, attribute, XPIDL_nsIXPCTestObjectReadWrite_stringProperty) --> */
+    tsAttribute: string;
+
+    /** <!-- binding_to(idl, getter, XPIDL_nsIXPCTestObjectReadWrite_stringProperty) --> */
+    tsGetter(): string;
+
+    /** <!-- binding_to(idl, setter, XPIDL_nsIXPCTestObjectReadWrite_stringProperty) --> */
+    tsSetter(value: string);
+}
+
+/** <!-- binding_to(idl, method, XPIDL_nsIXPCTestParams_testBoolean) --> */
+declare function tsMethod(a: boolean, b: boolean): boolean;
+
+/** <!-- binding_to(cpp, class, T_NS::R::XYZ) --> */
+enum TsEnum {
+    /** <!-- binding_to(cpp, const, E_<T_NS::R::XYZ>_TAG1) --> */
+    TsConstInbound,
+    /** <!-- bound_as(cpp, const, E_<T_NS::R::XYZ>_TAG2) --> */
+    TsConstOutbound,
+}

--- a/tools/Cargo.lock
+++ b/tools/Cargo.lock
@@ -3766,6 +3766,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4235,6 +4256,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "shell-words",
+ "strum",
  "termcolor",
  "thread_local 1.1.9",
  "tokio",

--- a/tools/Cargo.toml
+++ b/tools/Cargo.toml
@@ -16,6 +16,7 @@ itertools = "0.15"
 serde = { version = "1.0.196", features = ["derive", "rc", "std"] }
 serde_json = { version = "1.0.113", features = ["preserve_order"] }
 serde_repr = "0.1.18"
+strum = { version = "0.28.0", features = ["derive"] }
 thread_local = "1.1.9"
 tower = { version = "0.5.3", features = ["limit"] }
 

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -479,7 +479,6 @@ fn analyse_symbol(
     subtree_name: Option<&str>,
     relative_path: &str,
     doc_name: Option<&str>,
-    doc_namespace: Option<&str>,
 ) -> SymbolAnalysis {
     let mut pretty_pieces = vec![];
     let mut sym_pieces = vec![];
@@ -642,16 +641,6 @@ fn analyse_symbol(
         }
     }
 
-    // If we have an explicit doc namespace that provides context
-    // the descriptors do not provide, then use that for all
-    // pieces except the last piece we get from the descriptor.
-    if let Some(namespace) = doc_namespace
-        && let Some(last_piece) = pretty_pieces.pop()
-    {
-        pretty_pieces = namespace.split("::").map(|s| s.to_string()).collect();
-        pretty_pieces.push(last_piece);
-    }
-
     // We've standardized on "::" as the delimiter here even though
     // one might argue on a convention of using ".".  But crossref
     // currently requires "::" and this seems like a reasonable
@@ -756,22 +745,6 @@ fn analyze_using_scip(
                 //let mut align_bytes = 0;
                 let offset_bytes = 0;
 
-                // Until https://github.com/rust-lang/rust-analyzer/pull/16559
-                // landed in rust-analyzer, we tried to use the doc string
-                // containing the tunneled hover information to additionally
-                // namespace the pretty identifier in an attempt to match our
-                // original rust-analysis behavior.  This ended up only working
-                // for fields (where we also would populate size_bytes and
-                // offset_bytes above).  Bug 1881645 provides some more context
-                // but the general situation is that this specific logic can
-                // likely be removed as part of a nice clean-up, but it's also
-                // worth revisiting the symbol and pretty mappings with more
-                // intent.
-                //
-                // That said, there may be other SCIP languages where this could
-                // still be a useful hack.
-                let doc_namespace: Option<String> = None;
-
                 // High confidence identifier name of what's being defined for
                 // fallback use in the case of locals as extracted from the doc
                 // strings.
@@ -811,10 +784,7 @@ fn analyze_using_scip(
                                 // TODO: try and extract some info from here;
                                 // It looks like this could be very descriptor-dependent.
                             }
-                            ScipLang::Rust => {
-                                // We no longer do anything for rust.  See the
-                                // doc_namespace comments above.
-                            }
+                            ScipLang::Rust => {}
                             ScipLang::Typescript => {
                                 if let Some(caps) = RE_TS_TYPED.captures(doc) {
                                     if let Some(s) = caps.get(1) {
@@ -873,7 +843,6 @@ fn analyze_using_scip(
                             subtree_name,
                             &doc.relative_path,
                             None,
-                            None,
                         );
                         Some(enclosing_symbol_info.norm_sym)
                     } else {
@@ -892,7 +861,6 @@ fn analyze_using_scip(
                     subtree_name,
                     &doc.relative_path,
                     display_name,
-                    doc_namespace.as_deref(),
                 );
 
                 let mut supers = vec![];
@@ -913,7 +881,6 @@ fn analyze_using_scip(
                         lang_name,
                         subtree_name,
                         &doc.relative_path,
-                        None,
                         None,
                     );
 
@@ -1216,7 +1183,6 @@ fn analyze_using_scip(
                         lang_name,
                         subtree_name,
                         &doc.relative_path,
-                        None,
                         None,
                     );
 

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -17,8 +17,9 @@ use std::io;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use tools::file_format::analysis::{
-    AnalysisKind, AnalysisSource, AnalysisStructured, AnalysisTarget, LineRange, Location,
-    SourceRange, SourceTag, StructuredFieldInfo, StructuredMethodInfo, StructuredOverrideInfo,
+    AnalysisKind, AnalysisSource, AnalysisStructured, AnalysisTarget, BindingOwnerLang,
+    BindingSlotLang, BindingSlotProps, LineRange, Location, SourceRange, SourceTag,
+    StructuredBindingSlotInfo, StructuredFieldInfo, StructuredMethodInfo, StructuredOverrideInfo,
     StructuredSuperInfo, StructuredTag, TargetTag, WithLocation,
 };
 use tools::file_format::analysis_manglings::mangle_file;
@@ -151,6 +152,7 @@ fn scip_roles_to_searchfox_analysis_kind(roles: i32) -> AnalysisKind {
 
 /// Our specifically handled languages for conditional logic.  We currently
 /// require tree-sitter support for all supported languages.
+#[derive(Clone, Copy, PartialEq, Eq)]
 enum ScipLang {
     Python,
     Rust,
@@ -923,6 +925,8 @@ fn analyze_using_scip(
                 supers.sort_unstable_by_key(|r| r.sym);
                 overrides.sort_unstable_by_key(|r| r.sym);
 
+                let (slot_owner, binding_slots) = binding_links(scip_sym_info, lang);
+
                 let structured = AnalysisStructured {
                     structured: StructuredTag::Structured,
                     pretty: symbol_info.pretty,
@@ -931,7 +935,7 @@ fn analyze_using_scip(
                     kind: ustr(symbol_info.kind.or(fallback_kind).unwrap_or("")),
                     subsystem: None,
                     parent_sym: symbol_info.parent_sym,
-                    slot_owner: None,
+                    slot_owner,
                     impl_kind: ustr("impl"),
                     size_bytes: if size_bytes > 0 {
                         Some(size_bytes)
@@ -940,7 +944,7 @@ fn analyze_using_scip(
                     },
                     alignment_bytes: None,
                     own_vf_ptr_bytes: None,
-                    binding_slots: vec![],
+                    binding_slots,
                     ontology_slots: vec![],
                     supers,
                     methods: vec![],
@@ -1478,6 +1482,100 @@ fn analyze_using_scip(
     }
 
     assert_eq!(file.pos(), byte_count, "Should've processed the whole file");
+}
+
+/// Returns the binding slot data for scip_sym_info.
+///
+/// There is at most one other symbol this symbol is a binding to, but many symbols can bind to it.
+///
+/// This currently extracts binding information from the symbol's documentation.
+fn binding_links(
+    symbol: &scip::types::SymbolInformation,
+    language: ScipLang,
+) -> (
+    Option<StructuredBindingSlotInfo>,
+    Vec<StructuredBindingSlotInfo>,
+) {
+    lazy_static! {
+        static ref RE_BINDING_TO: Regex = Regex::new(
+            r"binding_to\s*\(\s*(?<language>[^,]+)\s*,\s*(?<kind>[^,]+)\s*,\s*(?<symbol>[^,]+)\s*\)"
+        )
+        .unwrap();
+        static ref RE_BOUND_AS: Regex = Regex::new(
+            r"bound_as\s*\(\s*(?<language>[^,]+)\s*,\s*(?<kind>[^,]+)\s*,\s*(?<symbol>[^,]+)\s*\)"
+        )
+        .unwrap();
+    }
+
+    let mut slot_owners = symbol
+        .documentation
+        .iter()
+        .flat_map(|doc| RE_BINDING_TO.captures_iter(doc))
+        .map(|captures| captures.extract())
+        .flat_map(|(_, [target_language, kind, target_symbol])| {
+            let self_language = match language {
+                ScipLang::Python => return None,
+                ScipLang::Rust => BindingSlotLang::Rust,
+                ScipLang::Typescript => BindingSlotLang::JS,
+                ScipLang::Jvm => BindingSlotLang::Jvm,
+            };
+
+            let other_language = target_language.parse().ok()?;
+            let kind = kind.parse().ok()?;
+
+            let props = BindingSlotProps {
+                slot_kind: kind,
+                slot_lang: self_language,
+                owner_lang: other_language,
+                impl_kind: None,
+            };
+
+            let info = StructuredBindingSlotInfo {
+                props,
+                sym: ustr(target_symbol),
+            };
+
+            Some(info)
+        });
+    let slot_owner = slot_owners.next();
+    for extra_slot_owner in slot_owners {
+        // Technically, nothing prevents having multiple binding_to annotations on the same item
+        warn!("Extra slot owner ignored: {:?}", extra_slot_owner);
+    }
+
+    let binding_slots = symbol
+        .documentation
+        .iter()
+        .flat_map(|doc| RE_BOUND_AS.captures_iter(doc))
+        .map(|captures| captures.extract())
+        .flat_map(|(_, [target_language, kind, target_symbol])| {
+            let self_language = match language {
+                ScipLang::Python => return None,
+                ScipLang::Rust => BindingOwnerLang::Rust,
+                ScipLang::Typescript => BindingOwnerLang::JS,
+                ScipLang::Jvm => BindingOwnerLang::Jvm,
+            };
+
+            let other_language = target_language.parse().ok()?;
+            let kind = kind.parse().ok()?;
+
+            let props = BindingSlotProps {
+                slot_kind: kind,
+                slot_lang: other_language,
+                owner_lang: self_language,
+                impl_kind: None,
+            };
+
+            let info = StructuredBindingSlotInfo {
+                props,
+                sym: ustr(target_symbol),
+            };
+
+            Some(info)
+        })
+        .collect();
+
+    (slot_owner, binding_slots)
 }
 
 fn main() {

--- a/tools/src/bin/scip-indexer.rs
+++ b/tools/src/bin/scip-indexer.rs
@@ -764,12 +764,6 @@ fn analyze_using_scip(
                 let mut type_pretty = None;
 
                 lazy_static! {
-                    // used for fields, methods, arguments/parameters
-                    static ref RE_TS_TYPED: Regex =
-                        Regex::new(r"^```ts\n([^ ]+) (.+): ([^\n]+)\n```$").unwrap();
-                    // used for modules, classes
-                    static ref RE_TS_UNTYPED: Regex =
-                        Regex::new(r"^```ts\n([^ ]+) (.+)\n```$").unwrap();
                     // used for modules, classes
                     static ref RE_KT_FUNCTION: Regex =
                         Regex::new(r"^```kt\n([^ ]+) ([^ ]+) fun ([^ ]+)\(.*\)(?:: (.*))?\n```$").unwrap();
@@ -785,24 +779,7 @@ fn analyze_using_scip(
                                 // It looks like this could be very descriptor-dependent.
                             }
                             ScipLang::Rust => {}
-                            ScipLang::Typescript => {
-                                if let Some(caps) = RE_TS_TYPED.captures(doc) {
-                                    if let Some(s) = caps.get(1) {
-                                        fallback_kind =
-                                            Some(s.as_str().trim_matches(|c| c == '(' || c == ')'));
-                                    }
-                                    if let Some(s) = caps.get(2) {
-                                        doc_name = Some(s.as_str().to_string());
-                                    }
-                                    if let Some(s) = caps.get(3) {
-                                        type_pretty = Some(ustr(s.as_str()));
-                                    }
-                                } else if let Some(caps) = RE_TS_UNTYPED.captures(doc)
-                                    && let Some(s) = caps.get(2)
-                                {
-                                    doc_name = Some(s.as_str().to_string());
-                                }
-                            }
+                            ScipLang::Typescript => {}
                             ScipLang::Jvm => {
                                 if let Some(caps) = RE_KT_FUNCTION.captures(doc) {
                                     fallback_kind = Some("method");
@@ -822,7 +799,35 @@ fn analyze_using_scip(
                 if let Some(doc) = scip_sym_info.signature_documentation.as_ref()
                     && !doc.text.is_empty()
                 {
-                    type_pretty = Some(ustr(&doc.text));
+                    lazy_static! {
+                        // used for fields, methods, arguments/parameters
+                        static ref RE_TS_TYPED: Regex =
+                            Regex::new(r"^([^ ]+) (.+): ([^\n]+)$").unwrap();
+                        // used for modules, classes
+                        static ref RE_TS_UNTYPED: Regex =
+                            Regex::new(r"^([^ ]+) (.+)\$").unwrap();
+                    }
+
+                    if lang == ScipLang::Typescript
+                        && let Some(caps) = RE_TS_TYPED.captures(&doc.text)
+                    {
+                        if let Some(s) = caps.get(1) {
+                            fallback_kind = Some(s.as_str().trim_matches(|c| c == '(' || c == ')'));
+                        }
+                        if let Some(s) = caps.get(2) {
+                            doc_name = Some(s.as_str().to_string());
+                        }
+                        if let Some(s) = caps.get(3) {
+                            type_pretty = Some(ustr(s.as_str()));
+                        }
+                    } else if lang == ScipLang::Typescript
+                        && let Some(caps) = RE_TS_UNTYPED.captures(&doc.text)
+                        && let Some(s) = caps.get(2)
+                    {
+                        doc_name = Some(s.as_str().to_string());
+                    } else {
+                        type_pretty = Some(ustr(&doc.text));
+                    }
                 }
 
                 let display_name = if !scip_sym_info.display_name.is_empty() {

--- a/tools/src/bin/web-server.rs
+++ b/tools/src/bin/web-server.rs
@@ -390,7 +390,10 @@ async fn main() {
                     }
 
                     Err(join_err) => {
-                        eprintln!("Request handler task failed or was cancelled: {:?}", join_err);
+                        eprintln!(
+                            "Request handler task failed or was cancelled: {:?}",
+                            join_err
+                        );
                         WebResponse::internal_error("Internal server error".to_owned())
                     }
                 }

--- a/tools/src/cmd_pipeline/cmd_jq.rs
+++ b/tools/src/cmd_pipeline/cmd_jq.rs
@@ -55,8 +55,12 @@ impl JQCommand {
             path: (),
         };
 
-        let defs = jaq_core::defs().chain(jaq_std::defs()).chain(jaq_json::defs());
-        let funs = jaq_core::funs().chain(jaq_std::funs()).chain(jaq_json::funs());
+        let defs = jaq_core::defs()
+            .chain(jaq_std::defs())
+            .chain(jaq_json::defs());
+        let funs = jaq_core::funs()
+            .chain(jaq_std::funs())
+            .chain(jaq_json::funs());
 
         let loader = jaq_core::load::Loader::new(defs);
         let arena = jaq_core::load::Arena::default();

--- a/tools/src/file_format/analysis.rs
+++ b/tools/src/file_format/analysis.rs
@@ -18,6 +18,7 @@ use std::marker::PhantomData;
 use std::ops::Deref;
 
 use itertools::Itertools;
+use strum::EnumString;
 
 #[cfg(not(target_arch = "wasm32"))]
 use flate2::read::GzDecoder;
@@ -351,8 +352,11 @@ where
     pub sym: StrT,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, EnumString,
+)]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum BindingSlotKind {
     /// A class that directly implements or will be subclassed.
     Class,
@@ -388,8 +392,11 @@ pub enum BindingSlotKind {
     EnablingFunc,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, EnumString,
+)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum BindingSlotLang {
     Cpp,
     JS,
@@ -397,8 +404,11 @@ pub enum BindingSlotLang {
     Jvm,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize, EnumString,
+)]
 #[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
 pub enum BindingOwnerLang {
     Idl,
     Glean,


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2053875

This tries to parse binding information from the SCIP symbol docstring:
- binding_to(language, kind, symbol) populates the slot_owner field
- bound_as(language, kind, symbol) populates the binding_slots field