### PR TITLE
Bug 2063286 - Move multiple overrides to submenu.

### DIFF
--- a/static/js/context-menu.js
+++ b/static/js/context-menu.js
@@ -1606,46 +1606,81 @@ var ContextMenu = new (class ContextMenu extends ContextMenuOrSubMenu {
         // Helper for cases like showing the recv def when the user is clicking
         // on a call to its send, but where we don't want to crowd the context
         // menu with the decl.
-        const directDefJumpify = (jumpref, pretty) => {
-          if (!jumpref.jumps) {
-            return;
-          }
-
-          if (jumpref.jumps.def && jumpref.jumps.def !== sourceLineClicked) {
-            jumpMenuItems.push(new GotoMenuItem({
+        //
+        // Returns whether a menu entry was added or not.
+        const directDefJumpify = (menu, jumpref, pretty) => {
+          if (jumpref.jumps?.def && jumpref.jumps.def !== sourceLineClicked) {
+            menu.push(new GotoMenuItem({
               html: this.fmt("Go to definition of <strong>_</strong>", pretty),
               href: `/${tree}/source/${jumpref.jumps.def}`,
               icon: "export-alt",
               section: "jumps",
               confidence,
             }));
+            return true;
           }
+          return false;
         }
 
-        // If the symbol has <= 2 overrides (we depend on the logic in our
-        // rust `determine_desired_extra_syms_from_jumpref` helper at jumpref
-        // generation time, so you can't just change the number here and have
-        // things work out well), then emit direct def jump options.
-        //
-        // This is motivated by XPIDL where we want to be able to jump directly
-        // to the overrides of the use of an XPIDL method in C++ where we are
-        // dealing with an interface pointer, as well as for the binding slots
-        // for when we are dealing with an XPIDL IDL def symbol.  This is
-        // factored out into a helper because those are different call-sites; we
-        // don't do an open-ended graph traversal.
+        // Provide a submenu to jump to overrides.
+        // If there's a single override, skip the submenu and just add the jump.
+        // If there's more than MAX_OVERRIDEN_BY_LINKS, link to the complete list as well.
         const overrideJumpifyHelper = (jumpref) => {
-          if (jumpref.meta?.overriddenBy?.length && jumpref.meta?.overriddenBy?.length <= 2) {
-            for (const overSym of jumpref.meta.overriddenBy) {
+          // Keep in sync with MAX_OVERRIDEN_BY_LINKS in `determine_desired_extra_syms_from_jumpref`
+          // so that SYM_INFO has the data we want.
+          const MAX_OVERRIDEN_BY_LINKS = 10;
+
+          const overriddenBy = jumpref.meta?.overriddenBy;
+          if (overriddenBy?.length) {
+            if (overriddenBy.length === 1) {
+              const overSym = overriddenBy[0];
               const overInfo = SYM_INFO[overSym];
               if (overInfo) {
-                let overPretty;
-                if (jumpref.meta.overriddenBy.length === 1) {
-                  overPretty = `Sole Override ${overInfo.pretty}`;
-                } else {
-                  overPretty = `Override ${overInfo.pretty}`;
-                }
-                directDefJumpify(overInfo, overPretty)
+                const overPretty = `Sole Override ${overInfo.pretty}`;
+                directDefJumpify(jumpMenuItems, overInfo, overPretty);
+              } else {
+                console.warn(`Missing SYM_INFO for ${overSym}.`)
               }
+            } else {
+              const submenuItems = [];
+              const submenuSearches = [];
+
+              if (overriddenBy.length > MAX_OVERRIDEN_BY_LINKS) {
+                submenuItems.push(new MenuItem({
+                  html: `Show all (${MAX_OVERRIDEN_BY_LINKS} out of ${overriddenBy.length} listed below)`,
+                  href: `/${tree}/search?q=symbol:${sym}&redirect=false`,
+                  section: "symbol-searches",
+                  icon: "search",
+                }));
+              }
+
+              for (const overSym of overriddenBy.slice(0, MAX_OVERRIDEN_BY_LINKS)) {
+                const overInfo = SYM_INFO[overSym];
+                if (overInfo) {
+                  const hasDirectJump = directDefJumpify(submenuItems, overInfo, overInfo.pretty);
+                  // When an override doesn't have a clear definition to jump to, provide a search entry instead.
+                  // This happens for instance when the symbol is defined inside a macro because we list both the
+                  // macro call and the token inside the macro definition as definition sites.
+                  if (!hasDirectJump) {
+                    submenuSearches.push({
+                      label: overInfo.pretty,
+                      syms: [overSym],
+                    });
+                  }
+                } else {
+                  console.warn(`Missing SYM_INFO for ${overSym}.`)
+                }
+              }
+
+              jumpMenuItems.push(new MenuItemWithSubMenu({
+                html: `${overriddenBy.length} Overrides`,
+                tree,
+                icon: "export-alt",
+                section: "jumps",
+                items: submenuItems,
+                searches: submenuSearches,
+                menu: this,
+              }));
             }
           }
         }
@@ -1698,7 +1733,7 @@ var ContextMenu = new (class ContextMenu extends ContextMenuOrSubMenu {
                     if (slot?.implKind) {
                       maybeSlotImplKind = ` ${slot.implKind}`;
                     }
-                    directDefJumpify(recvJumpref, `${implKind}${maybeLang} ${slot.slotKind}${maybeSlotImplKind} ${recvJumpref.pretty}`);
+                    directDefJumpify(jumpMenuItems, recvJumpref, `${implKind}${maybeLang} ${slot.slotKind}${maybeSlotImplKind} ${recvJumpref.pretty}`);
                   }
                 }
               }

--- a/tests/tests/checks/snapshots/web/dirs/main@root_listing__html.snap
+++ b/tests/tests/checks/snapshots/web/dirs/main@root_listing__html.snap
@@ -609,7 +609,7 @@ input_file: inputs/web/dirs/root_listing__html
 ">This file is intended to create interesting test cases for searches against
  a base class with a limited number of overrides.
 </td>
-          <td class="size"><a href="/tests/source/overs.cpp">1521</a></td>
+          <td class="size"><a href="/tests/source/overs.cpp">2784</a></td>
           <td class="coverage"><a href="/tests/source/overs.cpp" class="cov-percentage cov-percentage-none" title="There's no coverage data available for this file.">-</a></td>
         </tr>
 

--- a/tests/tests/files/overs.cpp
+++ b/tests/tests/files/overs.cpp
@@ -77,3 +77,69 @@ void generateTripleUses(void) {
   explicitTwo.triplePure();
   explicitThree.triplePure();
 }
+
+class SingleBase {
+ public:
+  virtual void singlePure() = 0;
+};
+
+class SingleSub : public SingleBase {
+ public:
+  void singlePure() override {}
+};
+
+class TwentyBase {
+ public:
+  virtual void twentyPure() = 0;
+};
+
+#define TWENTY_SUB(N)                                                         \
+  class TwentySub ## N : public TwentyBase {                                  \
+   public:                                                                    \
+    void twentyPure() override {}                                             \
+  }
+
+class TwentySub0 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+class TwentySub1 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+class TwentySub2 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+class TwentySub3 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+class TwentySub4 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+class TwentySub5 : public TwentyBase {
+ public:
+  void twentyPure() override {}
+};
+
+TWENTY_SUB(6);
+TWENTY_SUB(7);
+TWENTY_SUB(8);
+TWENTY_SUB(9);
+TWENTY_SUB(10);
+TWENTY_SUB(11);
+TWENTY_SUB(12);
+TWENTY_SUB(13);
+TWENTY_SUB(14);
+TWENTY_SUB(15);
+TWENTY_SUB(16);
+TWENTY_SUB(17);
+TWENTY_SUB(18);
+TWENTY_SUB(19);

--- a/tests/webtest/test_ContextMenuOverrides.js
+++ b/tests/webtest/test_ContextMenuOverrides.js
@@ -1,0 +1,79 @@
+"use strict";
+
+add_task(async function test_SingleOverride() {
+  const path = "/tests/source/overs.cpp";
+  await TestUtils.loadPath(path);
+
+  const singlePure = frame.contentDocument.querySelector('span[data-symbols="_ZN10SingleBase10singlePureEv"]');
+  ok(!!singlePure, "SingleBase::singlePure token exists");
+
+  TestUtils.click(singlePure);
+
+  const menu = frame.contentDocument.querySelector("#context-menu");
+  await waitForShown(menu, "Context menu is shown for symbol click");
+
+  const overrideRows = menu.querySelectorAll(".icon-export-alt");
+  is(overrideRows.length, 1, "Menu has 1 override row");
+  is(overrideRows[0].textContent, "Go to definition of Sole Override SingleSub::singlePure");
+});
+
+add_task(async function test_TwoOverrides() {
+  const path = "/tests/source/overs.cpp";
+  await TestUtils.loadPath(path);
+
+  const doublePure = frame.contentDocument.querySelector('span[data-symbols="_ZN10DoubleBase10doublePureEv"]');
+  ok(!!doublePure, "DoubleBase::doublePure token exists");
+
+  TestUtils.click(doublePure);
+
+  const menu = frame.contentDocument.querySelector("#context-menu");
+  await waitForShown(menu, "Context menu is shown for symbol click");
+
+  const overrideRows = menu.querySelectorAll(".icon-export-alt");
+  is(overrideRows.length, 1, "Menu has 1 override row");
+  ok(overrideRows[0].classList.contains("submenu-label"), "The override row is a submenu");
+  is(overrideRows[0].textContent, "2 Overrides");
+
+  TestUtils.dispatchMouseEvent("mouseenter", overrideRows[0]);
+
+  await TestUtils.waitForCondition(() => frame.contentDocument.querySelector(".context-submenu"), "Submenu is eventually created on mouseenter");
+  const submenu = frame.contentDocument.querySelector(".context-submenu");
+  await waitForShown(submenu, "Submenu is eventually shown on mouseenter");
+
+  const directJumps = submenu.querySelectorAll('a[href*="/tests/source/overs.cpp#"]');
+  is(directJumps.length, 2, "2 overrides with direct jump to definition are shown");
+});
+
+add_task(async function test_TwentyOverrides() {
+  const path = "/tests/source/overs.cpp";
+  await TestUtils.loadPath(path);
+
+  const twentyPure = frame.contentDocument.querySelector('span[data-symbols="_ZN10TwentyBase10twentyPureEv"]');
+  ok(!!twentyPure, "TwentyBase::twentyPure token exists");
+
+  TestUtils.click(twentyPure);
+
+  const menu = frame.contentDocument.querySelector("#context-menu");
+  await waitForShown(menu, "Context menu is shown for symbol click");
+
+  const overrideRows = menu.querySelectorAll(".icon-export-alt");
+  is(overrideRows.length, 1, "Menu has 1 override row");
+  ok(overrideRows[0].classList.contains("submenu-label"), "The override row is a submenu");
+  is(overrideRows[0].textContent, "20 Overrides");
+
+  TestUtils.dispatchMouseEvent("mouseenter", overrideRows[0]);
+
+  await TestUtils.waitForCondition(() => frame.contentDocument.querySelector(".context-submenu"), "Submenu is eventually created on mouseenter");
+  const submenu = frame.contentDocument.querySelector(".context-submenu");
+  await waitForShown(submenu, "Submenu is eventually shown on mouseenter");
+
+  const directJumps = submenu.querySelectorAll('a[href*="/tests/source/overs.cpp#"]');
+  is(directJumps.length, 6, "6 overrides with direct jump to definition are shown");
+
+  const searches = submenu.querySelectorAll('a[href*="/tests/search"]');
+  is(searches.length, 5, "5 searches shown");
+
+  const searchMore = searches[0];
+  is(searchMore, submenu.querySelector('a'), "Own search link is the first row");
+  is(searchMore.textContent, "Show all (10 out of 20 listed below)");
+});

--- a/tools/src/file_format/jumpref.rs
+++ b/tools/src/file_format/jumpref.rs
@@ -159,9 +159,11 @@ pub fn determine_desired_extra_syms_from_jumpref(
         }
     }
     if let Some(overridden) = jumpref.meta.as_ref().map(|meta| &meta.overridden_by_syms)
-        && overridden.len() <= 2
     {
-        for over_info in overridden {
+        // Keep in sync with overrideJumpifyHelper in context-menu.js
+        const MAX_OVERRIDEN_BY_LINKS: usize = 10;
+
+        for over_info in overridden.into_iter().take(MAX_OVERRIDEN_BY_LINKS) {
             // The override is all we need.
             extra_syms.push((*over_info, JumprefTraversals::empty()));
         }


### PR DESCRIPTION
Bugzilla URL: https://bugzilla.mozilla.org/show_bug.cgi?id=2063286

The previous logic was:
- no overrides: no context menu entries
- 1 override: 1 “Sole Override” context menu entry
- 2 overrides: 2 “Override” context menu entry
- more overrides: no context menu entries

The new logic is:
- no overrides: no context menu entries
- 1 override: 1 “Sole Override” context menu entry
- 2 to MAX_OVERRIDEN_BY_LINKS overrides: a submenu lists them all
- more overrides: a submenu lists MAX_OVERRIDEN_BY_LINKS and provides a link to the full search