### PR TITLE
Mark generated TypeScript definitions as generated

### DIFF
--- a/config_defaults/per-file-info.toml
+++ b/config_defaults/per-file-info.toml
@@ -13,6 +13,7 @@ sort_order = 3
 [pathkind.generated.heuristics]
 path_prefixes = [
     "__GENERATED__/",
+    "tools/@types/generated/",
 ]
 
 [pathkind.test]


### PR DESCRIPTION
As @asutherland pointed out in Matrix, this should be marked as generated.
Alternatively we could set `pathkind.generated.heuristics.dir_names = ["generated"]`, but I prefer being conservative here.