### PR TITLE
Bug 2059684 - Keep exact hit counts for the last 5 revisions of the coverage repository.

### DIFF
--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -203,6 +203,25 @@ var BlamePopup = new (class BlamePopup {
     }
   }
 
+  withSiMultiplier(number) {
+    const multipliers = [
+      [18, "exa",  "E"],
+      [15, "peta", "P"],
+      [12, "tera", "T"],
+      [9,  "giga", "G"],
+      [6,  "mega", "M"],
+      [3,  "kilo", "k"],
+    ];
+
+    for (const [exponent, name, symbol] of multipliers) {
+      const threshold = 10**exponent;
+      if (number >= threshold) {
+        return `${number / threshold}&#x202F;<abbr title="${name}">${symbol}</abbr>`;
+      }
+    }
+    return `${number}`;
+  }
+
   async generateCoverageContent(elt) {
     let content = "<div>";
 
@@ -227,10 +246,11 @@ var BlamePopup = new (class BlamePopup {
         content += `This line was not hit during test runs.`;
       } else {
         if (elt.classList.contains("cov-exact")) {
-          content += `This line was hit ${x} times per coverage instrumentation.`;
+          const hitCount = x.toLocaleString();
+          content += `This line was hit ${hitCount} times per coverage instrumentation.`;
         } else {
-          const hitCountMin = 10 ** (x - 1);
-          const hitCountMax = 10 ** x;
+          const hitCountMin = this.withSiMultiplier(10 ** (x - 1));
+          const hitCountMax = this.withSiMultiplier(10 ** x);
           content +=
             `This line was hit between ${hitCountMin} and ${hitCountMax} times ` +
             `per coverage instrumentation.`;

--- a/static/js/blame.js
+++ b/static/js/blame.js
@@ -222,15 +222,19 @@ var BlamePopup = new (class BlamePopup {
     } else if (elt.classList.contains("cov-uncovered")) {
       content += `This line wasn't instrumented for coverage.`;
     } else {
-      const logOnePlusHitCount = parseInt(elt.dataset.coverage, 10);
-      if (logOnePlusHitCount === 0) {
+      const x = parseInt(elt.dataset.coverage, 10);
+      if (x === 0) {
         content += `This line was not hit during test runs.`;
       } else {
-        const hitCountMin = 10 ** (logOnePlusHitCount - 1);
-        const hitCountMax = 10 ** logOnePlusHitCount;
-        content +=
-          `This line was hit between ${hitCountMin} and ${hitCountMax} times ` +
-          `per coverage instrumentation.`;
+        if (elt.classList.contains("cov-exact")) {
+          content += `This line was hit ${x} times per coverage instrumentation.`;
+        } else {
+          const hitCountMin = 10 ** (x - 1);
+          const hitCountMax = 10 ** x;
+          content +=
+            `This line was hit between ${hitCountMin} and ${hitCountMax} times ` +
+            `per coverage instrumentation.`;
+        }
       }
     }
 

--- a/tests/tests/setup
+++ b/tests/tests/setup
@@ -74,7 +74,7 @@ git commit -m "Add remaining files"
 
 HEAD_OID="$(git -C "$GIT_ROOT" rev-parse HEAD)"
 HEAD_DATE="$(git -C "$GIT_ROOT" show --no-patch --format=%cI HEAD)"
-codecov2git --report "$CONFIG_REPO/tests/metadata/code-coverage-report-full.json" --output-repo "$COVERAGE_ROOT" --commit "$HEAD_OID" --date "$HEAD_DATE"
+codecov2git --report "$CONFIG_REPO/tests/metadata/code-coverage-report-full.json" --output-repo "$COVERAGE_ROOT" --commit "$HEAD_OID" --date "$HEAD_DATE" --exact
 popd
 
 echo "Performing setup::build-blame step for $TREE_NAME : $(date +"%Y-%m-%dT%H:%M:%S%z")"

--- a/tools/src/bin/codecov2git.rs
+++ b/tools/src/bin/codecov2git.rs
@@ -13,7 +13,7 @@ use std::{
 use chrono::{DateTime, FixedOffset};
 use clap::Parser;
 
-use tools::file_format::code_coverage_report::{Report, ReportMetadata};
+use tools::file_format::code_coverage_report::{Report, ReportMetadata, last_quantized_ref};
 
 #[derive(Parser)]
 #[command(version, about)]
@@ -41,6 +41,10 @@ struct Args {
     /// Name of the testsuite covered by this report
     #[arg(short, long, default_value = "all")]
     testsuite: String,
+
+    /// Whether to save log10(hit count + 1) (default) or the exact hit count
+    #[arg(short, long)]
+    exact: bool,
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -52,6 +56,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         commit: args.commit,
         branch: branch.clone(),
         date: args.date,
+        exact: args.exact,
     };
 
     Command::new("git")
@@ -67,6 +72,18 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .output()?
         .status
         .success();
+
+    if existing_branch && !metadata.exact {
+        Command::new("git")
+            .args([
+                "reset",
+                &format!("refs/heads/{branch}"),
+                &last_quantized_ref(&branch),
+            ])
+            .arg(&args.output_repo)
+            .spawn()?
+            .wait()?;
+    }
 
     let mut fast_import = Command::new("git")
         .current_dir(&args.output_repo)

--- a/tools/src/bin/codecov2git.rs
+++ b/tools/src/bin/codecov2git.rs
@@ -60,9 +60,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .spawn()?
         .wait()?;
 
+    let reference = format!("refs/heads/{branch}");
     let existing_branch = Command::new("git")
         .current_dir(&args.output_repo)
-        .args(["show-ref", "--quiet", &format!("refs/heads/{branch}")])
+        .args(["show-ref", "--quiet", &reference])
         .output()?
         .status
         .success();
@@ -86,7 +87,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         writeln!(fast_import, "feature date-format=rfc2822")?;
         writeln!(&mut fast_import, "feature done")?;
         writeln!(&mut fast_import, "feature force")?;
-        report.write_to_git(&mut fast_import, existing_branch)?;
+
+        if existing_branch {
+            // Git fast-import will not add new commits to an existing branch unless we initialize it first.
+            // See https://git-scm.com/docs/git-fast-import#_from
+            writeln!(fast_import, "reset {reference}")?;
+            writeln!(fast_import, "from {reference}^0")?;
+        }
+
+        report.write_to_git(&mut fast_import)?;
         writeln!(&mut fast_import, "done")?;
     }
 

--- a/tools/src/bin/codecov2git_gcloud.rs
+++ b/tools/src/bin/codecov2git_gcloud.rs
@@ -431,21 +431,20 @@ fn send_to_git(
     output_repo_git: &Repository,
     fast_import_buffer: &mut impl Write,
     report: Report,
-    existing_branches: &mut HashSet<String>,
+    seen_branches: &mut HashSet<String>,
 ) -> anyhow::Result<()> {
     let ref_branch = format!("refs/heads/{}", report.metadata.branch);
 
-    // Only send `from {branch}^0` to fast-import once per branch
-    let resume_preexisting_branch = if existing_branches.contains(&ref_branch) {
-        false
-    } else {
-        let exists_in_repo = output_repo_git.find_reference(&ref_branch).is_ok();
-        existing_branches.insert(ref_branch.clone());
-        exists_in_repo
-    };
+    if seen_branches.insert(ref_branch.clone()) {
+        if output_repo_git.find_reference(&ref_branch).is_ok() {
+            // Git fast-import will not add new commits to an existing branch unless we initialize it first.
+            // See https://git-scm.com/docs/git-fast-import#_from
+            writeln!(fast_import_buffer, "reset {ref_branch}")?;
+            writeln!(fast_import_buffer, "from {ref_branch}^0")?;
+        }
+    }
 
-    debug!("Existing branch '{ref_branch}' in output repo: {resume_preexisting_branch}");
-    report.write_to_git(fast_import_buffer, resume_preexisting_branch)?;
+    report.write_to_git(fast_import_buffer)?;
     Ok(())
 }
 
@@ -482,14 +481,14 @@ fn git_sender(
     writeln!(&mut fast_import_buffer, "feature force")?;
     writeln!(&mut fast_import_buffer, "feature date-format=rfc2822")?;
 
-    let mut existing_branches = HashSet::new();
+    let mut seen_branches = HashSet::new();
     let handle = task::spawn_blocking(move || {
         while let Some(report) = reports.blocking_recv() {
             send_to_git(
                 &output_repo_git,
                 &mut fast_import_buffer,
                 report,
-                &mut existing_branches,
+                &mut seen_branches,
             )?;
         }
         // Call done => finish fast-import process and wait for it to complete.

--- a/tools/src/bin/codecov2git_gcloud.rs
+++ b/tools/src/bin/codecov2git_gcloud.rs
@@ -22,7 +22,7 @@ use tokio::{
     task::{self, JoinHandle},
 };
 use tools::{
-    file_format::code_coverage_report::{Report, ReportMetadata},
+    file_format::code_coverage_report::{EXACT, Report, ReportMetadata, last_quantized_ref},
     git_ops,
 };
 use tracing::{debug, info, warn};
@@ -34,6 +34,9 @@ use tracing_subscriber::{
 /// The number of tasks in-between each pipeline steps.
 /// Because the git fast-import task needs to be serialized anyway, there's little interest in going above 1.
 const PIPELINE_SIZE: usize = 1;
+
+/// The number of revisions which should keep the exact hit count instead of log10(count + 1)
+const EXACT_REVISION_COUNT: usize = 5;
 
 #[derive(Clone, Debug)]
 struct RevisionData {
@@ -128,6 +131,10 @@ async fn main() -> anyhow::Result<()> {
         })
         .collect();
     revisions.sort_by_key(|revision_data| revision_data.datetime);
+
+    for rev in revisions.iter_mut().rev().take(EXACT_REVISION_COUNT) {
+        rev.exact = true;
+    }
 
     info!("Nb sorted and filtered revisions: {}", revisions.len());
 
@@ -285,7 +292,10 @@ fn file_lister(
                         platform, testsuite, revision.git_revision
                     );
 
-                    if repo.find_reference(&ref_revision).is_ok() {
+                    if let Ok(reference) = repo.find_reference(&ref_revision)
+                        && let Ok(commit) = reference.peel_to_commit()
+                        && !commit.message().unwrap_or_default().contains(EXACT)
+                    {
                         warn!("Tag {} already exists, skipping...", ref_revision);
                         continue;
                     }
@@ -439,11 +449,30 @@ fn send_to_git(
     let ref_branch = format!("refs/heads/{}", report.metadata.branch);
 
     if seen_branches.insert(ref_branch.clone()) {
-        if output_repo_git.find_reference(&ref_branch).is_ok() {
-            // Git fast-import will not add new commits to an existing branch unless we initialize it first.
-            // See https://git-scm.com/docs/git-fast-import#_from
-            writeln!(fast_import_buffer, "reset {ref_branch}")?;
-            writeln!(fast_import_buffer, "from {ref_branch}^0")?;
+        if let Ok(reference) = output_repo_git.find_reference(&ref_branch) {
+            let last_quantized_ref = last_quantized_ref(&report.metadata.branch);
+            let has_last_quantized = output_repo_git.find_reference(&last_quantized_ref).is_ok();
+
+            if has_last_quantized {
+                info!("Resetting {ref_branch} to {last_quantized_ref}");
+                writeln!(fast_import_buffer, "reset {ref_branch}")?;
+                writeln!(fast_import_buffer, "from {last_quantized_ref}")?;
+            } else {
+                if !reference.peel_to_commit()?.message()?.contains(EXACT) {
+                    info!(
+                        "Incremental import on top of an old coverage repo, initializing {last_quantized_ref} to {ref_branch}"
+                    );
+                    writeln!(fast_import_buffer, "reset {last_quantized_ref}")?;
+                    writeln!(fast_import_buffer, "from {ref_branch}^0")?;
+
+                    // Git fast-import will not add new commits to an existing branch unless we initialize it first.
+                    // See https://git-scm.com/docs/git-fast-import#_from
+                    writeln!(fast_import_buffer, "reset {ref_branch}")?;
+                    writeln!(fast_import_buffer, "from {ref_branch}^0")?;
+                } else {
+                    info!("Ignoring all existing commits from {ref_branch}");
+                }
+            }
         }
     }
 

--- a/tools/src/bin/codecov2git_gcloud.rs
+++ b/tools/src/bin/codecov2git_gcloud.rs
@@ -40,6 +40,7 @@ struct RevisionData {
     datetime: DateTime<FixedOffset>,
     git_revision: String,
     hg_revision: String,
+    exact: bool,
 }
 
 #[derive(Parser)]
@@ -123,6 +124,7 @@ async fn main() -> anyhow::Result<()> {
             datetime,
             git_revision,
             hg_revision,
+            exact: false,
         })
         .collect();
     revisions.sort_by_key(|revision_data| revision_data.datetime);
@@ -404,6 +406,7 @@ fn parse(decompressed: &DecompressedReport) -> anyhow::Result<Report> {
         commit: decompressed.metadata.git_revision.to_string(),
         branch,
         date: decompressed.metadata.datetime,
+        exact: decompressed.metadata.exact,
     };
 
     let report = Report::read(decompressed.decompressed_bytes.as_slice(), metadata)?;

--- a/tools/src/file_format/code_coverage_report.rs
+++ b/tools/src/file_format/code_coverage_report.rs
@@ -121,10 +121,11 @@ impl Report {
         writeln!(fast_import, "deleteall")?;
         self.root.write_to_git(fast_import, "")?;
 
-        writeln!(fast_import, "tag reverse/{branch}/{}", self.metadata.commit)?;
-        writeln!(fast_import, "from :1")?;
-        writeln!(fast_import, "tagger <searchfox> {date}")?;
-        writeln!(fast_import, "data 0")?;
+        writeln!(
+            fast_import,
+            "reset refs/tags/reverse/{branch}/{}",
+            self.metadata.commit
+        )?;
 
         Ok(())
     }

--- a/tools/src/file_format/code_coverage_report.rs
+++ b/tools/src/file_format/code_coverage_report.rs
@@ -20,6 +20,14 @@ use serde::{Deserialize, Deserializer, Serialize, de};
 /// (This shouldn't be the case, we only output numbers and a couple of static strings.)
 const END: &str = "END";
 
+/// Marker written in the commit message for revisions with exact hit counts.
+pub const EXACT: &str = "exact";
+
+/// Reference used to identify the last quantized revision for a given branch.
+pub fn last_quantized_ref(branch: &str) -> String {
+    format!("refs/tags/last-quantized/{branch}")
+}
+
 #[derive(Debug)]
 pub struct Report {
     root: Directory,
@@ -31,6 +39,7 @@ pub struct ReportMetadata {
     pub commit: String,
     pub branch: String,
     pub date: DateTime<FixedOffset>,
+    pub exact: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -109,16 +118,32 @@ impl Report {
         writeln!(fast_import, "commit refs/heads/{branch}")?;
         writeln!(fast_import, "mark :1")?;
         writeln!(fast_import, "committer <searchfox> {date}")?;
-        writeln!(fast_import, "data {}", self.metadata.commit.len() + 1)?;
+        let data_length = if self.metadata.exact {
+            self.metadata.commit.len() + 2 + EXACT.len() + 1
+        } else {
+            self.metadata.commit.len() + 1
+        };
+        writeln!(fast_import, "data {data_length}")?;
         writeln!(fast_import, "{}", self.metadata.commit)?;
+        if self.metadata.exact {
+            writeln!(fast_import, "")?;
+            writeln!(fast_import, "{}", EXACT)?;
+        }
         writeln!(fast_import, "deleteall")?;
-        self.root.write_to_git(fast_import, "")?;
+        self.root
+            .write_to_git(fast_import, self.metadata.exact, "")?;
 
         writeln!(
             fast_import,
             "reset refs/tags/reverse/{branch}/{}",
             self.metadata.commit
         )?;
+        writeln!(fast_import, "from :1")?;
+
+        if !self.metadata.exact {
+            writeln!(fast_import, "reset {}", last_quantized_ref(branch))?;
+            writeln!(fast_import, "from :1")?;
+        }
 
         Ok(())
     }
@@ -128,12 +153,13 @@ impl Node {
     fn write_to_git<P: AsRef<Path>>(
         &self,
         fast_import: &mut impl Write,
+        exact: bool,
         path: P,
     ) -> io::Result<()> {
         use Node::*;
         match self {
-            Directory(directory) => directory.write_to_git(fast_import, path),
-            File(file) => file.write_to_git(fast_import, path),
+            Directory(directory) => directory.write_to_git(fast_import, exact, path),
+            File(file) => file.write_to_git(fast_import, exact, path),
         }
     }
 }
@@ -142,11 +168,12 @@ impl Directory {
     fn write_to_git<P: AsRef<Path>>(
         &self,
         fast_import: &mut impl Write,
+        exact: bool,
         path: P,
     ) -> io::Result<()> {
         for (name, child) in &self.children {
             let path = path.as_ref().join(name);
-            child.write_to_git(fast_import, &path)?;
+            child.write_to_git(fast_import, exact, &path)?;
         }
 
         {
@@ -167,6 +194,7 @@ impl File {
     fn write_to_git<P: AsRef<Path>>(
         &self,
         fast_import: &mut impl Write,
+        exact: bool,
         path: P,
     ) -> io::Result<()> {
         let path = path.as_ref().as_os_str().to_string_lossy();
@@ -175,8 +203,12 @@ impl File {
             writeln!(fast_import, "data <<{END}")?;
             for line in &self.coverage {
                 if let Some(count) = line {
-                    let log = (1 + count).ilog10();
-                    writeln!(fast_import, "{log}")?;
+                    if exact {
+                        writeln!(fast_import, "{count}")?;
+                    } else {
+                        let log = (1 + count).ilog10();
+                        writeln!(fast_import, "{log}")?;
+                    }
                 } else {
                     writeln!(fast_import)?;
                 }

--- a/tools/src/file_format/code_coverage_report.rs
+++ b/tools/src/file_format/code_coverage_report.rs
@@ -102,11 +102,7 @@ impl Report {
         Ok(report)
     }
 
-    pub fn write_to_git(
-        &self,
-        fast_import: &mut impl Write,
-        incremental: bool,
-    ) -> anyhow::Result<()> {
+    pub fn write_to_git(&self, fast_import: &mut impl Write) -> anyhow::Result<()> {
         let branch = &self.metadata.branch;
         let date = self.metadata.date.to_rfc2822();
 
@@ -115,9 +111,6 @@ impl Report {
         writeln!(fast_import, "committer <searchfox> {date}")?;
         writeln!(fast_import, "data {}", self.metadata.commit.len() + 1)?;
         writeln!(fast_import, "{}", self.metadata.commit)?;
-        if incremental {
-            writeln!(fast_import, "from refs/heads/{branch}^0")?;
-        }
         writeln!(fast_import, "deleteall")?;
         self.root.write_to_git(fast_import, "")?;
 

--- a/tools/src/format.rs
+++ b/tools/src/format.rs
@@ -744,7 +744,7 @@ pub fn format_file_data(
             //    coverage data is for a different revision control revision
             //    than the source code.
             use InterpolatedCoverage::*;
-            match coverage.get(i) {
+            match coverage.lines.get(i) {
                 None => r#" class="cov-strip cov-uncovered cov-unknown" aria-label="missing data""#
                     .to_owned(),
                 Some(InterpolatedMiss) => {
@@ -764,18 +764,24 @@ pub fn format_file_data(
                         .to_owned()
                 }
                 // Should this directly be a CSS variable?
-                Some(Covered(x)) => {
-                    let hit_count_min = 10_u32.pow(x - 1);
+                Some(&Covered(x)) => {
+                    let (hit_count, log_hit_count, precision_class) = if coverage.exact {
+                        (x, (x + 1).ilog10(), "cov-exact")
+                    } else {
+                        (10_u32.pow(x - 1), x, "cov-approx")
+                    };
+
                     format!(
-                        r#" class="cov-strip cov-hit cov-known cov-log10-{}" aria-label="hit {}{}" data-coverage="{}""#,
-                        *x,
-                        if hit_count_min < 1000 {
-                            hit_count_min
+                        r#" class="cov-strip cov-hit cov-known cov-log10-{} {}" aria-label="hit {}{}" data-coverage="{}""#,
+                        log_hit_count,
+                        precision_class,
+                        if hit_count < 1000 {
+                            hit_count
                         } else {
-                            hit_count_min / 1000
+                            hit_count / 1000
                         },
-                        if hit_count_min < 1000 { "" } else { "k" },
-                        *x
+                        if hit_count < 1000 { "" } else { "k" },
+                        x,
                     )
                 }
             }

--- a/tools/src/git_ops.rs
+++ b/tools/src/git_ops.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use crate::file_format::{
-    code_coverage_report,
+    code_coverage_report::{self, EXACT},
     config::GitData,
     coverage::{InterpolatedCoverage, interpolate_coverage},
 };
@@ -78,11 +78,16 @@ pub fn get_blame_lines(
     }
 }
 
+pub struct FileCoverage {
+    pub exact: bool,
+    pub lines: Vec<InterpolatedCoverage>,
+}
+
 pub fn get_coverage(
     git_data: Option<&GitData>,
     coverage_commit: Option<&Commit>,
     path: impl AsRef<Path>,
-) -> Option<Vec<InterpolatedCoverage>> {
+) -> Option<FileCoverage> {
     git_data
         .and_then(|git_data| git_data.coverage_repo.as_ref())
         .zip(coverage_commit)
@@ -94,7 +99,13 @@ pub fn get_coverage(
                 .map(|coverage_entry| {
                     let coverage_data = read_blob_entry(coverage_repo, &coverage_entry);
                     let raw = coverage_data.lines().map(FromStr::from_str).map(Result::ok);
-                    interpolate_coverage(raw)
+                    FileCoverage {
+                        exact: coverage_commit
+                            .message()
+                            .unwrap_or_default()
+                            .contains(EXACT),
+                        lines: interpolate_coverage(raw),
+                    }
                 })
         })
 }
@@ -179,7 +190,13 @@ pub fn coverage_history(
 
             let coverage_commit = coverage_repo.find_commit(commit_oid).ok()?;
 
-            let main_repo_oid = coverage_commit.message().ok()?.trim().to_owned();
+            let main_repo_oid = coverage_commit
+                .message()
+                .ok()?
+                .lines()
+                .next()?
+                .trim()
+                .to_owned();
 
             let commit_rev = commit_oid.to_string();
             let data = coverage_summary(git_data, &commit_rev, path)?;


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2059684

---

This adds the ability for the last commits of the coverage repo to keep
exact hit counts instead of the log10(hits + 1) we've been using since
https://github.com/mozsearch/mozsearch/commit/fa6befb722b6f57f77de450ba3fc840c1e17d303.

In the coverage repo, each branch will now have a tag named
last-quantized/{branch} to point at the last revision which uses the
log10(hits + 1) transform. Commits at the tip of the branch
(descendants of that tag) will have the marker “exact” in their
description.

When importing a report with approximated hit counts, we first reset
the branch to last-quantized/{branch} to ignore past commits with exact
hit counts.

When generating the HTML for the coverage strip, we check whether we
have exact hit counts or now from the commit message. If so we add the
cov-exact class.

blame.js then checks that class to determine if it should display
“hit between {10^x} and {10^(x+1)} times” or just “hit x times”.

The code supports migrating from coverage repos which don't have the
last-quantized/{branch} tags yet.